### PR TITLE
[FLINK-15952] Replace the usage of a raw byte[] for keys in MultiplexedState

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedMapStateAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedMapStateAccessor.java
@@ -23,16 +23,17 @@ import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.statefun.flink.core.generated.MultiplexedStateKey;
 import org.apache.flink.statefun.sdk.state.Accessor;
 
 final class MultiplexedMapStateAccessor<T> implements Accessor<T> {
-  private final MapState<byte[], byte[]> mapStateHandle;
-  private final byte[] accessorMapKey;
+  private final MapState<MultiplexedStateKey, byte[]> mapStateHandle;
+  private final MultiplexedStateKey accessorMapKey;
   private final RawSerializer<T> serializer;
 
   MultiplexedMapStateAccessor(
-      MapState<byte[], byte[]> handle,
-      byte[] accessorMapKey,
+      MapState<MultiplexedStateKey, byte[]> handle,
+      MultiplexedStateKey accessorMapKey,
       TypeSerializer<T> subValueSerializer) {
     this.mapStateHandle = Objects.requireNonNull(handle);
     this.accessorMapKey = Objects.requireNonNull(accessorMapKey);

--- a/statefun-flink/statefun-flink-core/src/main/protobuf/stateful-functions.proto
+++ b/statefun-flink/statefun-flink-core/src/main/protobuf/stateful-functions.proto
@@ -46,3 +46,10 @@ message Envelope {
         Payload payload = 3;
     }
 }
+
+message MultiplexedStateKey {
+    string function_namespace = 1;
+    string function_type = 2;
+    string state_name = 3;
+    repeated bytes user_keys = 4;
+}


### PR DESCRIPTION
This PR address the problem, that when using Flink's heap state backend keys to a `MapState` can not be of a primitive array type.
This PR introduces a new Protobuf message to be used as a key in a multiplexed state context.
```
message MultiplexedStateKey {
    string function_namespace = 1;
    string function_type = 2;
    string state_name = 3;
    repeated bytes user_keys = 4;
}
```
