### PR TITLE
[FLINK-15769] [kafka-io] Add configuring startup position for Kafka ingress

### DIFF
--- a/statefun-docs/docs/api_concepts/io_module/kafka.rst
+++ b/statefun-docs/docs/api_concepts/io_module/kafka.rst
@@ -46,14 +46,29 @@ It accepts the following arguments:
 1) The ingress identifier associated with this ingress
 2) The topic name / list of topic names
 3) The address of the bootstrap servers
-4) A ``KafkaIngressDeserializer`` for deserializing data from Kafka
-5) Properties for the Kafka consumer
+4) The consumer group id to use
+5) A ``KafkaIngressDeserializer`` for deserializing data from Kafka
+6) The position to start consuming from
 
 .. literalinclude:: ../../../src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
     :language: java
     :lines: 18-
 
+The ingress allows configuring the startup position to be one of the following:
+
+*``KafkaIngressStartupPosition#fromGroupOffsets()`` (default): starts from offsets that were committed to Kafka for the specified consumer group.
+*``KafkaIngressStartupPosition#fromEarliest()``: starts from the earliest offset.
+*``KafkaIngressStartupPosition#fromLatest()``: starts from the latest offset.
+*``KafkaIngressStartupPosition#fromSpecificOffsets(Map)``: starts from specific offsets, defined as a map of partitions to their target starting offset.
+*``KafkaIngressStartupPosition#fromDate(Date)``: starts from offsets that have an ingestion time larger than or equal to a specified date.
+
+On startup, if the specified startup offset for a partition is out-of-range or does not exist (which may be the case if the ingress is configured to
+start from group offsets, specific offsets, or from a date), then the ingress will fallback to using the position configured
+using ``KafkaIngressBuilder#withAutoOffsetResetPosition(KafkaIngressAutoResetPosition)``. By default, this is set to be the latest position.
+
+The ingress also accepts properties to directly configure the Kafka client, using ``KafkaIngressBuilder#withProperties(Properties)``.
 Please refer to the Kafka `consumer configuration <https://docs.confluent.io/current/installation/configuration/consumer-configs.html>`_ documentation for the full list of available properties.
+Note that configuration passed using named methods, such as ``KafkaIngressBuilder#withConsumerGroupId(String)``, will have higher precedence and overwrite their respective settings in the provided properties.
 
 Kafka Deserializer
 """"""""""""""""""

