### PR TITLE
[FLINK-15945] Remove MULTIPLEX_FLINK_STATE config

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJobConstants.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJobConstants.java
@@ -44,13 +44,6 @@ public final class StatefulFunctionsJobConstants {
           .withDescription(
               "Flink checkpoint interval in milliseconds, set to -1 to disable checkpointing");
 
-  public static final ConfigOption<Boolean> MULTIPLEX_FLINK_STATE =
-      ConfigOptions.key("statefun.state.multiplex-flink-state")
-          .defaultValue(true)
-          .withDescription(
-              "Use a single MapState to multiplex different function types and persisted values,"
-                  + "instead of using a ValueState for each <FunctionType, PersistedValue> combination");
-
   public static final ConfigOption<String> USER_MESSAGE_SERIALIZER =
       ConfigOptions.key("statefun.message.serializer")
           .defaultValue(MessageFactoryType.WITH_PROTOBUF_PAYLOADS.name())

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -104,7 +104,6 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
     //
     this.reductions =
         Reductions.create(
-            configuration,
             statefulFunctionsUniverse,
             getRuntimeContext(),
             getKeyedStateBackend(),

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -151,6 +151,6 @@ final class Reductions {
     // TODO ideally, we should revisit how configuration is being passed to the
     // TODO operators to be available at runtime
     return backendClassName.equals(
-            "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend");
+        "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend");
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -150,13 +150,7 @@ final class Reductions {
     // TODO to avoid additional dependencies on the Flink state backends
     // TODO ideally, we should revisit how configuration is being passed to the
     // TODO operators to be available at runtime
-    if (backendClassName.equals("org.apache.flink.runtime.state.heap.HeapKeyedStateBackend")) {
-      return false;
-    }
-    if (backendClassName.equals(
-        "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend")) {
-      return true;
-    }
-    throw new IllegalStateException("Unrecognized state backend type: " + backendClassName);
+    return backendClassName.equals(
+            "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend");
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.MapState;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalListState;
@@ -53,7 +52,6 @@ final class Reductions {
   }
 
   static Reductions create(
-      Configuration configuration,
       StatefulFunctionsUniverse statefulFunctionsUniverse,
       RuntimeContext context,
       KeyedStateBackend<Object> keyedStateBackend,

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalListState;
-import org.apache.flink.statefun.flink.core.StatefulFunctionsJobConstants;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Lazy;
@@ -79,7 +78,7 @@ final class Reductions {
     container.add("keyed-state-backend", KeyedStateBackend.class, keyedStateBackend);
     container.add(new DynamicallyRegisteredTypes(statefulFunctionsUniverse.types()));
 
-    if (configuration.getBoolean(StatefulFunctionsJobConstants.MULTIPLEX_FLINK_STATE)) {
+    if (useMultiplexedState(keyedStateBackend)) {
       container.add("state", State.class, MultiplexedState.class);
     } else {
       container.add("state", State.class, FlinkState.class);
@@ -144,5 +143,22 @@ final class Reductions {
     while (localFunctionGroup.processNextEnvelope()) {
       // TODO: consider preemption if too many local messages.
     }
+  }
+
+  private static boolean useMultiplexedState(KeyedStateBackend<?> keyedStateBackend) {
+    final String backendClassName = keyedStateBackend.getClass().getName();
+
+    // TODO this is fragile and error-prone to classname changes, but we're doing this
+    // TODO to avoid additional dependencies on the Flink state backends
+    // TODO ideally, we should revisit how configuration is being passed to the
+    // TODO operators to be available at runtime
+    if (backendClassName.equals("org.apache.flink.runtime.state.heap.HeapKeyedStateBackend")) {
+      return false;
+    }
+    if (backendClassName.equals(
+        "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend")) {
+      return true;
+    }
+    throw new IllegalStateException("Unrecognized state backend type: " + backendClassName);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -53,7 +53,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -87,12 +86,8 @@ public class ReductionsTest {
 
   @Test
   public void testFactory() {
-
-    Configuration configuration = new Configuration();
-
     Reductions reductions =
         Reductions.create(
-            configuration,
             new StatefulFunctionsUniverse(MessageFactoryType.WITH_KRYO_PAYLOADS),
             new FakeRuntimeContext(),
             new FakeKeyedStateBackend(),

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreator.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreator.java
@@ -160,12 +160,6 @@ public class StatefulFunctionsSavepointCreator {
   }
 
   private boolean disableMultiplexState() {
-    if (stateBackend instanceof FsStateBackend) {
-      return true;
-    }
-    if (stateBackend instanceof RocksDBStateBackend) {
-      return false;
-    }
-    throw new IllegalStateException("Unrecognized state backend type: " + stateBackend.getClass());
+    return !(stateBackend instanceof RocksDBStateBackend);
   }
 }


### PR DESCRIPTION
Prior to this PR, Stateful Functions allow enabling or disabling multiplex state, regardless of the state backend being used. This actually does not make sense, considering that:
* If the heap backend is used, there is no reason to multiplex state. Also taking into account that there are problems that exist for multiplexing state such as lack of support for state schema evolution.
* If RocksDB backend is used, it is highly encouraged to multiplex state, anyways.

Therefore, this PR removes the `MULTIPLEX_FLINK_STATE` configuration and simply piggybacks the behaviour of multiplexing state to the state backend being used, i.e. multiplex only when RocksDB state backend is used.