### PR TITLE
[FLINK-15899] [build] Inherit from Apache Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,34 @@ under the License.
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
+    </parent>
+
     <artifactId>statefun-parent</artifactId>
     <groupId>org.apache.flink</groupId>
     <name>statefun-parent</name>
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+    <url>http://flink.apache.org</url>
+    <inceptionYear>2014</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <url>https://github.com/apache/flink-statefun</url>
+        <connection>git@github.com:apache/flink-statefun.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-statefun.git</developerConnection>
+    </scm>
 
     <modules>
         <module>statefun-sdk</module>

--- a/statefun-examples/statefun-greeter-example/pom.xml
+++ b/statefun-examples/statefun-greeter-example/pom.xml
@@ -53,6 +53,13 @@ under the License.
                 <artifactId>protoc-jar-maven-plugin</artifactId>
                 <version>${protoc-jar-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.apache.flink.statefun.examples.greeter.generated</excludePackageNames>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     

--- a/statefun-examples/statefun-greeter-example/src/main/java/org/apache/flink/statefun/examples/greeter/GreetingModule.java
+++ b/statefun-examples/statefun-greeter-example/src/main/java/org/apache/flink/statefun/examples/greeter/GreetingModule.java
@@ -25,7 +25,7 @@ import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
  * The top level entry point for this application.
  *
  * <p>On deployment, the address of the Kafka brokers can be configured by passing the flag
- * `--kafka-address <address>`. If no flag is passed, then the default address will be used.
+ * `--kafka-address &lt;address&gt;`. If no flag is passed, then the default address will be used.
  */
 @AutoService(StatefulFunctionModule.class)
 public final class GreetingModule implements StatefulFunctionModule {

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/BootstrapDataRouterProvider.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/BootstrapDataRouterProvider.java
@@ -29,7 +29,11 @@ import org.apache.flink.statefun.sdk.io.Router;
  */
 public interface BootstrapDataRouterProvider<T> extends Serializable {
 
-  /** Creates a {@link Router} instance. */
+  /**
+   * Creates a {@link Router} instance.
+   *
+   * @return a router for bootstrap data
+   */
   @Nonnull
   Router<T> provide();
 }

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StateBootstrapFunction.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StateBootstrapFunction.java
@@ -35,10 +35,10 @@ import org.apache.flink.statefun.sdk.StatefulFunction;
  * <pre>{@code
  * public class MyStateBootstrapFunction implements StateBootstrapFunction {
  *
- *     @Persisted
+ *     {@code @Persisted}
  *     private PersistedValue<MyState> state = PersistedValue.of("my-state", MyState.class);
  *
- *     @Override
+ *     {@code @Override}
  *     public void bootstrap(Context context, Object input) {
  *         state.set(extractStateFromInput(input));
  *     }

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreator.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreator.java
@@ -86,6 +86,7 @@ public class StatefulFunctionsSavepointCreator {
    * is configured by the Stateful Functions application to be restored using the generated
    * savepoint.
    *
+   * @return the savepoint creator, with state multiplexing disabled
    * @see StatefulFunctionsJobConstants#MULTIPLEX_FLINK_STATE
    */
   public StatefulFunctionsSavepointCreator disableMultiplexState() {
@@ -100,6 +101,8 @@ public class StatefulFunctionsSavepointCreator {
    * <p>This affects the format of the generated savepoint, and should therefore be the same as what
    * is configured by the Stateful Functions application to be restored using the generated
    * savepoint.
+   *
+   * @return the savepoint creator, configured to use the {@link FsStateBackend}.
    */
   public StatefulFunctionsSavepointCreator withFsStateBackend() {
     this.stateBackend = new FsStateBackend("file:///tmp/ignored");
@@ -119,6 +122,7 @@ public class StatefulFunctionsSavepointCreator {
    * @param routerProvider provider of a {@link Router} that addresses each element in the bootstrap
    *     dataset to {@link StateBootstrapFunction} instances.
    * @param <IN> data type of the input bootstrap dataset
+   * @return the savepoint creator, configured to use the given bootstrap data
    */
   public <IN> StatefulFunctionsSavepointCreator withBootstrapData(
       DataSet<IN> bootstrapDataset, BootstrapDataRouterProvider<IN> routerProvider) {
@@ -131,6 +135,8 @@ public class StatefulFunctionsSavepointCreator {
    *
    * @param functionType the type of function that is being bootstrapped.
    * @param bootstrapFunctionProvider the bootstrap function provider to register.
+   * @return the savepoint creator, configured to use the given {@link
+   *     StateBootstrapFunctionProvider}.
    */
   public StatefulFunctionsSavepointCreator withStateBootstrapFunctionProvider(
       FunctionType functionType, StateBootstrapFunctionProvider bootstrapFunctionProvider) {

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistry.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistry.java
@@ -74,7 +74,11 @@ public final class StateBootstrapFunctionRegistry implements Serializable {
             functionType));
   }
 
-  /** Returns number of registrations. */
+  /**
+   * Returns number of registrations.
+   *
+   * @return number of registrations.
+   */
   public int numRegistrations() {
     return stateBootstrapFunctionProviders.size();
   }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/Context.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/Context.java
@@ -67,7 +67,8 @@ public interface Context {
    * Invokes another function with an input, identified by the target function's {@link Address},
    * after a given delay.
    *
-   * @param delay the amount of delay before invoking the target function. Value needs to be >= 0.
+   * @param delay the amount of delay before invoking the target function. Value needs to be &gt;=
+   *     0.
    * @param to the target function's address.
    * @param message the input to provide for the delayed invocation.
    */
@@ -89,7 +90,8 @@ public interface Context {
    * Invokes another function with an input, identified by the target function's {@link
    * FunctionType} and unique id.
    *
-   * @param delay the amount of delay before invoking the target function. Value needs to be >= 0.
+   * @param delay the amount of delay before invoking the target function. Value needs to be &gt;=
+   *     0.
    * @param functionType the target function's type.
    * @param id the target function's id within its type.
    * @param message the input to provide for the delayed invocation.

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/StatefulFunction.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/StatefulFunction.java
@@ -54,10 +54,10 @@ import org.apache.flink.statefun.sdk.state.PersistedValue;
  * <pre>{@code
  * public class MyFunction implements StatefulFunction {
  *
- *     @Persisted
+ *     {@code @Persisted}
  *     PersistedValue<Integer> intState = PersistedValue.of("state-name", Integer.class);
  *
- *     @Override
+ *     {@code @Override}
  *     public void invoke(Context context, Object input) {
  *         Integer stateValue = intState.get();
  *         //...

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/match/MatchBinder.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/match/MatchBinder.java
@@ -65,6 +65,7 @@ public final class MatchBinder {
    * @param type the expected input type.
    * @param action the action to take if this pattern matches.
    * @param <T> the expected input type.
+   * @return the binder, with predicate bound
    */
   @SuppressWarnings("unchecked")
   public <T> MatchBinder predicate(Class<T> type, BiConsumer<Context, T> action) {
@@ -91,6 +92,7 @@ public final class MatchBinder {
    * @param predicate a predicate on the input object state to match on.
    * @param action the action to take if this patten matches.
    * @param <T> the expected input type.
+   * @return the binder, with predicate bound
    */
   @SuppressWarnings("unchecked")
   public <T> MatchBinder predicate(
@@ -109,6 +111,7 @@ public final class MatchBinder {
    * thrown for inputs that fail to match.
    *
    * @param action the default action
+   * @return the binder, with default action bound
    */
   public MatchBinder otherwise(BiConsumer<Context, Object> action) {
     if (customDefaultAction) {

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/spi/StatefulFunctionModule.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/spi/StatefulFunctionModule.java
@@ -51,8 +51,8 @@ import org.apache.flink.statefun.sdk.io.Router;
  * {@code org.apache.flink.statefun.sdk.spi.StatefulFunctionModule}, i.e. the fully qualified name
  * of the {@link StatefulFunctionModule} class. Each line in the file should be the fully qualified
  * class name of a module in that JAR that you want to register for the Stateful Functions
- * application. The configuration file may also be automatically generated using Google's
- * <ahref="https://github.com/google/auto/tree/master/service">AutoService</a> tool.
+ * application. The configuration file may also be automatically generated using Google's <a
+ * href="https://github.com/google/auto/tree/master/service">AutoService</a> tool.
  *
  * <p>Finally, to allow the Stateful Functions runtime to discover the registered modules, the JAR
  * files containing the modules and provider configuration files should be added to a


### PR DESCRIPTION
This is a first step towards making Stateful Functions release-ready.

See details about what settings the Apache Parent POM covers here: https://maven.apache.org/pom/asf/index.html.

As an end result of this change, we should be able to perform `mvn clean install -Papache-release` without issues.