### PR TITLE
[FLINK-15842] Upgrade Spotbugs to version 3.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spotbugs.version>3.1.1</spotbugs.version>
+        <spotbugs.version>3.1.12</spotbugs.version>
         <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
         <auto-service.version>1.0-rc6</auto-service.version>
         <protobuf.version>3.7.1</protobuf.version>


### PR DESCRIPTION
Spotbugs needs to be upgraded because the old version we use uses an outdated Dom4J version that performs illegal reflective access operations. This prevents the project to be built using JDK 11.

Can be verified by building the project with JDK 11.