### PR TITLE
[FLINK-15954] Add a PersistedTable to the SDK

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCache.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCache.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.cache;
+
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public final class SingleThreadedLruCache<K, V> {
+  private final Cache<K, V> cache;
+
+  public SingleThreadedLruCache(int maxCapacity) {
+    this.cache = new Cache<>(maxCapacity, maxCapacity);
+  }
+
+  public void put(K key, V value) {
+    cache.put(key, value);
+  }
+
+  @Nullable
+  public V get(K key) {
+    return cache.get(key);
+  }
+
+  public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+    return cache.computeIfAbsent(key, mappingFunction);
+  }
+
+  private static final class Cache<K, V> extends LinkedHashMap<K, V> {
+
+    private static final long serialVersionUID = 1;
+
+    private final int maxCapacity;
+
+    private Cache(int initialCapacity, int maxCapacity) {
+      super(initialCapacity, 0.75f, true);
+      this.maxCapacity = maxCapacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Entry<K, V> eldest) {
+      return size() > maxCapacity;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCache.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCache.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2019 Ververica GmbH.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.statefun.flink.core.cache;
 
 import java.util.LinkedHashMap;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/BoundState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/BoundState.java
@@ -19,18 +19,54 @@ package org.apache.flink.statefun.flink.core.state;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
 public class BoundState {
 
-  private final List<PersistedValue<Object>> persistedValues;
+  public static Builder builder() {
+    return new Builder();
+  }
 
-  BoundState(List<PersistedValue<Object>> persistedValues) {
-    this.persistedValues = new ArrayList<>(persistedValues);
+  private final List<PersistedValue<?>> persistedValues;
+  private final List<PersistedTable<?, ?>> persistedTables;
+
+  private BoundState(
+      List<PersistedValue<?>> persistedValues, List<PersistedTable<?, ?>> persistedTables) {
+    this.persistedValues = Objects.requireNonNull(persistedValues);
+    this.persistedTables = Objects.requireNonNull(persistedTables);
   }
 
   @SuppressWarnings("unused")
-  public List<PersistedValue<Object>> persistedValues() {
+  public List<PersistedValue<?>> persistedValues() {
     return persistedValues;
+  }
+
+  @SuppressWarnings("unused")
+  public List<PersistedTable<?, ?>> getPersistedTables() {
+    return persistedTables;
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public static final class Builder {
+    private List<PersistedValue<?>> persistedValues = new ArrayList<>();
+    private List<PersistedTable<?, ?>> persistedTables = new ArrayList<>();
+
+    private Builder() {}
+
+    public Builder withPersistedValue(PersistedValue<?> persistedValue) {
+      this.persistedValues.add(persistedValue);
+      return this;
+    }
+
+    public Builder withPersistedTable(PersistedTable<?, ?> persistedTable) {
+      this.persistedTables.add(persistedTable);
+      return this;
+    }
+
+    public BoundState build() {
+      return new BoundState(persistedValues, persistedTables);
+    }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
@@ -19,6 +19,8 @@ package org.apache.flink.statefun.flink.core.state;
 
 import java.util.Objects;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -30,7 +32,9 @@ import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.TableAccessor;
 
 public final class FlinkState implements State {
 
@@ -57,6 +61,18 @@ public final class FlinkState implements State {
     ValueStateDescriptor<T> descriptor = new ValueStateDescriptor<>(stateName, typeInfo);
     ValueState<T> handle = runtimeContext.getState(descriptor);
     return new FlinkValueAccessor<>(handle);
+  }
+
+  @Override
+  public <K, V> TableAccessor<K, V> createFlinkStateTableAccessor(
+      FunctionType functionType, PersistedTable<K, V> persistedTable) {
+    MapState<K, V> handle =
+        runtimeContext.getMapState(
+            new MapStateDescriptor<>(
+                flinkStateName(functionType, persistedTable.name()),
+                persistedTable.keyType(),
+                persistedTable.valueType()));
+    return new FlinkTableAccessor<>(handle);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.state;
+
+import java.util.Objects;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.statefun.sdk.state.TableAccessor;
+
+final class FlinkTableAccessor<K, V> implements TableAccessor<K, V> {
+
+  private final MapState<K, V> handle;
+
+  FlinkTableAccessor(MapState<K, V> handle) {
+    this.handle = Objects.requireNonNull(handle);
+  }
+
+  @Override
+  public void set(K key, V value) {
+    try {
+      handle.put(key, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public V get(K key) {
+    try {
+      return handle.get(key);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void remove(K key) {
+    try {
+      handle.remove(key);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedMapStateAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedMapStateAccessor.java
@@ -17,12 +17,9 @@
  */
 package org.apache.flink.statefun.flink.core.state;
 
-import java.io.IOException;
 import java.util.Objects;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataInputDeserializer;
-import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.statefun.flink.core.generated.MultiplexedStateKey;
 import org.apache.flink.statefun.sdk.state.Accessor;
 
@@ -73,31 +70,6 @@ final class MultiplexedMapStateAccessor<T> implements Accessor<T> {
       mapStateHandle.remove(accessorMapKey);
     } catch (Exception e) {
       throw new RuntimeException(e);
-    }
-  }
-
-  private static final class RawSerializer<T> {
-    private final TypeSerializer<T> delegate;
-    private final DataOutputSerializer output;
-    private final DataInputDeserializer input;
-
-    RawSerializer(TypeSerializer<T> delegate) {
-      this.delegate = Objects.requireNonNull(delegate);
-      this.output = new DataOutputSerializer(32);
-      this.input = new DataInputDeserializer();
-    }
-
-    byte[] serialize(T value) throws IOException {
-      output.clear();
-      delegate.serialize(value, output);
-      return output.getCopyOfBuffer(); // TODO: consider avoiding buffer copying
-    }
-
-    T deserialize(byte[] bytes) throws IOException {
-      input.setBuffer(bytes);
-      final T value = delegate.deserialize(input);
-      input.releaseArrays();
-      return value;
     }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedState.java
@@ -35,7 +35,9 @@ import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.TableAccessor;
 
 public final class MultiplexedState implements State {
 
@@ -63,6 +65,19 @@ public final class MultiplexedState implements State {
         multiplexedSubstateKey(functionType, persistedValue.name());
     final TypeSerializer<T> valueSerializer = multiplexedSubstateValueSerializer(persistedValue);
     return new MultiplexedMapStateAccessor<>(sharedMapStateHandle, uniqueSubKey, valueSerializer);
+  }
+
+  @Override
+  public <K, V> TableAccessor<K, V> createFlinkStateTableAccessor(
+      FunctionType functionType, PersistedTable<K, V> persistedTable) {
+    final MultiplexedStateKey uniqueSubKeyPrefix =
+        multiplexedSubstateKey(functionType, persistedTable.name());
+    final TypeSerializer<K> keySerializer =
+        types.registerType(persistedTable.keyType()).createSerializer(executionConfiguration);
+    final TypeSerializer<V> valueSerializer =
+        types.registerType(persistedTable.valueType()).createSerializer(executionConfiguration);
+    return new MultiplexedTableStateAccessor<>(
+        sharedMapStateHandle, uniqueSubKeyPrefix, keySerializer, valueSerializer);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.state;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.statefun.flink.core.cache.SingleThreadedLruCache;
+import org.apache.flink.statefun.flink.core.generated.MultiplexedStateKey;
+import org.apache.flink.statefun.sdk.state.TableAccessor;
+
+final class MultiplexedTableStateAccessor<K, V> implements TableAccessor<K, V> {
+  private final MapState<MultiplexedStateKey, byte[]> mapStateHandle;
+  private final MultiplexedStateKey accessorMapKeyPrefix;
+  private final TaggedRawSerializer<K> keySerializer;
+  private final TaggedRawSerializer<V> valueSerializer;
+
+  private final SingleThreadedLruCache<K, MultiplexedStateKey> commonKeysCache =
+      new SingleThreadedLruCache<>(128);
+
+  MultiplexedTableStateAccessor(
+      MapState<MultiplexedStateKey, byte[]> handle,
+      MultiplexedStateKey accessorMapKeyPrefix,
+      TypeSerializer<K> subKeySerializer,
+      TypeSerializer<V> subValueSerializer) {
+    this.mapStateHandle = Objects.requireNonNull(handle);
+    this.keySerializer = new TaggedRawSerializer<>(new byte[0], subKeySerializer);
+    this.valueSerializer = new TaggedRawSerializer<>(new byte[0], subValueSerializer);
+    this.accessorMapKeyPrefix = accessorMapKeyPrefix;
+  }
+
+  @Override
+  public void set(K key, V value) {
+    try {
+      MultiplexedStateKey keyBytes = stateKey(key);
+      if (value == null) {
+        mapStateHandle.remove(keyBytes);
+      } else {
+        byte[] bytes = valueSerializer.serialize(value);
+        mapStateHandle.put(keyBytes, bytes);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public V get(K userKey) {
+    try {
+      final MultiplexedStateKey stateKey = stateKey(userKey);
+      final byte[] bytes = mapStateHandle.get(stateKey);
+      if (bytes == null) {
+        return null;
+      }
+      return valueSerializer.deserialize(bytes);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void remove(K userKey) {
+    try {
+      mapStateHandle.remove(stateKey(userKey));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nonnull
+  private MultiplexedStateKey stateKey(final K userKey) {
+    Objects.requireNonNull(userKey, "Key can not be NULL");
+    @Nullable MultiplexedStateKey stateKey = commonKeysCache.get(userKey);
+    if (stateKey != null) {
+      return stateKey;
+    }
+    try {
+      commonKeysCache.put(userKey, stateKey = computeStateKeyFromUserKey(userKey));
+      return stateKey;
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to serialize the key " + userKey, e);
+    }
+  }
+
+  private MultiplexedStateKey computeStateKeyFromUserKey(K userKey) throws IOException {
+    byte[] userKeyBytes = keySerializer.serialize(userKey);
+    ByteString userKeyByteString = ByteString.copyFrom(userKeyBytes);
+    return accessorMapKeyPrefix.toBuilder().addUserKeys(userKeyByteString).build();
+  }
+
+  private static final class TaggedRawSerializer<T> {
+
+    private final TypeSerializer<T> delegate;
+    private final DataOutputSerializer output;
+    private final DataInputDeserializer input;
+    private final byte[] tag;
+
+    TaggedRawSerializer(byte[] tag, TypeSerializer<T> delegate) {
+      this.tag = Objects.requireNonNull(tag);
+      this.delegate = Objects.requireNonNull(delegate);
+      this.output = new DataOutputSerializer(32 + tag.length);
+      this.input = new DataInputDeserializer();
+    }
+
+    byte[] serialize(T value) throws IOException {
+      output.clear();
+      output.write(tag);
+      delegate.serialize(value, output);
+      return output.getCopyOfBuffer(); // TODO: consider avoiding buffer copying
+    }
+
+    T deserialize(byte[] bytes) throws IOException {
+      input.setBuffer(bytes);
+      input.skipBytesToRead(tag.length);
+      final T value = delegate.deserialize(input);
+      input.releaseArrays();
+      return value;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
@@ -29,13 +29,16 @@ import org.apache.flink.statefun.flink.core.generated.MultiplexedStateKey;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 
 final class MultiplexedTableStateAccessor<K, V> implements TableAccessor<K, V> {
+
+  private static final int COMMON_KEY_CACHE_SIZE = 128;
+
   private final MapState<MultiplexedStateKey, byte[]> mapStateHandle;
   private final MultiplexedStateKey accessorMapKeyPrefix;
   private final RawSerializer<K> keySerializer;
   private final RawSerializer<V> valueSerializer;
 
   private final SingleThreadedLruCache<K, MultiplexedStateKey> commonKeysCache =
-      new SingleThreadedLruCache<>(128);
+      new SingleThreadedLruCache<>(COMMON_KEY_CACHE_SIZE);
 
   MultiplexedTableStateAccessor(
       MapState<MultiplexedStateKey, byte[]> handle,

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/MultiplexedTableStateAccessor.java
@@ -48,7 +48,7 @@ final class MultiplexedTableStateAccessor<K, V> implements TableAccessor<K, V> {
     this.mapStateHandle = Objects.requireNonNull(handle);
     this.keySerializer = new RawSerializer<>(subKeySerializer);
     this.valueSerializer = new RawSerializer<>(subValueSerializer);
-    this.accessorMapKeyPrefix = accessorMapKeyPrefix;
+    this.accessorMapKeyPrefix = Objects.requireNonNull(accessorMapKeyPrefix);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -30,10 +30,10 @@ import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
-final class PersistedValues {
+final class PersistedStates {
 
   static List<?> findReflectively(@Nullable Object instance) {
-    PersistedValues visitor = new PersistedValues();
+    PersistedStates visitor = new PersistedStates();
     visitor.visit(instance);
     return visitor.getPersistedValues();
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedValues.java
@@ -27,17 +27,18 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
+import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
 final class PersistedValues {
 
-  static List<PersistedValue<Object>> findReflectively(@Nullable Object instance) {
+  static List<?> findReflectively(@Nullable Object instance) {
     PersistedValues visitor = new PersistedValues();
     visitor.visit(instance);
     return visitor.getPersistedValues();
   }
 
-  private final List<PersistedValue<Object>> persistedValues = new ArrayList<>();
+  private final List<Object> persistedValues = new ArrayList<>();
 
   private void visit(@Nullable Object instance) {
     if (instance == null) {
@@ -48,17 +49,14 @@ final class PersistedValues {
     }
   }
 
-  private List<PersistedValue<Object>> getPersistedValues() {
+  private List<Object> getPersistedValues() {
     return persistedValues;
   }
 
   private void visitField(@Nonnull Object instance, @Nonnull Field field) {
-    if (field.getType() != PersistedValue.class) {
+    if (field.getType() != PersistedValue.class && field.getType() != PersistedTable.class) {
       throw new IllegalArgumentException(
-          "Unknown persisted value type "
-              + field.getType()
-              + " on "
-              + instance.getClass().getName());
+          "Unknown persisted type " + field.getType() + " on " + instance.getClass().getName());
     }
     if (Modifier.isStatic(field.getModifiers())) {
       throw new IllegalArgumentException(
@@ -67,7 +65,7 @@ final class PersistedValues {
               + " on "
               + instance.getClass().getName());
     }
-    PersistedValue<Object> persistedValue = getPersistedValueReflectively(instance, field);
+    Object persistedValue = getPersistedValueReflectively(instance, field);
     if (persistedValue == null) {
       throw new IllegalStateException(
           "The field " + field + " of a " + instance.getClass().getName() + " was not initialized");
@@ -75,15 +73,13 @@ final class PersistedValues {
     persistedValues.add(persistedValue);
   }
 
-  @SuppressWarnings("unchecked")
-  private static PersistedValue<Object> getPersistedValueReflectively(
-      Object instance, Field persistedValueField) {
+  private static Object getPersistedValueReflectively(Object instance, Field persistedField) {
     try {
-      persistedValueField.setAccessible(true);
-      return (PersistedValue<Object>) persistedValueField.get(instance);
+      persistedField.setAccessible(true);
+      return persistedField.get(instance);
     } catch (IllegalAccessException e) {
       throw new RuntimeException(
-          "Unable access field " + persistedValueField.getName() + " of " + instance.getClass());
+          "Unable access field " + persistedField.getName() + " of " + instance.getClass());
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/RawSerializer.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/RawSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.state;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+final class RawSerializer<T> {
+  private final TypeSerializer<T> delegate;
+  private final DataOutputSerializer output;
+  private final DataInputDeserializer input;
+
+  RawSerializer(TypeSerializer<T> delegate) {
+    this.delegate = Objects.requireNonNull(delegate);
+    this.output = new DataOutputSerializer(32);
+    this.input = new DataInputDeserializer();
+  }
+
+  byte[] serialize(T value) throws IOException {
+    output.clear();
+    delegate.serialize(value, output);
+    return output.getCopyOfBuffer(); // TODO: consider avoiding buffer copying
+  }
+
+  T deserialize(byte[] bytes) throws IOException {
+    input.setBuffer(bytes);
+    final T value = delegate.deserialize(input);
+    input.releaseArrays();
+    return value;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
@@ -20,12 +20,17 @@ package org.apache.flink.statefun.flink.core.state;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.TableAccessor;
 
 public interface State {
 
   <T> Accessor<T> createFlinkStateAccessor(
       FunctionType functionType, PersistedValue<T> persistedValue);
+
+  <K, V> TableAccessor<K, V> createFlinkStateTableAccessor(
+      FunctionType functionType, PersistedTable<K, V> persistedTable);
 
   void setCurrentKey(Address address);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/StateBinder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/StateBinder.java
@@ -39,9 +39,9 @@ public final class StateBinder {
   }
 
   public BoundState bind(FunctionType functionType, @Nullable Object instance) {
-    List<?> values = PersistedValues.findReflectively(instance);
+    List<?> states = PersistedStates.findReflectively(instance);
     Builder builder = BoundState.builder();
-    for (Object persisted : values) {
+    for (Object persisted : states) {
       if (persisted instanceof PersistedValue) {
         PersistedValue<?> persistedValue = (PersistedValue<?>) persisted;
         Accessor<?> accessor = state.createFlinkStateAccessor(functionType, persistedValue);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
@@ -22,4 +22,9 @@ public class ApiExtension {
       PersistedValue<T> persistedValue, Accessor<T> accessor) {
     persistedValue.setAccessor(accessor);
   }
+
+  public static <K, V> void setPersistedTableAccessor(
+      PersistedTable<K, V> persistedTable, TableAccessor<K, V> accessor) {
+    persistedTable.setAccessor(accessor);
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2019 Ververica GmbH.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.cache;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class SingleThreadedLruCacheTest {
+
+  @Test
+  public void exampleUsage() {
+    SingleThreadedLruCache<String, String> cache = new SingleThreadedLruCache<>(2);
+
+    cache.put("a", "1");
+    cache.put("b", "2");
+
+    assertThat(cache.get("a"), is("1"));
+    assertThat(cache.get("b"), is("2"));
+  }
+
+  @Test
+  public void leastRecentlyElementShouldBeEvicted() {
+    SingleThreadedLruCache<String, String> cache = new SingleThreadedLruCache<>(2);
+
+    cache.put("a", "1");
+    cache.put("b", "2");
+    cache.put("c", "3");
+
+    assertThat(cache.get("a"), nullValue());
+    assertThat(cache.get("b"), is("2"));
+    assertThat(cache.get("c"), is("3"));
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.state;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.annotations.ForRuntime;
+import org.apache.flink.statefun.sdk.annotations.Persisted;
+
+/**
+ * A {@link PersistedTable} is a table (collection of keys and values) registered within {@link
+ * StatefulFunction}s and is persisted and maintained by the system for fault-tolerance.
+ *
+ * <p>Created persisted tables must be registered by using the {@link Persisted} annotation. Please
+ * see the class-level Javadoc of {@link StatefulFunction} for an example on how to do that.
+ *
+ * @see StatefulFunction
+ * @param <K> type of the key - Please note that the key have a meaningful {@link #hashCode()} and
+ *     {@link #equals(Object)} implemented.
+ * @param <V> type of the value.
+ */
+public final class PersistedTable<K, V> {
+  private final String name;
+  private final Class<K> keyType;
+  private final Class<V> valueType;
+  private TableAccessor<K, V> accessor;
+
+  private PersistedTable(
+      String name, Class<K> keyType, Class<V> valueType, TableAccessor<K, V> accessor) {
+    this.name = Objects.requireNonNull(name);
+    this.keyType = Objects.requireNonNull(keyType);
+    this.valueType = Objects.requireNonNull(valueType);
+    this.accessor = Objects.requireNonNull(accessor);
+  }
+
+  /**
+   * Creates a {@link PersistedTable} instance that may be used to access persisted state managed by
+   * the system. Access to the persisted table is identified by an unique name, type of the key, and
+   * type of the value. These may not change across multiple executions of the application.
+   *
+   * @param name the unique name of the persisted state.
+   * @param keyType the type of the state keys of this {@code PersistedTable}.
+   * @param valueType the type of the state values of this {@code PersistedTale}.
+   * @param <K> the type of the state keys.
+   * @param <V> the type of the state values.
+   * @return a {@code PersistedTable} instance.
+   */
+  public static <K, V> PersistedTable<K, V> of(String name, Class<K> keyType, Class<V> valueType) {
+    return new PersistedTable<>(name, keyType, valueType, new NonFaultTolerantAccessor<>());
+  }
+
+  /**
+   * Returns the unique name of the persisted table.
+   *
+   * @return unique name of the persisted table.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the type of the persisted tables keys.
+   *
+   * @return the type of the persisted tables keys.
+   */
+  public Class<K> keyType() {
+    return keyType;
+  }
+
+  /**
+   * Returns the type of the persisted tables values.
+   *
+   * @return the type of the persisted tables values.
+   */
+  public Class<V> valueType() {
+    return valueType;
+  }
+
+  /**
+   * Returns a persisted table's value.
+   *
+   * @return the persisted table value associated with {@code key}.
+   */
+  public V get(K key) {
+    return accessor.get(key);
+  }
+
+  /**
+   * Updates the persisted table.
+   *
+   * @param key the to associate the value with.
+   * @param value the new value.
+   */
+  public void set(K key, V value) {
+    accessor.set(key, value);
+  }
+
+  /**
+   * Removes the value associated with {@code key}.
+   *
+   * @param key the key to remove.
+   */
+  public void remove(K key) {
+    accessor.remove(key);
+  }
+
+  @ForRuntime
+  void setAccessor(TableAccessor<K, V> newAccessor) {
+    Objects.requireNonNull(newAccessor);
+    this.accessor = newAccessor;
+  }
+
+  private static final class NonFaultTolerantAccessor<K, V> implements TableAccessor<K, V> {
+    private final Map<K, V> map = new HashMap<>();
+
+    @Override
+    public void set(K key, V value) {
+      map.put(key, value);
+    }
+
+    @Override
+    public V get(K key) {
+      return map.get(key);
+    }
+
+    @Override
+    public void remove(K key) {
+      map.remove(key);
+    }
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.state;
+
+public interface TableAccessor<K, V> {
+
+  void set(K key, V value);
+
+  V get(K key);
+
+  void remove(K key);
+}


### PR DESCRIPTION
This PR introduces another persisted state type to the SDK, named a PersistedTable.
A persisted table is a map/dictionary/an association between keys -> values.
Example usage:
```
class MyFunc implements StatefulFunction {

   @Persisted
   PersistedTable<String, Integer> words = PersistedTable.of("words", String.class, Integer.class);

 
 @Override
  public void invoke(Context context, Object input) {
       Integer count = words.get((String) input);
       words.set((String)input, inc(count));       
  }   

...
}

```
* note: This PR builds on top of #15 