### PR TITLE
[FLINK-15851] [build] Add azure-pipelines.yml for Azure Pipelines CI setup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+trigger:
+  branches:
+    include:
+    - '*'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+resources:
+  containers:
+  - container: jdk8
+    image: maven:3.6.3-jdk-8
+  - container: jdk11
+    image: maven:3.6.3-jdk-11
+
+jobs:
+- job: BuildJDK8
+  container: jdk8
+  steps:
+  - task: Maven@3
+    inputs:
+      mavenPomFile: 'pom.xml'
+      javaHomeOption: 'path'
+      jdkDirectory: '/usr/local/openjdk-8'
+      jdkVersionOption: '1.8'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: true
+      testResultsFiles: '**/surefire-reports/TEST-*.xml'
+      goals: 'clean install'
+
+- job: BuildJDK11
+  container: jdk11
+  steps:
+  - task: Maven@3
+    inputs:
+      mavenPomFile: 'pom.xml'
+      javaHomeOption: 'path'
+      jdkDirectory: '/usr/local/openjdk-11'
+      jdkVersionOption: '1.11'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: true
+      testResultsFiles: '**/surefire-reports/TEST-*.xml'
+      goals: 'clean install'

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spotbugs.version>3.1.1</spotbugs.version>
+        <spotbugs.version>3.1.12</spotbugs.version>
         <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
         <auto-service.version>1.0-rc6</auto-service.version>
         <protobuf.version>3.7.1</protobuf.version>


### PR DESCRIPTION
This PR is based on #8, because it fixes the build for JDK 11. Only the second commit is relevant.

This is a first step in setting up a CI build pipeline for Stateful Functions. For an overview of all steps, please see description in the JIRA ticket.

This Azure Pipelines YAML configuration runs two jobs, one that builds with JDK 8, and the another with JDK 11.
Setting this up to also cover end-to-end tests is a follow-up task, tracked by umbrella ticket FLINK-15850.

---

Verifying that this works:
Please see an example triggered build summary / output logs at https://dev.azure.com/tzulitai/tzulitai.flink.statefun/_build/results?buildId=25

Note that this also verifies the JDK 11 build fix in #8.