### PR TITLE
[FLINK-15839] [kafka-io] Fix Stateful Functions KafkaIngressBuilder properties resolution logic

### DIFF
--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSourceProvider.java
@@ -63,10 +63,10 @@ public class KafkaSourceProvider implements SourceProvider {
       KafkaIngressStartupPosition.SpecificOffsetsPosition offsetsPosition =
           startupPosition.asSpecificOffsets();
       consumer.setStartFromSpecificOffsets(
-          convertKafkaTopicPartitionMap(offsetsPosition.getSpecificOffsets()));
+          convertKafkaTopicPartitionMap(offsetsPosition.specificOffsets()));
     } else if (startupPosition.isDate()) {
       KafkaIngressStartupPosition.DatePosition datePosition = startupPosition.asDate();
-      consumer.setStartFromTimestamp(datePosition.getEpochMilli());
+      consumer.setStartFromTimestamp(datePosition.epochMilli());
     } else {
       throw new IllegalStateException("Safe guard; should not occur");
     }

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -52,5 +52,19 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressAutoResetPosition.java
@@ -24,7 +24,8 @@ public enum KafkaIngressAutoResetPosition {
   EARLIEST,
   LATEST;
 
-  public String asKafkaConfig() {
+  @Override
+  public String toString() {
     return name().toLowerCase(Locale.ENGLISH);
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -178,7 +178,7 @@ public class KafkaIngressStartupPosition {
       this.specificOffsets = specificOffsets;
     }
 
-    public Map<KafkaTopicPartition, Long> getSpecificOffsets() {
+    public Map<KafkaTopicPartition, Long> specificOffsets() {
       return specificOffsets;
     }
 
@@ -212,7 +212,7 @@ public class KafkaIngressStartupPosition {
       this.date = date;
     }
 
-    public long getEpochMilli() {
+    public long epochMilli() {
       return date.toInstant().toEpochMilli();
     }
 

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressStartupPosition.java
@@ -34,17 +34,17 @@ public class KafkaIngressStartupPosition {
    * KafkaIngressBuilder#withConsumerGroupId(String)}.
    */
   public static KafkaIngressStartupPosition fromGroupOffsets() {
-    return new GroupOffsetsPosition();
+    return GroupOffsetsPosition.INSTANCE;
   }
 
   /** Start consuming from the earliest offset possible. */
   public static KafkaIngressStartupPosition fromEarliest() {
-    return new EarliestPosition();
+    return EarliestPosition.INSTANCE;
   }
 
   /** Start consuming from the latest offset, i.e. head of the topic partitions. */
   public static KafkaIngressStartupPosition fromLatest() {
-    return new LatestPosition();
+    return LatestPosition.INSTANCE;
   }
 
   /**
@@ -120,15 +120,54 @@ public class KafkaIngressStartupPosition {
   }
 
   public static final class GroupOffsetsPosition extends KafkaIngressStartupPosition {
+
+    private static final GroupOffsetsPosition INSTANCE = new GroupOffsetsPosition();
+
     private GroupOffsetsPosition() {}
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj != null && obj instanceof GroupOffsetsPosition;
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
   }
 
   public static final class EarliestPosition extends KafkaIngressStartupPosition {
+
+    private static final EarliestPosition INSTANCE = new EarliestPosition();
+
     private EarliestPosition() {}
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj != null && obj instanceof EarliestPosition;
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
   }
 
   public static final class LatestPosition extends KafkaIngressStartupPosition {
+
+    private static final LatestPosition INSTANCE = new LatestPosition();
+
     private LatestPosition() {}
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj != null && obj instanceof LatestPosition;
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
   }
 
   public static final class SpecificOffsetsPosition extends KafkaIngressStartupPosition {
@@ -142,6 +181,27 @@ public class KafkaIngressStartupPosition {
     public Map<KafkaTopicPartition, Long> getSpecificOffsets() {
       return specificOffsets;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      }
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof SpecificOffsetsPosition)) {
+        return false;
+      }
+
+      SpecificOffsetsPosition that = (SpecificOffsetsPosition) obj;
+      return that.specificOffsets.equals(specificOffsets);
+    }
+
+    @Override
+    public int hashCode() {
+      return specificOffsets.hashCode();
+    }
   }
 
   public static final class DatePosition extends KafkaIngressStartupPosition {
@@ -154,6 +214,27 @@ public class KafkaIngressStartupPosition {
 
     public long getEpochMilli() {
       return date.toInstant().toEpochMilli();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      }
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof DatePosition)) {
+        return false;
+      }
+
+      DatePosition that = (DatePosition) obj;
+      return that.date.equals(date);
+    }
+
+    @Override
+    public int hashCode() {
+      return date.hashCode();
     }
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/OptionalConfig.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/OptionalConfig.java
@@ -19,6 +19,7 @@ package org.apache.flink.statefun.sdk.kafka;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Properties;
 import javax.annotation.Nullable;
 
 /**
@@ -44,14 +45,6 @@ final class OptionalConfig<T> {
     this.defaultValue = defaultValue;
   }
 
-  boolean hasDefault() {
-    return defaultValue != null;
-  }
-
-  boolean isSet() {
-    return value != null;
-  }
-
   void set(T value) {
     this.value = Objects.requireNonNull(value);
   }
@@ -62,5 +55,19 @@ final class OptionalConfig<T> {
           "A value has not been set, and no default value was defined.");
     }
     return isSet() ? value : defaultValue;
+  }
+
+  void overwritePropertiesIfPresent(Properties properties, String key) {
+    if (isSet() || (!properties.containsKey(key) && hasDefault())) {
+      properties.setProperty(key, get().toString());
+    }
+  }
+
+  private boolean hasDefault() {
+    return defaultValue != null;
+  }
+
+  private boolean isSet() {
+    return value != null;
   }
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/OptionalConfig.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/OptionalConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class to represent an optional config, which may have a predefined default value.
+ *
+ * @param <T> type of the configuration value.
+ */
+final class OptionalConfig<T> {
+
+  private final T defaultValue;
+  private T value;
+
+  static <T> OptionalConfig<T> withDefault(T defaultValue) {
+    Objects.requireNonNull(defaultValue);
+    return new OptionalConfig<>(defaultValue);
+  }
+
+  static <T> OptionalConfig<T> withoutDefault() {
+    return new OptionalConfig<>(null);
+  }
+
+  private OptionalConfig(@Nullable T defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+
+  boolean hasDefault() {
+    return defaultValue != null;
+  }
+
+  boolean isSet() {
+    return value != null;
+  }
+
+  void set(T value) {
+    this.value = Objects.requireNonNull(value);
+  }
+
+  T get() {
+    if (!isSet() && !hasDefault()) {
+      throw new NoSuchElementException(
+          "A value has not been set, and no default value was defined.");
+    }
+    return isSet() ? value : defaultValue;
+  }
+}

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderTest.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka;
+
+import static org.apache.flink.statefun.sdk.kafka.testutils.Matchers.hasProperty;
+import static org.apache.flink.statefun.sdk.kafka.testutils.Matchers.isMapOfSize;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Test;
+
+public class KafkaIngressBuilderTest {
+
+  private static final IngressIdentifier<String> DUMMY_ID =
+      new IngressIdentifier<>(String.class, "ns", "name");
+
+  @Test
+  public void idIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.id(), is(DUMMY_ID));
+  }
+
+  @Test
+  public void ingressTypeIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.type(), is(Constants.KAFKA_INGRESS_TYPE));
+  }
+
+  @Test
+  public void topicsIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.topics(), contains("topic"));
+  }
+
+  @Test
+  public void deserializerIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.deserializer(), instanceOf(NoOpDeserializer.class));
+  }
+
+  @Test
+  public void startupPositionIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.startupPosition(), is(KafkaIngressStartupPosition.fromLatest()));
+  }
+
+  @Test
+  public void propertiesIsCorrect() {
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(
+        spec.properties(),
+        allOf(
+            isMapOfSize(3),
+            hasProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:8082"),
+            hasProperty(ConsumerConfig.GROUP_ID_CONFIG, "test-group"),
+            hasProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")));
+  }
+
+  @Test
+  public void namedMethodConfigValuesOverwriteProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "should-be-overwritten");
+
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class)
+            .withProperties(properties);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(
+        spec.properties(), hasProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:8082"));
+  }
+
+  @Test
+  public void defaultNamedMethodConfigValuesShouldNotOverwriteProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    KafkaIngressBuilder<String> builder =
+        KafkaIngressBuilder.forIdentifier(DUMMY_ID)
+            .withKafkaAddress("localhost:8082")
+            .withTopic("topic")
+            .withConsumerGroupId("test-group")
+            .withDeserializer(NoOpDeserializer.class)
+            .withProperties(properties);
+
+    KafkaIngressSpec<String> spec = builder.build();
+
+    assertThat(spec.properties(), hasProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+  }
+
+  private static class NoOpDeserializer implements KafkaIngressDeserializer<String> {
+    @Override
+    public String deserialize(ConsumerRecord<byte[], byte[]> input) {
+      return null;
+    }
+  }
+}

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
@@ -28,8 +28,6 @@ public final class Matchers {
 
   private Matchers() {}
 
-  private Matchers() {}
-
   public static <K, V> Matcher<Map<K, V>> isMapOfSize(int size) {
     return new TypeSafeMatcher<Map<K, V>>() {
       @Override

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.kafka.testutils;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class Matchers {
+
+  private Matchers() {}
+
+  public static <K, V> Matcher<Map<K, V>> isMapOfSize(int size) {
+    return new TypeSafeMatcher<Map<K, V>>() {
+      @Override
+      protected boolean matchesSafely(Map<K, V> map) {
+        return map.size() == size;
+      }
+
+      @Override
+      public void describeTo(Description description) {}
+    };
+  }
+
+  public static Matcher<Properties> hasProperty(String key, String value) {
+    return new TypeSafeMatcher<Properties>() {
+      @Override
+      protected boolean matchesSafely(Properties properties) {
+        return Objects.equals(properties.getProperty(key), value);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("<" + key + "=" + value + ">");
+      }
+    };
+  }
+}

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/testutils/Matchers.java
@@ -24,7 +24,9 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-public class Matchers {
+public final class Matchers {
+
+  private Matchers() {}
 
   private Matchers() {}
 


### PR DESCRIPTION
This PR revisits how we resolve configs for the `KafkaIngressBuilder`, given that we have:
- Named configuration methods for important settings
- Some of which have default values, some don't
- Some eventually resolve as a Kafka client property, some are not
- At the same time, also accept a `Properties` which may also explicitly define values for the above.

The end result of the changes in this PR is as follows:
- Configs passed via named methods should always overwrite the value set via passed in `Properties`
- Any default values for named configuration methods should be defined in the builder
- If no config was passed via its named method, then we use the default value (if any) to overwrite the properties IFF the user also did not provide a value for it there.

---

The individual commits and their messages / descriptions should be sufficient in explaining what was changed to achieve this.

---

New tests in `KafkaIngressBuilderTest` was added to verify the changes.
Please also see there to get an overview of the expected behaviour.