### PR TITLE
[FLINK-15818] [kafka-io] Add startup postition configuration for Kafka ingress YAML support

### DIFF
--- a/statefun-docs/docs/api_concepts/io_module/kafka.rst
+++ b/statefun-docs/docs/api_concepts/io_module/kafka.rst
@@ -46,14 +46,29 @@ It accepts the following arguments:
 1) The ingress identifier associated with this ingress
 2) The topic name / list of topic names
 3) The address of the bootstrap servers
-4) A ``KafkaIngressDeserializer`` for deserializing data from Kafka
-5) Properties for the Kafka consumer
+4) The consumer group id to use
+5) A ``KafkaIngressDeserializer`` for deserializing data from Kafka
+6) The position to start consuming from
 
 .. literalinclude:: ../../../src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
     :language: java
     :lines: 18-
 
+The ingress allows configuring the startup position to be one of the following:
+
+*``KafkaIngressStartupPosition#fromGroupOffsets()`` (default): starts from offsets that were committed to Kafka for the specified consumer group.
+*``KafkaIngressStartupPosition#fromEarliest()``: starts from the earliest offset.
+*``KafkaIngressStartupPosition#fromLatest()``: starts from the latest offset.
+*``KafkaIngressStartupPosition#fromSpecificOffsets(Map)``: starts from specific offsets, defined as a map of partitions to their target starting offset.
+*``KafkaIngressStartupPosition#fromDate(Date)``: starts from offsets that have an ingestion time larger than or equal to a specified date.
+
+On startup, if the specified startup offset for a partition is out-of-range or does not exist (which may be the case if the ingress is configured to
+start from group offsets, specific offsets, or from a date), then the ingress will fallback to using the position configured
+using ``KafkaIngressBuilder#withAutoOffsetResetPosition(KafkaIngressAutoResetPosition)``. By default, this is set to be the latest position.
+
+The ingress also accepts properties to directly configure the Kafka client, using ``KafkaIngressBuilder#withProperties(Properties)``.
 Please refer to the Kafka `consumer configuration <https://docs.confluent.io/current/installation/configuration/consumer-configs.html>`_ documentation for the full list of available properties.
+Note that configuration passed using named methods, such as ``KafkaIngressBuilder#withConsumerGroupId(String)``, will have higher precedence and overwrite their respective settings in the provided properties.
 
 Kafka Deserializer
 """"""""""""""""""

