### PR TITLE
[FLINK-15931] [release] Add tool scripts for releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ target
 _build
 /dist/html/
 build-linter
+
+# temporary release files
+release/

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -36,6 +36,7 @@ fi
 set -o errexit
 set -o nounset
 
+CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
@@ -56,5 +57,6 @@ cd ${PROJECT_ROOT}
 git checkout -b ${TARGET_BRANCH}
 
 RELEASE_COMMIT_HASH=`git rev-parse HEAD`
-
 echo "Done. Created a new release branch with commit hash ${RELEASE_COMMIT_HASH}."
+
+cd ${CURR_DIR}

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -39,6 +39,12 @@ set -o nounset
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
 ###########################
 
 TARGET_BRANCH=release-${RELEASE_VERSION}
@@ -50,10 +56,5 @@ cd ${PROJECT_ROOT}
 git checkout -b ${TARGET_BRANCH}
 
 RELEASE_COMMIT_HASH=`git rev-parse HEAD`
-
-TAG_COMMIT_MSG="Apache Flink Stateful Functions, release ${RELEASE_VERSION}"
-if [ "${RELEASE_CANDIDATE}" != "none" ]; then
-  TAG_COMMIT_MSG="${TAG_COMMIT_MSG} candidate #${RELEASE_CANDIDATE}"
-fi
 
 echo "Done. Created a new release branch with commit hash ${RELEASE_COMMIT_HASH}."

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+RELEASE_CANDIDATE=${RELEASE_CANDIDATE:-none}
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+	echo "RELEASE_VERSION was not set"
+	exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+###########################
+
+TARGET_BRANCH=release-${RELEASE_VERSION}
+if [ "${RELEASE_CANDIDATE}" != "none" ]; then
+  TARGET_BRANCH=${TARGET_BRANCH}-rc${RELEASE_CANDIDATE}
+fi
+
+cd ${PROJECT_ROOT}
+git checkout -b ${TARGET_BRANCH}
+
+RELEASE_COMMIT_HASH=`git rev-parse HEAD`
+
+TAG_COMMIT_MSG="Apache Flink Stateful Functions, release ${RELEASE_VERSION}"
+if [ "${RELEASE_CANDIDATE}" != "none" ]; then
+  TAG_COMMIT_MSG="${TAG_COMMIT_MSG} candidate #${RELEASE_CANDIDATE}"
+fi
+
+echo "Done. Created a new release branch with commit hash ${RELEASE_COMMIT_HASH}."

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -1,0 +1,75 @@
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+	echo "RELEASE_VERSION is unset"
+	exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="$( cd "$( dirname "${BASE_DIR}/../../../" )" >/dev/null && pwd )"
+
+if [ "$(uname)" == "Darwin" ]; then
+    SHASUM="shasum -a 512"
+else
+    SHASUM="sha512sum"
+fi
+
+###########################
+
+RELEASE_DIR=${PROJECT_ROOT}/release
+CLONE_DIR=${RELEASE_DIR}/flink-statefun-tmp-clone
+
+rm -rf ${RELEASE_DIR}
+mkdir ${RELEASE_DIR}
+
+# delete the temporary release directory on error
+trap 'rm -rf ${RELEASE_DIR}' ERR
+
+echo "Creating source package"
+
+# create a temporary git clone to ensure that we have a pristine source release
+git clone ${PROJECT_ROOT} ${CLONE_DIR}
+
+cd ${CLONE_DIR}
+rsync -a \
+  --exclude ".git" --exclude ".gitignore" \
+  --exclude "target" \
+  --exclude ".idea" --exclude "*.iml" \
+  . flink-statefun-${RELEASE_VERSION}
+
+tar czf ${RELEASE_DIR}/flink-statefun-${RELEASE_VERSION}-src.tgz flink-statefun-${RELEASE_VERSION}
+gpg --armor --detach-sig ${RELEASE_DIR}/flink-statefun-${RELEASE_VERSION}-src.tgz
+cd ${RELEASE_DIR}
+${SHASUM} flink-statefun-${RELEASE_VERSION}-src.tgz > flink-statefun-${RELEASE_VERSION}-src.tgz.sha512
+
+rm -rf ${CLONE_DIR}
+cd ${BASE_DIR}
+
+echo "Done. Source release package and signatures created under ${RELEASE_DIR}/."

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -32,6 +32,7 @@ fi
 set -o errexit
 set -o nounset
 
+CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="$( cd "$( dirname "${BASE_DIR}/../../../" )" >/dev/null && pwd )"
 
@@ -76,6 +77,7 @@ cd ${RELEASE_DIR}
 ${SHASUM} flink-statefun-${RELEASE_VERSION}-src.tgz > flink-statefun-${RELEASE_VERSION}-src.tgz.sha512
 
 rm -rf ${CLONE_DIR}
-cd ${BASE_DIR}
 
 echo "Done. Source release package and signatures created under ${RELEASE_DIR}/."