--- a/statefun-docs/src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
+++ b/statefun-docs/src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
@@ -21,7 +21,7 @@ import org.apache.flink.statefun.docs.models.User;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
 
 public class IngressSpecs {
 
@@ -31,8 +31,9 @@ public class IngressSpecs {
   public static final IngressSpec<User> kafkaIngress =
       KafkaIngressBuilder.forIdentifier(ID)
           .withKafkaAddress("localhost:9092")
+          .withConsumerGroupId("greetings")
           .withTopic("my-topic")
           .withDeserializer(UserDeserializer.class)
-          .withProperty(ConsumerConfig.GROUP_ID_CONFIG, "greetings")
+          .withStartupPosition(KafkaIngressStartupPosition.fromLatest())
           .build();
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -68,7 +68,7 @@ public class KafkaSourceProvider implements SourceProvider {
           convertKafkaTopicPartitionMap(offsetsPosition.getSpecificOffsets()));
     } else if (startupPosition.isDate()) {
       KafkaIngressStartupPosition.DatePosition datePosition = startupPosition.asDate();
-      consumer.setStartFromTimestamp(datePosition.getTime());
+      consumer.setStartFromTimestamp(datePosition.getEpochMilli());
     } else {
       throw new IllegalStateException("Safe guard; should not occur");
     }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -52,6 +52,8 @@ public class KafkaSourceProvider implements SourceProvider {
     Properties properties = new Properties();
     properties.putAll(spec.properties());
     properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
+    properties.put(
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, spec.autoResetPosition().asKafkaConfig());
     spec.consumerGroupId()
         .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
 

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -96,6 +96,6 @@ public class KafkaSourceProvider implements SourceProvider {
   private static org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
       convertKafkaTopicPartition(KafkaTopicPartition partition) {
     return new org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition(
-        partition.getTopic(), partition.getPartition());
+        partition.topic(), partition.partition());
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
-import java.util.Properties;
 import org.apache.flink.statefun.flink.io.common.ReflectionUtil;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
@@ -26,16 +25,15 @@ import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaSourceProvider implements SourceProvider {
 
   @Override
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
-    Properties properties = createPropertiesFromSpec(spec);
 
-    return new FlinkKafkaConsumer<>(spec.topics(), deserializationSchemaFromSpec(spec), properties);
+    return new FlinkKafkaConsumer<>(
+        spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
   }
 
   private static <T> KafkaIngressSpec<T> asKafkaSpec(IngressSpec<T> ingressSpec) {
@@ -46,18 +44,6 @@ public class KafkaSourceProvider implements SourceProvider {
       throw new NullPointerException("Unable to translate a NULL spec");
     }
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
-  }
-
-  private static <T> Properties createPropertiesFromSpec(KafkaIngressSpec<T> spec) {
-    Properties properties = new Properties();
-    properties.putAll(spec.properties());
-    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
-    properties.put(
-        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, spec.autoResetPosition().asKafkaConfig());
-    spec.consumerGroupId()
-        .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
-
-    return properties;
   }
 
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -26,16 +26,14 @@ import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaSourceProvider implements SourceProvider {
 
   @Override
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
-
-    Properties properties = new Properties();
-    properties.putAll(spec.properties());
-    properties.put("bootstrap.servers", spec.kafkaAddress());
+    Properties properties = createPropertiesFromSpec(spec);
 
     return new FlinkKafkaConsumer<>(spec.topics(), deserializationSchemaFromSpec(spec), properties);
   }
@@ -48,6 +46,16 @@ public class KafkaSourceProvider implements SourceProvider {
       throw new NullPointerException("Unable to translate a NULL spec");
     }
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
+  }
+
+  private static <T> Properties createPropertiesFromSpec(KafkaIngressSpec<T> spec) {
+    Properties properties = new Properties();
+    properties.putAll(spec.properties());
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
+    spec.consumerGroupId()
+        .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
+
+    return properties;
   }
 
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -17,11 +17,15 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.flink.statefun.flink.io.common.ReflectionUtil;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
@@ -32,8 +36,11 @@ public class KafkaSourceProvider implements SourceProvider {
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
 
-    return new FlinkKafkaConsumer<>(
-        spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
+    FlinkKafkaConsumer<T> consumer =
+        new FlinkKafkaConsumer<>(
+            spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
+    configureStartupPosition(consumer, spec.startupPosition());
+    return consumer;
   }
 
   private static <T> KafkaIngressSpec<T> asKafkaSpec(IngressSpec<T> ingressSpec) {
@@ -46,10 +53,49 @@ public class KafkaSourceProvider implements SourceProvider {
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
   }
 
+  private static <T> void configureStartupPosition(
+      FlinkKafkaConsumer<T> consumer, KafkaIngressStartupPosition startupPosition) {
+    if (startupPosition.isGroupOffsets()) {
+      consumer.setStartFromGroupOffsets();
+    } else if (startupPosition.isEarliest()) {
+      consumer.setStartFromEarliest();
+    } else if (startupPosition.isLatest()) {
+      consumer.setStartFromLatest();
+    } else if (startupPosition.isSpecificOffsets()) {
+      KafkaIngressStartupPosition.SpecificOffsetsPosition offsetsPosition =
+          startupPosition.asSpecificOffsets();
+      consumer.setStartFromSpecificOffsets(
+          convertKafkaTopicPartitionMap(offsetsPosition.getSpecificOffsets()));
+    } else if (startupPosition.isDate()) {
+      KafkaIngressStartupPosition.DatePosition datePosition = startupPosition.asDate();
+      consumer.setStartFromTimestamp(datePosition.getTime());
+    } else {
+      throw new IllegalStateException("Safe guard; should not occur");
+    }
+  }
+
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(
       KafkaIngressSpec<T> spec) {
     KafkaIngressDeserializer<T> ingressDeserializer =
         ReflectionUtil.instantiate(spec.deserializerClass());
     return new KafkaDeserializationSchemaDelegate<>(ingressDeserializer);
+  }
+
+  private static Map<
+          org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition, Long>
+      convertKafkaTopicPartitionMap(Map<KafkaTopicPartition, Long> offsets) {
+    Map<org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition, Long> result =
+        new HashMap<>(offsets.size());
+    for (Map.Entry<KafkaTopicPartition, Long> offset : offsets.entrySet()) {
+      result.put(convertKafkaTopicPartition(offset.getKey()), offset.getValue());
+    }
+
+    return result;
+  }
+
+  private static org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
+      convertKafkaTopicPartition(KafkaTopicPartition partition) {
+    return new org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition(
+        partition.getTopic(), partition.getPartition());
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Locale;
+
+/** The auto offset reset position to use in case consumed offsets are invalid. */
+public enum KafkaIngressAutoResetPosition {
+  EARLIEST,
+  LATEST;
+
+  public String asKafkaConfig() {
+    return name().toLowerCase(Locale.ENGLISH);
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -37,6 +37,7 @@ public final class KafkaIngressBuilder<T> {
   private String consumerGroupId;
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
+  private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -97,9 +98,25 @@ public final class KafkaIngressBuilder<T> {
     return this;
   }
 
+  /**
+   * @param autoResetPosition the auto offset reset position to use, in case consumed offsets are
+   *     invalid.
+   */
+  public KafkaIngressBuilder<T> withAutoResetPosition(
+      KafkaIngressAutoResetPosition autoResetPosition) {
+    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
+    return this;
+  }
+
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
     return new KafkaIngressSpec<>(
-        id, kafkaAddress, properties, topics, deserializerClass, consumerGroupId);
+        id,
+        kafkaAddress,
+        properties,
+        topics,
+        deserializerClass,
+        autoResetPosition,
+        consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -39,8 +39,7 @@ public final class KafkaIngressBuilder<T> {
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
   private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
-  private KafkaIngressStartupPosition startupPosition =
-      KafkaIngressStartupPosition.fromGroupOffsets();
+  private KafkaIngressStartupPosition startupPosition = KafkaIngressStartupPosition.fromLatest();
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -112,7 +111,8 @@ public final class KafkaIngressBuilder<T> {
   }
 
   /**
-   * Configures the position that the ingress should start consuming from.
+   * Configures the position that the ingress should start consuming from. By default, the startup
+   * position is {@link KafkaIngressStartupPosition#fromLatest()}.
    *
    * <p>Note that this configuration only affects the position when starting the application from a
    * fresh start. When restoring the application from a savepoint, the ingress will always start

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -39,6 +39,8 @@ public final class KafkaIngressBuilder<T> {
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
   private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
+  private KafkaIngressStartupPosition startupPosition =
+      KafkaIngressStartupPosition.fromGroupOffsets();
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -109,11 +111,26 @@ public final class KafkaIngressBuilder<T> {
     return this;
   }
 
+  /**
+   * Configures the position that the ingress should start consuming from.
+   *
+   * <p>Note that this configuration only affects the position when starting the application from a
+   * fresh start. When restoring the application from a savepoint, the ingress will always start
+   * consuming from the offsets persisted in the savepoint.
+   *
+   * @param startupPosition the position that the Kafka ingress should start consuming from.
+   * @see KafkaIngressStartupPosition
+   */
+  public KafkaIngressBuilder<T> withStartupPosition(KafkaIngressStartupPosition startupPosition) {
+    this.startupPosition = Objects.requireNonNull(startupPosition);
+    return this;
+  }
+
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
     Properties properties = resolveKafkaProperties();
 
-    return new KafkaIngressSpec<>(id, properties, topics, deserializerClass);
+    return new KafkaIngressSpec<>(id, properties, topics, deserializerClass, startupPosition);
   }
 
   private Properties resolveKafkaProperties() {

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -34,6 +34,7 @@ public final class KafkaIngressBuilder<T> {
   private final IngressIdentifier<T> id;
   private final List<String> topics = new ArrayList<>();
   private final Properties properties = new Properties();
+  private String consumerGroupId;
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
 
@@ -48,6 +49,12 @@ public final class KafkaIngressBuilder<T> {
    */
   public static <T> KafkaIngressBuilder<T> forIdentifier(IngressIdentifier<T> id) {
     return new KafkaIngressBuilder<>(id);
+  }
+
+  /** @param consumerGroupId the consumer group id to use. */
+  public KafkaIngressBuilder<T> withConsumerGroupId(String consumerGroupId) {
+    this.consumerGroupId = Objects.requireNonNull(consumerGroupId);
+    return this;
   }
 
   /** @param kafkaAddress Comma separated addresses of the brokers. */
@@ -92,6 +99,7 @@ public final class KafkaIngressBuilder<T> {
 
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
-    return new KafkaIngressSpec<>(id, kafkaAddress, properties, topics, deserializerClass);
+    return new KafkaIngressSpec<>(
+        id, kafkaAddress, properties, topics, deserializerClass, consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -19,7 +19,9 @@ package org.apache.flink.statefun.sdk.kafka;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
@@ -31,17 +33,21 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private final IngressIdentifier<T> ingressIdentifier;
 
+  @Nullable private final String consumerGroupId;
+
   KafkaIngressSpec(
       IngressIdentifier<T> id,
       String kafkaAddress,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      String consumerGroupId) {
     this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+    this.consumerGroupId = consumerGroupId;
   }
 
   @Override
@@ -68,5 +74,9 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public Optional<String> consumerGroupId() {
+    return (consumerGroupId == null) ? Optional.empty() : Optional.of(consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -19,38 +19,26 @@ package org.apache.flink.statefun.sdk.kafka;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 
 public class KafkaIngressSpec<T> implements IngressSpec<T> {
-  private final String kafkaAddress;
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
-  private final KafkaIngressAutoResetPosition autoResetPosition;
   private final IngressIdentifier<T> ingressIdentifier;
-
-  @Nullable private final String consumerGroupId;
 
   KafkaIngressSpec(
       IngressIdentifier<T> id,
-      String kafkaAddress,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
-      KafkaIngressAutoResetPosition autoResetPosition,
-      String consumerGroupId) {
-    this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
-    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
-    this.consumerGroupId = consumerGroupId;
   }
 
   @Override
@@ -63,10 +51,6 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
     return Constants.KAFKA_INGRESS_TYPE;
   }
 
-  public String kafkaAddress() {
-    return kafkaAddress;
-  }
-
   public Properties properties() {
     return properties;
   }
@@ -77,13 +61,5 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
-  }
-
-  public KafkaIngressAutoResetPosition autoResetPosition() {
-    return autoResetPosition;
-  }
-
-  public Optional<String> consumerGroupId() {
-    return (consumerGroupId == null) ? Optional.empty() : Optional.of(consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -20,25 +20,33 @@ package org.apache.flink.statefun.sdk.kafka;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
+  private final KafkaIngressStartupPosition startupPosition;
   private final IngressIdentifier<T> ingressIdentifier;
 
   KafkaIngressSpec(
       IngressIdentifier<T> id,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      KafkaIngressStartupPosition startupPosition) {
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+
+    validateStartupPosition(
+        startupPosition, properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG));
+    this.startupPosition = Objects.requireNonNull(startupPosition);
   }
 
   @Override
@@ -61,5 +69,18 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public KafkaIngressStartupPosition startupPosition() {
+    return startupPosition;
+  }
+
+  private static void validateStartupPosition(
+      KafkaIngressStartupPosition startupPosition, @Nullable String groupIdConfig) {
+    if (startupPosition.isGroupOffsets() && groupIdConfig == null) {
+      throw new IllegalStateException(
+          "The ingress is configured to start from committed consumer group offsets in Kafka, but no consumer group id was set.\n"
+              + "Please set the group id with the withConsumerGroupId(String) method.");
+    }
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -31,6 +31,7 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
+  private final KafkaIngressAutoResetPosition autoResetPosition;
   private final IngressIdentifier<T> ingressIdentifier;
 
   @Nullable private final String consumerGroupId;
@@ -41,12 +42,14 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
       Properties properties,
       List<String> topics,
       Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      KafkaIngressAutoResetPosition autoResetPosition,
       String consumerGroupId) {
     this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
     this.consumerGroupId = consumerGroupId;
   }
 
@@ -74,6 +77,10 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public KafkaIngressAutoResetPosition autoResetPosition() {
+    return autoResetPosition;
   }
 
   public Optional<String> consumerGroupId() {

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Date;
+import java.util.Map;
+
+/** Position for the ingress to start consuming Kafka partitions. */
+@SuppressWarnings("WeakerAccess, unused")
+public class KafkaIngressStartupPosition {
+
+  /** Private constructor to prevent instantiation. */
+  private KafkaIngressStartupPosition() {}
+
+  /**
+   * Start consuming from committed consumer group offsets in Kafka.
+   *
+   * <p>Note that a consumer group id must be provided for this startup mode. Please see {@link
+   * KafkaIngressBuilder#withConsumerGroupId(String)}.
+   */
+  public static KafkaIngressStartupPosition fromGroupOffsets() {
+    return new GroupOffsetsPosition();
+  }
+
+  /** Start consuming from the earliest offset possible. */
+  public static KafkaIngressStartupPosition fromEarliest() {
+    return new EarliestPosition();
+  }
+
+  /** Start consuming from the latest offset, i.e. head of the topic partitions. */
+  public static KafkaIngressStartupPosition fromLatest() {
+    return new LatestPosition();
+  }
+
+  /**
+   * Start consuming from a specified set of offsets.
+   *
+   * <p>If a specified offset does not exist for a partition, the position for that partition will
+   * fallback to the reset position configured via {@link
+   * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
+   *
+   * @param specificOffsets map of specific set of offsets.
+   */
+  public static KafkaIngressStartupPosition fromSpecificOffsets(
+      Map<KafkaTopicPartition, Long> specificOffsets) {
+    if (specificOffsets == null || specificOffsets.isEmpty()) {
+      throw new IllegalArgumentException("Provided specific offsets must not be empty.");
+    }
+    return new SpecificOffsetsPosition(specificOffsets);
+  }
+
+  /**
+   * Start consuming from offsets with ingestion timestamps after or equal to a specified {@link
+   * Date}.
+   *
+   * <p>If a Kafka partition does not have any records with ingestion timestamps after or equal to
+   * the specified date, the position for that partition will fallback to the reset position
+   * configured via {@link
+   * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
+   */
+  public static KafkaIngressStartupPosition fromDate(Date date) {
+    return new DatePosition(date);
+  }
+
+  /** Checks whether this position is configured using committed consumer group offsets in Kafka. */
+  public boolean isGroupOffsets() {
+    return getClass() == GroupOffsetsPosition.class;
+  }
+
+  /** Checks whether this position is configured using the earliest offset. */
+  public boolean isEarliest() {
+    return getClass() == EarliestPosition.class;
+  }
+
+  /** Checks whether this position is configured using the latest offset. */
+  public boolean isLatest() {
+    return getClass() == LatestPosition.class;
+  }
+
+  /** Checks whether this position is configured using specific offsets. */
+  public boolean isSpecificOffsets() {
+    return getClass() == SpecificOffsetsPosition.class;
+  }
+
+  /** Checks whether this position is configured using a date. */
+  public boolean isDate() {
+    return getClass() == DatePosition.class;
+  }
+
+  /** Returns this position as a {@link SpecificOffsetsPosition}. */
+  public SpecificOffsetsPosition asSpecificOffsets() {
+    if (!isSpecificOffsets()) {
+      throw new IllegalStateException(
+          "This is not a startup position configured using specific offsets.");
+    }
+    return (SpecificOffsetsPosition) this;
+  }
+
+  /** Returns this position as a {@link DatePosition}. */
+  public DatePosition asDate() {
+    if (!isDate()) {
+      throw new IllegalStateException("This is not a startup position configured using a Date.");
+    }
+    return (DatePosition) this;
+  }
+
+  public static class GroupOffsetsPosition extends KafkaIngressStartupPosition {}
+
+  public static class EarliestPosition extends KafkaIngressStartupPosition {}
+
+  public static class LatestPosition extends KafkaIngressStartupPosition {}
+
+  public static class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
+
+    private final Map<KafkaTopicPartition, Long> specificOffsets;
+
+    SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
+      this.specificOffsets = specificOffsets;
+    }
+
+    public Map<KafkaTopicPartition, Long> getSpecificOffsets() {
+      return specificOffsets;
+    }
+  }
+
+  public static class DatePosition extends KafkaIngressStartupPosition {
+
+    private final Date date;
+
+    DatePosition(Date date) {
+      this.date = date;
+    }
+
+    public long getTime() {
+      return date.getTime();
+    }
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.sdk.kafka;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 /** Position for the ingress to start consuming Kafka partitions. */
@@ -66,14 +66,14 @@ public class KafkaIngressStartupPosition {
 
   /**
    * Start consuming from offsets with ingestion timestamps after or equal to a specified {@link
-   * Date}.
+   * ZonedDateTime}.
    *
    * <p>If a Kafka partition does not have any records with ingestion timestamps after or equal to
    * the specified date, the position for that partition will fallback to the reset position
    * configured via {@link
    * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
    */
-  public static KafkaIngressStartupPosition fromDate(Date date) {
+  public static KafkaIngressStartupPosition fromDate(ZonedDateTime date) {
     return new DatePosition(date);
   }
 
@@ -146,14 +146,14 @@ public class KafkaIngressStartupPosition {
 
   public static final class DatePosition extends KafkaIngressStartupPosition {
 
-    private final Date date;
+    private final ZonedDateTime date;
 
-    private DatePosition(Date date) {
+    private DatePosition(ZonedDateTime date) {
       this.date = date;
     }
 
-    public long getTime() {
-      return date.getTime();
+    public long getEpochMilli() {
+      return date.toInstant().toEpochMilli();
     }
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -119,17 +119,23 @@ public class KafkaIngressStartupPosition {
     return (DatePosition) this;
   }
 
-  public static class GroupOffsetsPosition extends KafkaIngressStartupPosition {}
+  public static final class GroupOffsetsPosition extends KafkaIngressStartupPosition {
+    private GroupOffsetsPosition() {}
+  }
 
-  public static class EarliestPosition extends KafkaIngressStartupPosition {}
+  public static final class EarliestPosition extends KafkaIngressStartupPosition {
+    private EarliestPosition() {}
+  }
 
-  public static class LatestPosition extends KafkaIngressStartupPosition {}
+  public static final class LatestPosition extends KafkaIngressStartupPosition {
+    private LatestPosition() {}
+  }
 
-  public static class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
+  public static final class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
 
     private final Map<KafkaTopicPartition, Long> specificOffsets;
 
-    SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
+    private SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
       this.specificOffsets = specificOffsets;
     }
 
@@ -138,11 +144,11 @@ public class KafkaIngressStartupPosition {
     }
   }
 
-  public static class DatePosition extends KafkaIngressStartupPosition {
+  public static final class DatePosition extends KafkaIngressStartupPosition {
 
     private final Date date;
 
-    DatePosition(Date date) {
+    private DatePosition(Date date) {
       this.date = date;
     }
 

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Objects;
+
+/** Representation of a Kafka partition. */
+public final class KafkaTopicPartition {
+
+  private final String topic;
+  private final int partition;
+
+  public KafkaTopicPartition(String topic, int partition) {
+    this.topic = Objects.requireNonNull(topic);
+
+    if (partition < 0) {
+      throw new IllegalArgumentException(
+          "Invalid partition id: " + partition + "; value must be larger or equal to 0.");
+    }
+    this.partition = partition;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public int getPartition() {
+    return partition;
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaTopicPartition{" + "topic='" + topic + '\'' + ", partition=" + partition + '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * topic.hashCode() + partition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof KafkaTopicPartition)) {
+      return false;
+    }
+
+    KafkaTopicPartition that = (KafkaTopicPartition) o;
+    return this.partition == that.partition && this.topic.equals(that.topic);
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
@@ -35,11 +35,11 @@ public final class KafkaTopicPartition {
     this.partition = partition;
   }
 
-  public String getTopic() {
+  public String topic() {
     return topic;
   }
 
-  public int getPartition() {
+  public int partition() {
     return partition;
   }
 


### PR DESCRIPTION
With this PR, the following options are now supported:
* from committed consumer group offsets in Kafka
* from earliest offset
* from latest offset
* from specific offsets
* from offsets with ingestion timestamp >= specified date

The changes simply expose configuration. Actual functionality is already implemented by the `FlinkKafkaConsumer`. The exposed configuration API is the following:
```
KafkaIngressBuilder<T> builder = KafkaIngressBuilder.forIdentifier(...)
    .withStartupPosition(KafkaIngressStartupPosition.fromGroupOffsets())
    .withStartupPosition(KafkaIngressStartupPosition.fromEarliest())
    .withStartupPosition(KafkaIngressStartupPosition.fromLatest())
    .withStartupPosition(KafkaIngressStartupPosition.fromSpecificOffsets(Map<KafkaTopicPartition, Long>))
    .withStartupPosition(KafkaIngressStartupPosition.fromDate(java.util.Date))
```

---

Apart from the main changes, there are 3 additional preliminary changes:
* 7e8e522 Add named method for setting consumer group id `withConsumerGroupId(String)` to builder
* 8d09c39 Add named method for setting auto offset reset position
* 0982eec Move Kafka properties resolution from `KafkaSourceProvider` to builder

The additional named methods makes sense, since they have an interplay with the startup position configs. For example, for `KafkaIngressStartupPosition.fromGroupOffsets()`, a consumer group id must be set.
This is not provided as part of the `fromGroupOffsets` signature because consumer group ids have functionality beyond startup position (e.g., we may later introduce offset committing back to Kafka which also relies on a consumer group id being set).