--- a/statefun-docs/src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
+++ b/statefun-docs/src/main/java/org/apache/flink/statefun/docs/io/kafka/IngressSpecs.java
@@ -21,7 +21,7 @@ import org.apache.flink.statefun.docs.models.User;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
 
 public class IngressSpecs {
 
@@ -31,8 +31,9 @@ public class IngressSpecs {
   public static final IngressSpec<User> kafkaIngress =
       KafkaIngressBuilder.forIdentifier(ID)
           .withKafkaAddress("localhost:9092")
+          .withConsumerGroupId("greetings")
           .withTopic("my-topic")
           .withDeserializer(UserDeserializer.class)
-          .withProperty(ConsumerConfig.GROUP_ID_CONFIG, "greetings")
+          .withStartupPosition(KafkaIngressStartupPosition.fromLatest())
           .build();
 }

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/json/SelectorsTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/json/SelectorsTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,6 +47,25 @@ public class SelectorsTest {
     String value = Selectors.textAt(node, FOO_FIELD);
 
     assertThat(value, is("bar"));
+  }
+
+  @Test
+  public void emptyOptionalTextAt() {
+    ObjectNode node = newObject();
+
+    Optional<String> value = Selectors.optionalTextAt(node, FOO_FIELD);
+
+    assertThat(value, is(Optional.empty()));
+  }
+
+  @Test
+  public void nonEmptyOptionalTextAt() {
+    ObjectNode node = newObject();
+    node.put("foo", "bar");
+
+    Optional<String> value = Selectors.optionalTextAt(node, FOO_FIELD);
+
+    assertThat(value, is(Optional.of("bar")));
   }
 
   @Test
@@ -88,11 +108,25 @@ public class SelectorsTest {
     assertThat(value, allOf(hasEntry("k1", "v1"), hasEntry("k2", "v2")));
   }
 
+  @Test
+  public void longPropertiesAt() {
+    ObjectNode node = newObject();
+    node.putArray("foo").add(newKvObject("k1", 91L)).add(newKvObject("k2", 1108L));
+
+    Map<String, Long> value = Selectors.longPropertiesAt(node, FOO_FIELD);
+
+    assertThat(value, allOf(hasEntry("k1", 91L), hasEntry("k2", 1108L)));
+  }
+
   private ObjectNode newObject() {
     return mapper.createObjectNode();
   }
 
   private ObjectNode newKvObject(String key, String value) {
+    return newObject().put(key, value);
+  }
+
+  private ObjectNode newKvObject(String key, long value) {
     return newObject().put(key, value);
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -68,7 +68,7 @@ public class KafkaSourceProvider implements SourceProvider {
           convertKafkaTopicPartitionMap(offsetsPosition.getSpecificOffsets()));
     } else if (startupPosition.isDate()) {
       KafkaIngressStartupPosition.DatePosition datePosition = startupPosition.asDate();
-      consumer.setStartFromTimestamp(datePosition.getTime());
+      consumer.setStartFromTimestamp(datePosition.getEpochMilli());
     } else {
       throw new IllegalStateException("Safe guard; should not occur");
     }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -52,6 +52,8 @@ public class KafkaSourceProvider implements SourceProvider {
     Properties properties = new Properties();
     properties.putAll(spec.properties());
     properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
+    properties.put(
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, spec.autoResetPosition().asKafkaConfig());
     spec.consumerGroupId()
         .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
 

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -96,6 +96,6 @@ public class KafkaSourceProvider implements SourceProvider {
   private static org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
       convertKafkaTopicPartition(KafkaTopicPartition partition) {
     return new org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition(
-        partition.getTopic(), partition.getPartition());
+        partition.topic(), partition.partition());
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
-import java.util.Properties;
 import org.apache.flink.statefun.flink.io.common.ReflectionUtil;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
@@ -26,16 +25,15 @@ import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaSourceProvider implements SourceProvider {
 
   @Override
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
-    Properties properties = createPropertiesFromSpec(spec);
 
-    return new FlinkKafkaConsumer<>(spec.topics(), deserializationSchemaFromSpec(spec), properties);
+    return new FlinkKafkaConsumer<>(
+        spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
   }
 
   private static <T> KafkaIngressSpec<T> asKafkaSpec(IngressSpec<T> ingressSpec) {
@@ -46,18 +44,6 @@ public class KafkaSourceProvider implements SourceProvider {
       throw new NullPointerException("Unable to translate a NULL spec");
     }
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
-  }
-
-  private static <T> Properties createPropertiesFromSpec(KafkaIngressSpec<T> spec) {
-    Properties properties = new Properties();
-    properties.putAll(spec.properties());
-    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
-    properties.put(
-        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, spec.autoResetPosition().asKafkaConfig());
-    spec.consumerGroupId()
-        .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
-
-    return properties;
   }
 
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -26,16 +26,14 @@ import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaSourceProvider implements SourceProvider {
 
   @Override
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
-
-    Properties properties = new Properties();
-    properties.putAll(spec.properties());
-    properties.put("bootstrap.servers", spec.kafkaAddress());
+    Properties properties = createPropertiesFromSpec(spec);
 
     return new FlinkKafkaConsumer<>(spec.topics(), deserializationSchemaFromSpec(spec), properties);
   }
@@ -48,6 +46,16 @@ public class KafkaSourceProvider implements SourceProvider {
       throw new NullPointerException("Unable to translate a NULL spec");
     }
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
+  }
+
+  private static <T> Properties createPropertiesFromSpec(KafkaIngressSpec<T> spec) {
+    Properties properties = new Properties();
+    properties.putAll(spec.properties());
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
+    spec.consumerGroupId()
+        .ifPresent(groupId -> properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId));
+
+    return properties;
   }
 
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -19,10 +19,8 @@ package org.apache.flink.statefun.flink.io.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.flink.statefun.flink.io.common.ReflectionUtil;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
-import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
 import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
@@ -76,9 +74,7 @@ public class KafkaSourceProvider implements SourceProvider {
 
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(
       KafkaIngressSpec<T> spec) {
-    KafkaIngressDeserializer<T> ingressDeserializer =
-        ReflectionUtil.instantiate(spec.deserializerClass());
-    return new KafkaDeserializationSchemaDelegate<>(ingressDeserializer);
+    return new KafkaDeserializationSchemaDelegate<>(spec.deserializer());
   }
 
   private static Map<

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -17,11 +17,15 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.flink.statefun.flink.io.common.ReflectionUtil;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
@@ -32,8 +36,11 @@ public class KafkaSourceProvider implements SourceProvider {
   public <T> SourceFunction<T> forSpec(IngressSpec<T> ingressSpec) {
     KafkaIngressSpec<T> spec = asKafkaSpec(ingressSpec);
 
-    return new FlinkKafkaConsumer<>(
-        spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
+    FlinkKafkaConsumer<T> consumer =
+        new FlinkKafkaConsumer<>(
+            spec.topics(), deserializationSchemaFromSpec(spec), spec.properties());
+    configureStartupPosition(consumer, spec.startupPosition());
+    return consumer;
   }
 
   private static <T> KafkaIngressSpec<T> asKafkaSpec(IngressSpec<T> ingressSpec) {
@@ -46,10 +53,49 @@ public class KafkaSourceProvider implements SourceProvider {
     throw new IllegalArgumentException(String.format("Wrong type %s", ingressSpec.type()));
   }
 
+  private static <T> void configureStartupPosition(
+      FlinkKafkaConsumer<T> consumer, KafkaIngressStartupPosition startupPosition) {
+    if (startupPosition.isGroupOffsets()) {
+      consumer.setStartFromGroupOffsets();
+    } else if (startupPosition.isEarliest()) {
+      consumer.setStartFromEarliest();
+    } else if (startupPosition.isLatest()) {
+      consumer.setStartFromLatest();
+    } else if (startupPosition.isSpecificOffsets()) {
+      KafkaIngressStartupPosition.SpecificOffsetsPosition offsetsPosition =
+          startupPosition.asSpecificOffsets();
+      consumer.setStartFromSpecificOffsets(
+          convertKafkaTopicPartitionMap(offsetsPosition.getSpecificOffsets()));
+    } else if (startupPosition.isDate()) {
+      KafkaIngressStartupPosition.DatePosition datePosition = startupPosition.asDate();
+      consumer.setStartFromTimestamp(datePosition.getTime());
+    } else {
+      throw new IllegalStateException("Safe guard; should not occur");
+    }
+  }
+
   private <T> KafkaDeserializationSchema<T> deserializationSchemaFromSpec(
       KafkaIngressSpec<T> spec) {
     KafkaIngressDeserializer<T> ingressDeserializer =
         ReflectionUtil.instantiate(spec.deserializerClass());
     return new KafkaDeserializationSchemaDelegate<>(ingressDeserializer);
+  }
+
+  private static Map<
+          org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition, Long>
+      convertKafkaTopicPartitionMap(Map<KafkaTopicPartition, Long> offsets) {
+    Map<org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition, Long> result =
+        new HashMap<>(offsets.size());
+    for (Map.Entry<KafkaTopicPartition, Long> offset : offsets.entrySet()) {
+      result.put(convertKafkaTopicPartition(offset.getKey()), offset.getValue());
+    }
+
+    return result;
+  }
+
+  private static org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
+      convertKafkaTopicPartition(KafkaTopicPartition partition) {
+    return new org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition(
+        partition.getTopic(), partition.getPartition());
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProvider.java
@@ -18,19 +18,31 @@
 package org.apache.flink.statefun.flink.io.kafka;
 
 import com.google.protobuf.Message;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressAutoResetPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilderApiExtension;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
-import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
 
 final class ProtobufKafkaSourceProvider implements SourceProvider {
 
@@ -42,51 +54,175 @@ final class ProtobufKafkaSourceProvider implements SourceProvider {
   private static final JsonPointer PROPERTIES_POINTER =
       JsonPointer.compile("/ingress/spec/properties");
   private static final JsonPointer ADDRESS_POINTER = JsonPointer.compile("/ingress/spec/address");
+  private static final JsonPointer GROUP_ID_POINTER =
+      JsonPointer.compile("/ingress/spec/consumerGroupId");
+  private static final JsonPointer AUTO_RESET_POS_POINTER =
+      JsonPointer.compile("/ingress/spec/autoOffsetResetPosition");
+
+  private static final JsonPointer STARTUP_POS_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition");
+  private static final JsonPointer STARTUP_POS_TYPE_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/type");
+  private static final JsonPointer STARTUP_SPECIFIC_OFFSETS_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/offsets");
+  private static final JsonPointer STARTUP_DATE_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/date");
+
+  private static final String STARTUP_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS Z";
+
+  private final KafkaSourceProvider delegateProvider = new KafkaSourceProvider();
 
   @Override
   public <T> SourceFunction<T> forSpec(IngressSpec<T> spec) {
-    JsonNode json = asJsonIngressSpec(spec);
-    Properties properties = kafkaClientProperties(json);
-    List<String> topics = Selectors.textListAt(json, TOPICS_POINTER);
-    KafkaDeserializationSchema<T> deserializationSchema = deserializationSchema(json);
-    return new FlinkKafkaConsumer<>(topics, deserializationSchema, properties);
+    KafkaIngressSpec<T> kafkaIngressSpec = asKafkaIngressSpec(spec);
+    return delegateProvider.forSpec(kafkaIngressSpec);
   }
 
-  private <T> KafkaDeserializationSchema<T> deserializationSchema(JsonNode json) {
-    String descriptorSetPath = Selectors.textAt(json, DESCRIPTOR_SET_POINTER);
-    String messageType = Selectors.textAt(json, MESSAGE_TYPE_POINTER);
-    // this cast is safe since we validate that the produced message type (T) is assignable to a
-    // Message.
-    // see asJsonIngressSpec()
-    @SuppressWarnings("unchecked")
-    KafkaIngressDeserializer<T> deserializer =
-        (KafkaIngressDeserializer<T>)
-            new ProtobufKafkaIngressDeserializer(descriptorSetPath, messageType);
-    return new KafkaDeserializationSchemaDelegate<>(deserializer);
-  }
-
-  private static Properties kafkaClientProperties(JsonNode json) {
-    Map<String, String> kvs = Selectors.propertiesAt(json, PROPERTIES_POINTER);
-    Properties properties = new Properties();
-    properties.put("bootstrap.servers", Selectors.textAt(json, ADDRESS_POINTER));
-    kvs.forEach(properties::put);
-    return properties;
-  }
-
-  private static JsonNode asJsonIngressSpec(IngressSpec<?> spec) {
+  private static <T> KafkaIngressSpec<T> asKafkaIngressSpec(IngressSpec<T> spec) {
     if (!(spec instanceof JsonIngressSpec)) {
       throw new IllegalArgumentException("Wrong type " + spec.type());
     }
-    JsonIngressSpec<?> casted = (JsonIngressSpec<?>) spec;
+    JsonIngressSpec<T> casted = (JsonIngressSpec<T>) spec;
+
+    IngressIdentifier<T> id = casted.id();
     Class<?> producedType = casted.id().producedType();
     if (!Message.class.isAssignableFrom(producedType)) {
       throw new IllegalArgumentException(
-          "ProtocolBuffer based ingress is able to produce types that derive from "
+          "ProtocolBuffer based ingress is only able to produce types that derive from "
               + Message.class.getName()
               + " but "
               + producedType.getName()
               + " is provided.");
     }
-    return casted.json();
+
+    JsonNode json = casted.json();
+
+    KafkaIngressBuilder<T> kafkaIngressBuilder = KafkaIngressBuilder.forIdentifier(id);
+    kafkaIngressBuilder
+        .withKafkaAddress(kafkaAddress(json))
+        .withProperties(kafkaClientProperties(json))
+        .addTopics(topics(json));
+
+    optionalConsumerGroupId(json).ifPresent(kafkaIngressBuilder::withConsumerGroupId);
+    optionalAutoOffsetResetPosition(json).ifPresent(kafkaIngressBuilder::withAutoResetPosition);
+    optionalStartupPosition(json).ifPresent(kafkaIngressBuilder::withStartupPosition);
+
+    KafkaIngressBuilderApiExtension.withDeserializer(kafkaIngressBuilder, deserializer(json));
+
+    return kafkaIngressBuilder.build();
+  }
+
+  private static List<String> topics(JsonNode json) {
+    return Selectors.textListAt(json, TOPICS_POINTER);
+  }
+
+  private static Properties kafkaClientProperties(JsonNode json) {
+    Map<String, String> kvs = Selectors.propertiesAt(json, PROPERTIES_POINTER);
+    Properties properties = new Properties();
+    kvs.forEach(properties::put);
+    return properties;
+  }
+
+  private static String kafkaAddress(JsonNode json) {
+    return Selectors.textAt(json, ADDRESS_POINTER);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> KafkaIngressDeserializer<T> deserializer(JsonNode json) {
+    String descriptorSetPath = Selectors.textAt(json, DESCRIPTOR_SET_POINTER);
+    String messageType = Selectors.textAt(json, MESSAGE_TYPE_POINTER);
+    // this cast is safe since we validate that the produced message type (T) is assignable to a
+    // Message.
+    // see asJsonIngressSpec()
+    return (KafkaIngressDeserializer<T>)
+        new ProtobufKafkaIngressDeserializer(descriptorSetPath, messageType);
+  }
+
+  private static Optional<String> optionalConsumerGroupId(JsonNode json) {
+    return Selectors.optionalTextAt(json, GROUP_ID_POINTER);
+  }
+
+  private static Optional<KafkaIngressAutoResetPosition> optionalAutoOffsetResetPosition(
+      JsonNode json) {
+    Optional<String> conf = Selectors.optionalTextAt(json, AUTO_RESET_POS_POINTER);
+    if (!conf.isPresent()) {
+      return Optional.empty();
+    }
+
+    String autoOffsetResetConfig = conf.get().toUpperCase(Locale.ENGLISH);
+
+    try {
+      return Optional.of(KafkaIngressAutoResetPosition.valueOf(autoOffsetResetConfig));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid autoOffsetResetPosition: "
+              + autoOffsetResetConfig
+              + "; valid values are "
+              + Arrays.toString(KafkaIngressAutoResetPosition.values()),
+          e);
+    }
+  }
+
+  private static Optional<KafkaIngressStartupPosition> optionalStartupPosition(JsonNode json) {
+    if (json.at(STARTUP_POS_POINTER).isMissingNode()) {
+      return Optional.empty();
+    }
+
+    String startupType =
+        Selectors.textAt(json, STARTUP_POS_TYPE_POINTER).toLowerCase(Locale.ENGLISH);
+    switch (startupType) {
+      case "group-offsets":
+        return Optional.of(KafkaIngressStartupPosition.fromGroupOffsets());
+      case "earliest":
+        return Optional.of(KafkaIngressStartupPosition.fromEarliest());
+      case "latest":
+        return Optional.of(KafkaIngressStartupPosition.fromLatest());
+      case "specific-offsets":
+        return Optional.of(
+            KafkaIngressStartupPosition.fromSpecificOffsets(specificOffsetsStartupMap(json)));
+      case "date":
+        return Optional.of(KafkaIngressStartupPosition.fromDate(startupDate(json)));
+      default:
+        throw new IllegalArgumentException(
+            "Invalid startup position type: "
+                + startupType
+                + "; valid values are [group-offsets, earliest, latest, specific-offsets, date]");
+    }
+  }
+
+  private static Map<KafkaTopicPartition, Long> specificOffsetsStartupMap(JsonNode json) {
+    Map<String, Long> kvs = Selectors.longPropertiesAt(json, STARTUP_SPECIFIC_OFFSETS_POINTER);
+    Map<KafkaTopicPartition, Long> offsets = new HashMap<>(kvs.size());
+    kvs.forEach(
+        (partition, offset) ->
+            offsets.put(KafkaTopicPartition.fromString(partition), validateOffsetLong(offset)));
+    return offsets;
+  }
+
+  private static Date startupDate(JsonNode json) {
+    String dateStr = Selectors.textAt(json, STARTUP_DATE_POINTER);
+    SimpleDateFormat dateFormat = new SimpleDateFormat(STARTUP_DATE_FORMAT);
+    try {
+      return dateFormat.parse(dateStr);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException(
+          "Unable to parse date string for startup position: "
+              + dateStr
+              + "; the date should conform to the pattern "
+              + STARTUP_DATE_FORMAT,
+          e);
+    }
+  }
+
+  private static Long validateOffsetLong(Long offset) {
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          "Invalid offset value: "
+              + offset
+              + "; must be a numeric integer with value between 0 and "
+              + Long.MAX_VALUE);
+    }
+
+    return offset;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderApiExtension.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderApiExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+public class KafkaIngressBuilderApiExtension {
+  public static <T> void withDeserializer(
+      KafkaIngressBuilder<T> kafkaIngressBuilder, KafkaIngressDeserializer<T> deserializer) {
+    kafkaIngressBuilder.withDeserializer(deserializer);
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/resources/protobuf-kafka-ingress.yaml
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/resources/protobuf-kafka-ingress.yaml
@@ -19,10 +19,18 @@ ingress:
     id: com.mycomp.igal/names
   spec:
     address: kafka-broker:9092
+    consumerGroupId: greeter
     topics:
       - names
+    autoOffsetResetPosition: earliest
+    startupPosition:
+      type: specific-offsets
+      offsets:
+        - names/0: 91
+        - names/1: 11
+        - names/2: 8
     properties:
-      - consumer.group: greeter
+      - foo.config: bar
     messageType: org.apache.flink.test.SimpleMessage
     descriptorSet: classpath:test.desc
     

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Locale;
+
+/** The auto offset reset position to use in case consumed offsets are invalid. */
+public enum KafkaIngressAutoResetPosition {
+  EARLIEST,
+  LATEST;
+
+  public String asKafkaConfig() {
+    return name().toLowerCase(Locale.ENGLISH);
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -37,6 +37,7 @@ public final class KafkaIngressBuilder<T> {
   private String consumerGroupId;
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
+  private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -97,9 +98,25 @@ public final class KafkaIngressBuilder<T> {
     return this;
   }
 
+  /**
+   * @param autoResetPosition the auto offset reset position to use, in case consumed offsets are
+   *     invalid.
+   */
+  public KafkaIngressBuilder<T> withAutoResetPosition(
+      KafkaIngressAutoResetPosition autoResetPosition) {
+    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
+    return this;
+  }
+
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
     return new KafkaIngressSpec<>(
-        id, kafkaAddress, properties, topics, deserializerClass, consumerGroupId);
+        id,
+        kafkaAddress,
+        properties,
+        topics,
+        deserializerClass,
+        autoResetPosition,
+        consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -39,8 +39,7 @@ public final class KafkaIngressBuilder<T> {
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
   private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
-  private KafkaIngressStartupPosition startupPosition =
-      KafkaIngressStartupPosition.fromGroupOffsets();
+  private KafkaIngressStartupPosition startupPosition = KafkaIngressStartupPosition.fromLatest();
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -112,7 +111,8 @@ public final class KafkaIngressBuilder<T> {
   }
 
   /**
-   * Configures the position that the ingress should start consuming from.
+   * Configures the position that the ingress should start consuming from. By default, the startup
+   * position is {@link KafkaIngressStartupPosition#fromLatest()}.
    *
    * <p>Note that this configuration only affects the position when starting the application from a
    * fresh start. When restoring the application from a savepoint, the ingress will always start

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -39,6 +39,8 @@ public final class KafkaIngressBuilder<T> {
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
   private KafkaIngressAutoResetPosition autoResetPosition = KafkaIngressAutoResetPosition.LATEST;
+  private KafkaIngressStartupPosition startupPosition =
+      KafkaIngressStartupPosition.fromGroupOffsets();
 
   private KafkaIngressBuilder(IngressIdentifier<T> id) {
     this.id = Objects.requireNonNull(id);
@@ -109,11 +111,26 @@ public final class KafkaIngressBuilder<T> {
     return this;
   }
 
+  /**
+   * Configures the position that the ingress should start consuming from.
+   *
+   * <p>Note that this configuration only affects the position when starting the application from a
+   * fresh start. When restoring the application from a savepoint, the ingress will always start
+   * consuming from the offsets persisted in the savepoint.
+   *
+   * @param startupPosition the position that the Kafka ingress should start consuming from.
+   * @see KafkaIngressStartupPosition
+   */
+  public KafkaIngressBuilder<T> withStartupPosition(KafkaIngressStartupPosition startupPosition) {
+    this.startupPosition = Objects.requireNonNull(startupPosition);
+    return this;
+  }
+
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
     Properties properties = resolveKafkaProperties();
 
-    return new KafkaIngressSpec<>(id, properties, topics, deserializerClass);
+    return new KafkaIngressSpec<>(id, properties, topics, deserializerClass, startupPosition);
   }
 
   private Properties resolveKafkaProperties() {

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -130,8 +130,8 @@ public final class KafkaIngressBuilder<T> {
     return this;
   }
 
-  /** @return A new {@link IngressSpec}. */
-  public IngressSpec<T> build() {
+  /** @return A new {@link KafkaIngressSpec}. */
+  public KafkaIngressSpec<T> build() {
     Properties properties = resolveKafkaProperties();
 
     return new KafkaIngressSpec<>(id, properties, topics, deserializer, startupPosition);

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -34,6 +34,7 @@ public final class KafkaIngressBuilder<T> {
   private final IngressIdentifier<T> id;
   private final List<String> topics = new ArrayList<>();
   private final Properties properties = new Properties();
+  private String consumerGroupId;
   private Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private String kafkaAddress;
 
@@ -48,6 +49,12 @@ public final class KafkaIngressBuilder<T> {
    */
   public static <T> KafkaIngressBuilder<T> forIdentifier(IngressIdentifier<T> id) {
     return new KafkaIngressBuilder<>(id);
+  }
+
+  /** @param consumerGroupId the consumer group id to use. */
+  public KafkaIngressBuilder<T> withConsumerGroupId(String consumerGroupId) {
+    this.consumerGroupId = Objects.requireNonNull(consumerGroupId);
+    return this;
   }
 
   /** @param kafkaAddress Comma separated addresses of the brokers. */
@@ -92,6 +99,7 @@ public final class KafkaIngressBuilder<T> {
 
   /** @return A new {@link IngressSpec}. */
   public IngressSpec<T> build() {
-    return new KafkaIngressSpec<>(id, kafkaAddress, properties, topics, deserializerClass);
+    return new KafkaIngressSpec<>(
+        id, kafkaAddress, properties, topics, deserializerClass, consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -19,7 +19,9 @@ package org.apache.flink.statefun.sdk.kafka;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
@@ -31,17 +33,21 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
   private final IngressIdentifier<T> ingressIdentifier;
 
+  @Nullable private final String consumerGroupId;
+
   KafkaIngressSpec(
       IngressIdentifier<T> id,
       String kafkaAddress,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      String consumerGroupId) {
     this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+    this.consumerGroupId = consumerGroupId;
   }
 
   @Override
@@ -68,5 +74,9 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public Optional<String> consumerGroupId() {
+    return (consumerGroupId == null) ? Optional.empty() : Optional.of(consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -19,38 +19,26 @@ package org.apache.flink.statefun.sdk.kafka;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 
 public class KafkaIngressSpec<T> implements IngressSpec<T> {
-  private final String kafkaAddress;
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
-  private final KafkaIngressAutoResetPosition autoResetPosition;
   private final IngressIdentifier<T> ingressIdentifier;
-
-  @Nullable private final String consumerGroupId;
 
   KafkaIngressSpec(
       IngressIdentifier<T> id,
-      String kafkaAddress,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
-      KafkaIngressAutoResetPosition autoResetPosition,
-      String consumerGroupId) {
-    this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
-    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
-    this.consumerGroupId = consumerGroupId;
   }
 
   @Override
@@ -63,10 +51,6 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
     return Constants.KAFKA_INGRESS_TYPE;
   }
 
-  public String kafkaAddress() {
-    return kafkaAddress;
-  }
-
   public Properties properties() {
     return properties;
   }
@@ -77,13 +61,5 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
-  }
-
-  public KafkaIngressAutoResetPosition autoResetPosition() {
-    return autoResetPosition;
-  }
-
-  public Optional<String> consumerGroupId() {
-    return (consumerGroupId == null) ? Optional.empty() : Optional.of(consumerGroupId);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -29,7 +29,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Properties properties;
   private final List<String> topics;
-  private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
+  private final KafkaIngressDeserializer<T> deserializer;
   private final KafkaIngressStartupPosition startupPosition;
   private final IngressIdentifier<T> ingressIdentifier;
 
@@ -37,11 +37,11 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
       IngressIdentifier<T> id,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      KafkaIngressDeserializer<T> deserializer,
       KafkaIngressStartupPosition startupPosition) {
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
-    this.deserializerClass = Objects.requireNonNull(deserializerClass);
+    this.deserializer = Objects.requireNonNull(deserializer);
     this.ingressIdentifier = Objects.requireNonNull(id);
 
     validateStartupPosition(
@@ -67,8 +67,8 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
     return topics;
   }
 
-  public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
-    return deserializerClass;
+  public KafkaIngressDeserializer<T> deserializer() {
+    return deserializer;
   }
 
   public KafkaIngressStartupPosition startupPosition() {

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -20,25 +20,33 @@ package org.apache.flink.statefun.sdk.kafka;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
+  private final KafkaIngressStartupPosition startupPosition;
   private final IngressIdentifier<T> ingressIdentifier;
 
   KafkaIngressSpec(
       IngressIdentifier<T> id,
       Properties properties,
       List<String> topics,
-      Class<? extends KafkaIngressDeserializer<T>> deserializerClass) {
+      Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      KafkaIngressStartupPosition startupPosition) {
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+
+    validateStartupPosition(
+        startupPosition, properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG));
+    this.startupPosition = Objects.requireNonNull(startupPosition);
   }
 
   @Override
@@ -61,5 +69,18 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public KafkaIngressStartupPosition startupPosition() {
+    return startupPosition;
+  }
+
+  private static void validateStartupPosition(
+      KafkaIngressStartupPosition startupPosition, @Nullable String groupIdConfig) {
+    if (startupPosition.isGroupOffsets() && groupIdConfig == null) {
+      throw new IllegalStateException(
+          "The ingress is configured to start from committed consumer group offsets in Kafka, but no consumer group id was set.\n"
+              + "Please set the group id with the withConsumerGroupId(String) method.");
+    }
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressSpec.java
@@ -31,6 +31,7 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
   private final Properties properties;
   private final List<String> topics;
   private final Class<? extends KafkaIngressDeserializer<T>> deserializerClass;
+  private final KafkaIngressAutoResetPosition autoResetPosition;
   private final IngressIdentifier<T> ingressIdentifier;
 
   @Nullable private final String consumerGroupId;
@@ -41,12 +42,14 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
       Properties properties,
       List<String> topics,
       Class<? extends KafkaIngressDeserializer<T>> deserializerClass,
+      KafkaIngressAutoResetPosition autoResetPosition,
       String consumerGroupId) {
     this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
     this.properties = Objects.requireNonNull(properties);
     this.topics = Objects.requireNonNull(topics);
     this.deserializerClass = Objects.requireNonNull(deserializerClass);
     this.ingressIdentifier = Objects.requireNonNull(id);
+    this.autoResetPosition = Objects.requireNonNull(autoResetPosition);
     this.consumerGroupId = consumerGroupId;
   }
 
@@ -74,6 +77,10 @@ public class KafkaIngressSpec<T> implements IngressSpec<T> {
 
   public Class<? extends KafkaIngressDeserializer<T>> deserializerClass() {
     return deserializerClass;
+  }
+
+  public KafkaIngressAutoResetPosition autoResetPosition() {
+    return autoResetPosition;
   }
 
   public Optional<String> consumerGroupId() {

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Date;
+import java.util.Map;
+
+/** Position for the ingress to start consuming Kafka partitions. */
+@SuppressWarnings("WeakerAccess, unused")
+public class KafkaIngressStartupPosition {
+
+  /** Private constructor to prevent instantiation. */
+  private KafkaIngressStartupPosition() {}
+
+  /**
+   * Start consuming from committed consumer group offsets in Kafka.
+   *
+   * <p>Note that a consumer group id must be provided for this startup mode. Please see {@link
+   * KafkaIngressBuilder#withConsumerGroupId(String)}.
+   */
+  public static KafkaIngressStartupPosition fromGroupOffsets() {
+    return new GroupOffsetsPosition();
+  }
+
+  /** Start consuming from the earliest offset possible. */
+  public static KafkaIngressStartupPosition fromEarliest() {
+    return new EarliestPosition();
+  }
+
+  /** Start consuming from the latest offset, i.e. head of the topic partitions. */
+  public static KafkaIngressStartupPosition fromLatest() {
+    return new LatestPosition();
+  }
+
+  /**
+   * Start consuming from a specified set of offsets.
+   *
+   * <p>If a specified offset does not exist for a partition, the position for that partition will
+   * fallback to the reset position configured via {@link
+   * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
+   *
+   * @param specificOffsets map of specific set of offsets.
+   */
+  public static KafkaIngressStartupPosition fromSpecificOffsets(
+      Map<KafkaTopicPartition, Long> specificOffsets) {
+    if (specificOffsets == null || specificOffsets.isEmpty()) {
+      throw new IllegalArgumentException("Provided specific offsets must not be empty.");
+    }
+    return new SpecificOffsetsPosition(specificOffsets);
+  }
+
+  /**
+   * Start consuming from offsets with ingestion timestamps after or equal to a specified {@link
+   * Date}.
+   *
+   * <p>If a Kafka partition does not have any records with ingestion timestamps after or equal to
+   * the specified date, the position for that partition will fallback to the reset position
+   * configured via {@link
+   * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
+   */
+  public static KafkaIngressStartupPosition fromDate(Date date) {
+    return new DatePosition(date);
+  }
+
+  /** Checks whether this position is configured using committed consumer group offsets in Kafka. */
+  public boolean isGroupOffsets() {
+    return getClass() == GroupOffsetsPosition.class;
+  }
+
+  /** Checks whether this position is configured using the earliest offset. */
+  public boolean isEarliest() {
+    return getClass() == EarliestPosition.class;
+  }
+
+  /** Checks whether this position is configured using the latest offset. */
+  public boolean isLatest() {
+    return getClass() == LatestPosition.class;
+  }
+
+  /** Checks whether this position is configured using specific offsets. */
+  public boolean isSpecificOffsets() {
+    return getClass() == SpecificOffsetsPosition.class;
+  }
+
+  /** Checks whether this position is configured using a date. */
+  public boolean isDate() {
+    return getClass() == DatePosition.class;
+  }
+
+  /** Returns this position as a {@link SpecificOffsetsPosition}. */
+  public SpecificOffsetsPosition asSpecificOffsets() {
+    if (!isSpecificOffsets()) {
+      throw new IllegalStateException(
+          "This is not a startup position configured using specific offsets.");
+    }
+    return (SpecificOffsetsPosition) this;
+  }
+
+  /** Returns this position as a {@link DatePosition}. */
+  public DatePosition asDate() {
+    if (!isDate()) {
+      throw new IllegalStateException("This is not a startup position configured using a Date.");
+    }
+    return (DatePosition) this;
+  }
+
+  public static class GroupOffsetsPosition extends KafkaIngressStartupPosition {}
+
+  public static class EarliestPosition extends KafkaIngressStartupPosition {}
+
+  public static class LatestPosition extends KafkaIngressStartupPosition {}
+
+  public static class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
+
+    private final Map<KafkaTopicPartition, Long> specificOffsets;
+
+    SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
+      this.specificOffsets = specificOffsets;
+    }
+
+    public Map<KafkaTopicPartition, Long> getSpecificOffsets() {
+      return specificOffsets;
+    }
+  }
+
+  public static class DatePosition extends KafkaIngressStartupPosition {
+
+    private final Date date;
+
+    DatePosition(Date date) {
+      this.date = date;
+    }
+
+    public long getTime() {
+      return date.getTime();
+    }
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.sdk.kafka;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 /** Position for the ingress to start consuming Kafka partitions. */
@@ -66,14 +66,14 @@ public class KafkaIngressStartupPosition {
 
   /**
    * Start consuming from offsets with ingestion timestamps after or equal to a specified {@link
-   * Date}.
+   * ZonedDateTime}.
    *
    * <p>If a Kafka partition does not have any records with ingestion timestamps after or equal to
    * the specified date, the position for that partition will fallback to the reset position
    * configured via {@link
    * KafkaIngressBuilder#withAutoResetPosition(KafkaIngressAutoResetPosition)}.
    */
-  public static KafkaIngressStartupPosition fromDate(Date date) {
+  public static KafkaIngressStartupPosition fromDate(ZonedDateTime date) {
     return new DatePosition(date);
   }
 
@@ -146,14 +146,14 @@ public class KafkaIngressStartupPosition {
 
   public static final class DatePosition extends KafkaIngressStartupPosition {
 
-    private final Date date;
+    private final ZonedDateTime date;
 
-    private DatePosition(Date date) {
+    private DatePosition(ZonedDateTime date) {
       this.date = date;
     }
 
-    public long getTime() {
-      return date.getTime();
+    public long getEpochMilli() {
+      return date.toInstant().toEpochMilli();
     }
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -119,17 +119,23 @@ public class KafkaIngressStartupPosition {
     return (DatePosition) this;
   }
 
-  public static class GroupOffsetsPosition extends KafkaIngressStartupPosition {}
+  public static final class GroupOffsetsPosition extends KafkaIngressStartupPosition {
+    private GroupOffsetsPosition() {}
+  }
 
-  public static class EarliestPosition extends KafkaIngressStartupPosition {}
+  public static final class EarliestPosition extends KafkaIngressStartupPosition {
+    private EarliestPosition() {}
+  }
 
-  public static class LatestPosition extends KafkaIngressStartupPosition {}
+  public static final class LatestPosition extends KafkaIngressStartupPosition {
+    private LatestPosition() {}
+  }
 
-  public static class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
+  public static final class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
 
     private final Map<KafkaTopicPartition, Long> specificOffsets;
 
-    SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
+    private SpecificOffsetsPosition(Map<KafkaTopicPartition, Long> specificOffsets) {
       this.specificOffsets = specificOffsets;
     }
 
@@ -138,11 +144,11 @@ public class KafkaIngressStartupPosition {
     }
   }
 
-  public static class DatePosition extends KafkaIngressStartupPosition {
+  public static final class DatePosition extends KafkaIngressStartupPosition {
 
     private final Date date;
 
-    DatePosition(Date date) {
+    private DatePosition(Date date) {
       this.date = date;
     }
 

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.Objects;
+
+/** Representation of a Kafka partition. */
+public final class KafkaTopicPartition {
+
+  private final String topic;
+  private final int partition;
+
+  public KafkaTopicPartition(String topic, int partition) {
+    this.topic = Objects.requireNonNull(topic);
+
+    if (partition < 0) {
+      throw new IllegalArgumentException(
+          "Invalid partition id: " + partition + "; value must be larger or equal to 0.");
+    }
+    this.partition = partition;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public int getPartition() {
+    return partition;
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaTopicPartition{" + "topic='" + topic + '\'' + ", partition=" + partition + '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * topic.hashCode() + partition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof KafkaTopicPartition)) {
+      return false;
+    }
+
+    KafkaTopicPartition that = (KafkaTopicPartition) o;
+    return this.partition == that.partition && this.topic.equals(that.topic);
+  }
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
@@ -35,11 +35,11 @@ public final class KafkaTopicPartition {
     this.partition = partition;
   }
 
-  public String getTopic() {
+  public String topic() {
     return topic;
   }
 
-  public int getPartition() {
+  public int partition() {
     return partition;
   }
 

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartition.java
@@ -25,6 +25,38 @@ public final class KafkaTopicPartition {
   private final String topic;
   private final int partition;
 
+  public static KafkaTopicPartition fromString(String topicAndPartition) {
+    Objects.requireNonNull(topicAndPartition);
+    final int pos = topicAndPartition.lastIndexOf("/");
+    if (pos <= 0 || pos == topicAndPartition.length() - 1) {
+      throw new IllegalArgumentException(
+          topicAndPartition + " does not conform to the <topic>/<partition_id> format");
+    }
+
+    String topic = topicAndPartition.substring(0, pos);
+    Integer partitionId;
+    try {
+      partitionId = Integer.valueOf(topicAndPartition.substring(pos + 1));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid topic partition definition: "
+              + topicAndPartition
+              + "; partition id is expected to be an integer with value between 0 and "
+              + Integer.MAX_VALUE,
+          e);
+    }
+
+    if (partitionId < 0) {
+      throw new IllegalArgumentException(
+          "Invalid topic partition definition: "
+              + topicAndPartition
+              + "; partition id is expected to be an integer with value between 0 and "
+              + Integer.MAX_VALUE);
+    }
+
+    return new KafkaTopicPartition(topic, partitionId);
+  }
+
   public KafkaTopicPartition(String topic, int partition) {
     this.topic = Objects.requireNonNull(topic);
 


### PR DESCRIPTION
This is a follow-up to #5, and is based on that PR.
It extends the addition of configuring startup position / auto offset reset position / consumer group id to the YAML-based Kafka ingress.

Only the last 3 commits starting from c09fcd2 is relevant.

Moreover, this PR unifies the source creation logic between `ProtobufKafkaSourceProvider` and `KafkaSourceProvider`, to be always delegated through `KafkaSourceProvider`.
With this change, the `ProtobufKafkaSourceProvider` only deals with parsing the Json ingress spec into a `KafkaIngressSpec`, and delegates the actual creation of the Flink Kafka source to a `KafkaSourceProvider`.
This allows us to consolidate configuration validation logic in a single place (builder + `KafkaIngressSpec`).

Example YAML with the new configs:
```
ingress:
  meta:
    type: org.apache.flink.statefun.sdk.kafka/protobuf-kafka-connector
    id: com.mycomp.igal/names
  spec:
    address: kafka-broker:9092
    consumerGroupId: greeter
    topics:
      - names
    autoOffsetResetPosition: earliest
    startupPosition:
      type: specific-offsets
      offsets:
        - names/0: 91
        - names/1: 11
        - names/2: 8
    properties:
      - foo.config: bar
    messageType: org.apache.flink.test.SimpleMessage
    descriptorSet: classpath:test.desc
```

Other startup position types:
```
startupPosition:
      type: date
      date: 2020-01-31 16:01:49.440 +0800
```
```
startupPosition:
      type: earliest / latest / group-offsets
```

These can be validated using the existing `ProtobufKafkaSourceProviderTest#exampleUsage` test.