+
+cd ${CURR_DIR}

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -35,6 +35,12 @@ set -o nounset
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="$( cd "$( dirname "${BASE_DIR}/../../../" )" >/dev/null && pwd )"
 
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
 if [ "$(uname)" == "Darwin" ]; then
     SHASUM="shasum -a 512"
 else

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -29,6 +29,12 @@ set -o nounset
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
 ###########################
 
 cd ${PROJECT_ROOT}

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+###########################
+
+cd ${PROJECT_ROOT}
+
+echo "Deploying to repository.apache.org"
+$MVN clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -26,6 +26,7 @@ MVN=${MVN:-mvn}
 set -o errexit
 set -o nounset
 
+CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
@@ -40,4 +41,6 @@ fi
 cd ${PROJECT_ROOT}
 
 echo "Deploying to repository.apache.org"
-$MVN clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10
+${MVN} clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10
+
+cd ${CURR_DIR}

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Required variables
+##
+OLD_VERSION=${OLD_VERSION}
+NEW_VERSION=${NEW_VERSION}
+
+if [ -z "${OLD_VERSION}" ]; then
+    echo "OLD_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+###########################
+
+cd ${PROJECT_ROOT}
+
+#change version in all pom files
+find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>(.*)'${OLD_VERSION}'(.*)</version>#<version>${1}'${NEW_VERSION}'${2}</version>#' {} \;
+
+git commit -am "[release] Update version to ${NEW_VERSION}"
+
+NEW_VERSION_COMMIT_HASH=`git rev-parse HEAD`
+
+echo "Done. Created a new commit for the new version ${NEW_VERSION}, with hash ${NEW_VERSION_COMMIT_HASH}"
+echo "If this is a new version to be released (or a candidate to be voted on), don't forget to create a signed release tag on GitHub and push the changes."
+echo "e.g., git tag -s -m \"Apache Flink Stateful Functions, release 1.1 candidate #2\" release-1.1-rc2 ${NEW_VERSION_COMMIT_HASH}"

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -40,6 +40,12 @@ set -o nounset
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
 ###########################
 
 cd ${PROJECT_ROOT}

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -18,15 +18,14 @@
 #
 
 ##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
 ## Required variables
 ##
-OLD_VERSION=${OLD_VERSION}
 NEW_VERSION=${NEW_VERSION}
-
-if [ -z "${OLD_VERSION}" ]; then
-    echo "OLD_VERSION was not set."
-    exit 1
-fi
 
 if [ -z "${NEW_VERSION}" ]; then
     echo "NEW_VERSION was not set."
@@ -37,6 +36,7 @@ fi
 set -o errexit
 set -o nounset
 
+CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
@@ -51,7 +51,7 @@ fi
 cd ${PROJECT_ROOT}
 
 #change version in all pom files
-find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>(.*)'${OLD_VERSION}'(.*)</version>#<version>${1}'${NEW_VERSION}'${2}</version>#' {} \;
+${MVN} versions:set -DgenerateBackupPoms=false -DnewVersion=${NEW_VERSION}
 
 git commit -am "[release] Update version to ${NEW_VERSION}"
 
@@ -60,3 +60,5 @@ NEW_VERSION_COMMIT_HASH=`git rev-parse HEAD`
 echo "Done. Created a new commit for the new version ${NEW_VERSION}, with hash ${NEW_VERSION_COMMIT_HASH}"
 echo "If this is a new version to be released (or a candidate to be voted on), don't forget to create a signed release tag on GitHub and push the changes."
 echo "e.g., git tag -s -m \"Apache Flink Stateful Functions, release 1.1 candidate #2\" release-1.1-rc2 ${NEW_VERSION_COMMIT_HASH}"
+
+cd ${CURR_DIR}


### PR DESCRIPTION
This adds utility scripts for the following functionality:
* Create a new release branch
* Update POM versions in current branch, and creates a commit
* Create a source release package
* Deploying Maven artifacts to Apache staging area

This scripts are adopted from `apache/flink` with modifications to suit Stateful Functions.

---

Example usage:

* Create a new version branch:
```
$flink-statefun: RELEASE_VERSION=1.2.3 RELEASE_CANDIDATE=2 ./tools/releasing/create_release_branch.sh
```
This checkouts a new branch (with no additional changes) named `release-1.2.3`

* Update POM versions in current branch:
```
$flink-statefun: OLD_VERSION=1.2-SNAPSHOT NEW_VERSION=1.2.3 ./tools/releasing/update_branch_version.sh
```
This updates all POM files, and creates a commit for the changes.

* Create a source release package:
```
$flink-statefun: RELEASE_VERSION=1.2.3 ./tools/releasing/create_source_release.sh
```
This creates a `release` directory in the project root, containing the source tarball `flink-statefun-1.2.3-src.tgz` and signatures.

* Deploy Maven artifacts to Apache staging area:
```
$flink-statefun: ./tools/releasing/deploy_staging_jars.sh
```
This builds the project and deploys artifacts to be staged at [repository.apache.org](repository.apache.org).