### PR TITLE
[FLINK-15851] [build] Add .travis.yml for Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ jobs:
       jdk: "openjdk11"
       script: mvn clean install
       name: build - jdk11
+
+# Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ dist: xenial
 
 language: java
 
-jdk:
- - openjdk8
- - openjdk11
+jobs:
+  include:
+    - if: type in (pull_request, push)
+      jdk: "openjdk8"
+      script: mvn clean install
+      name: build - jdk8
+    - if: type in (pull_request, push)
+      jdk: "openjdk11"
+      script: mvn clean install
+      name: build - jdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dist: xenial
+
+language: java
+
+jdk:
+ - openjdk8
+ - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spotbugs.version>3.1.1</spotbugs.version>
+        <spotbugs.version>3.1.12</spotbugs.version>
         <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
         <auto-service.version>1.0-rc6</auto-service.version>
         <protobuf.version>3.7.1</protobuf.version>


### PR DESCRIPTION
Alternative approach to #9 where Stateful Functions continue to use Travis for the time being.

This could make more sense considering:
- The Azure Pipelines setup with ASF is currently a bit problematic
- Travis is pretty sufficient for the current needs of the Stateful Functions project

---

Example build summary can be found here:
https://travis-ci.org/tzulitai/flink-statefun/builds/645335960