### PR TITLE
[FLINK-15955] Split RemoteFunction into gRPC/HTTP

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import org.apache.flink.statefun.sdk.FunctionType;
+
+public interface FunctionSpec {
+
+    FunctionType functionType();
+
+    Kind kind();
+
+    enum Kind {
+        HTTP,
+        GRPC
+    }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionSpec.java
@@ -21,12 +21,12 @@ import org.apache.flink.statefun.sdk.FunctionType;
 
 public interface FunctionSpec {
 
-    FunctionType functionType();
+  FunctionType functionType();
 
-    Kind kind();
+  Kind kind();
 
-    enum Kind {
-        HTTP,
-        GRPC
-    }
+  enum Kind {
+    HTTP,
+    GRPC
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunction.java
@@ -17,24 +17,19 @@
  */
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
-import java.util.Map;
-import org.apache.flink.statefun.sdk.FunctionType;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.Context;
 import org.apache.flink.statefun.sdk.StatefulFunction;
-import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 
-public class RemoteFunctionProvider implements StatefulFunctionProvider {
-  private final Map<FunctionType, RemoteFunctionSpec> supportedTypes;
+public class GrpcFunction implements StatefulFunction {
+  private final GrpcFunctionSpec functionSpec;
 
-  public RemoteFunctionProvider(Map<FunctionType, RemoteFunctionSpec> supportedTypes) {
-    this.supportedTypes = supportedTypes;
+  public GrpcFunction(GrpcFunctionSpec functionSpec) {
+    this.functionSpec = Objects.requireNonNull(functionSpec);
   }
 
   @Override
-  public StatefulFunction functionOfType(FunctionType type) {
-    RemoteFunctionSpec spec = supportedTypes.get(type);
-    if (spec == null) {
-      throw new IllegalArgumentException("Unsupported type " + type);
-    }
-    return new RemoteFunction(spec);
+  public void invoke(Context context, Object input) {
+    throw new UnsupportedOperationException(functionSpec.functionType() + " is not yet supported.");
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunctionProvider.java
@@ -17,24 +17,24 @@
  */
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
-import java.net.SocketAddress;
-import java.util.Objects;
+import java.util.Map;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 
-final class RemoteFunctionSpec {
-  private final FunctionType functionType;
-  private final SocketAddress functionAddress;
+public class GrpcFunctionProvider implements StatefulFunctionProvider {
+  private final Map<FunctionType, GrpcFunctionSpec> supportedTypes;
 
-  RemoteFunctionSpec(FunctionType functionType, SocketAddress functionAddress) {
-    this.functionType = Objects.requireNonNull(functionType);
-    this.functionAddress = Objects.requireNonNull(functionAddress);
+  public GrpcFunctionProvider(Map<FunctionType, GrpcFunctionSpec> supportedTypes) {
+    this.supportedTypes = supportedTypes;
   }
 
-  FunctionType functionType() {
-    return functionType;
-  }
-
-  SocketAddress address() {
-    return functionAddress;
+  @Override
+  public StatefulFunction functionOfType(FunctionType type) {
+    GrpcFunctionSpec spec = supportedTypes.get(type);
+    if (spec == null) {
+      throw new IllegalArgumentException("Unsupported type " + type);
+    }
+    return new GrpcFunction(spec);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/GrpcFunctionSpec.java
@@ -17,19 +17,30 @@
  */
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
+import java.net.SocketAddress;
 import java.util.Objects;
-import org.apache.flink.statefun.sdk.Context;
-import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.FunctionType;
 
-public class RemoteFunction implements StatefulFunction {
-  private final RemoteFunctionSpec functionSpec;
+final class GrpcFunctionSpec implements FunctionSpec {
+  private final FunctionType functionType;
+  private final SocketAddress functionAddress;
 
-  public RemoteFunction(RemoteFunctionSpec functionSpec) {
-    this.functionSpec = Objects.requireNonNull(functionSpec);
+  GrpcFunctionSpec(FunctionType functionType, SocketAddress functionAddress) {
+    this.functionType = Objects.requireNonNull(functionType);
+    this.functionAddress = Objects.requireNonNull(functionAddress);
   }
 
   @Override
-  public void invoke(Context context, Object input) {
-    throw new UnsupportedOperationException(functionSpec.functionType() + " is not yet supported.");
+  public FunctionType functionType() {
+    return functionType;
+  }
+
+  @Override
+  public Kind kind() {
+    return Kind.GRPC;
+  }
+
+  public SocketAddress address() {
+    return functionAddress;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import java.util.Map;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+
+public class HttpFunctionProvider implements StatefulFunctionProvider {
+  public HttpFunctionProvider(Map<FunctionType, HttpFunctionSpec> specs) {}
+
+  @Override
+  public StatefulFunction functionOfType(FunctionType type) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionSpec.java
@@ -23,31 +23,31 @@ import java.util.Objects;
 import org.apache.flink.statefun.sdk.FunctionType;
 
 public final class HttpFunctionSpec implements FunctionSpec {
-    private final FunctionType functionType;
-    private final URI endpoint;
-    private final List<String> states;
+  private final FunctionType functionType;
+  private final URI endpoint;
+  private final List<String> states;
 
-    public HttpFunctionSpec(FunctionType functionType, URI endpoint, List<String> states) {
-        this.functionType = Objects.requireNonNull(functionType);
-        this.endpoint = Objects.requireNonNull(endpoint);
-        this.states = Objects.requireNonNull(states);
-    }
+  public HttpFunctionSpec(FunctionType functionType, URI endpoint, List<String> states) {
+    this.functionType = Objects.requireNonNull(functionType);
+    this.endpoint = Objects.requireNonNull(endpoint);
+    this.states = Objects.requireNonNull(states);
+  }
 
-    @Override
-    public FunctionType functionType() {
-        return functionType;
-    }
+  @Override
+  public FunctionType functionType() {
+    return functionType;
+  }
 
-    @Override
-    public Kind kind() {
-        return Kind.HTTP;
-    }
+  @Override
+  public Kind kind() {
+    return Kind.HTTP;
+  }
 
-    public URI endpoint() {
-        return endpoint;
-    }
+  public URI endpoint() {
+    return endpoint;
+  }
 
-    public List<String> states() {
-        return states;
-    }
+  public List<String> states() {
+    return states;
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/HttpFunctionSpec.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.FunctionType;
+
+public final class HttpFunctionSpec implements FunctionSpec {
+    private final FunctionType functionType;
+    private final URI endpoint;
+    private final List<String> states;
+
+    public HttpFunctionSpec(FunctionType functionType, URI endpoint, List<String> states) {
+        this.functionType = Objects.requireNonNull(functionType);
+        this.endpoint = Objects.requireNonNull(endpoint);
+        this.states = Objects.requireNonNull(states);
+    }
+
+    @Override
+    public FunctionType functionType() {
+        return functionType;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.HTTP;
+    }
+
+    public URI endpoint() {
+        return endpoint;
+    }
+
+    public List<String> states() {
+        return states;
+    }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -64,15 +64,15 @@ final class JsonModule implements StatefulFunctionModule {
   }
 
   private void configureFunctions(Binder binder, Iterable<? extends JsonNode> functions) {
-    final Map<FunctionType, RemoteFunctionSpec> definedFunctions =
+    final Map<FunctionType, GrpcFunctionSpec> definedFunctions =
         StreamSupport.stream(functions.spliterator(), false)
             .map(JsonModule::parseRemoteFunctionSpec)
-            .collect(toMap(RemoteFunctionSpec::functionType, Function.identity()));
+            .collect(toMap(GrpcFunctionSpec::functionType, Function.identity()));
 
     // currently we had a single function type that can be specified at a module.yaml
     // and this is the RemoteFunction. Therefore we translate immediately the function spec
     // to a (GRPC) RemoteFunctionProvider.
-    RemoteFunctionProvider provider = new RemoteFunctionProvider(definedFunctions);
+    GrpcFunctionProvider provider = new GrpcFunctionProvider(definedFunctions);
     for (FunctionType type : definedFunctions.keySet()) {
       binder.bindFunctionProvider(type, provider);
     }
@@ -168,10 +168,10 @@ final class JsonModule implements StatefulFunctionModule {
   // Functions
   // ----------------------------------------------------------------------------------------------------------
 
-  private static RemoteFunctionSpec parseRemoteFunctionSpec(JsonNode functionNode) {
+  private static GrpcFunctionSpec parseRemoteFunctionSpec(JsonNode functionNode) {
     FunctionType functionType = functionType(functionNode);
     InetSocketAddress functionAddress = functionAddress(functionNode);
-    return new RemoteFunctionSpec(functionType, functionAddress);
+    return new GrpcFunctionSpec(functionType, functionAddress);
   }
 
   private static FunctionType functionType(JsonNode functionNode) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -18,27 +18,37 @@
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.flink.statefun.flink.core.common.Maps.transformValues;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URL;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.StreamSupport;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.statefun.flink.common.ResourceLocator;
 import org.apache.flink.statefun.flink.common.json.NamespaceNamePair;
 import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.common.protobuf.ProtobufDescriptorMap;
+import org.apache.flink.statefun.flink.core.jsonmodule.FunctionSpec.Kind;
 import org.apache.flink.statefun.flink.core.protorouter.ProtobufRouter;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.IngressType;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.Router;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
@@ -64,17 +74,31 @@ final class JsonModule implements StatefulFunctionModule {
   }
 
   private void configureFunctions(Binder binder, Iterable<? extends JsonNode> functions) {
-    final Map<FunctionType, GrpcFunctionSpec> definedFunctions =
+    final Map<Kind, Map<FunctionType, FunctionSpec>> definedFunctions =
         StreamSupport.stream(functions.spliterator(), false)
-            .map(JsonModule::parseRemoteFunctionSpec)
-            .collect(toMap(GrpcFunctionSpec::functionType, Function.identity()));
+            .map(JsonModule::parseFunctionSpec)
+            .collect(groupingBy(FunctionSpec::kind, groupByFunctionType()));
 
-    // currently we had a single function type that can be specified at a module.yaml
-    // and this is the RemoteFunction. Therefore we translate immediately the function spec
-    // to a (GRPC) RemoteFunctionProvider.
-    GrpcFunctionProvider provider = new GrpcFunctionProvider(definedFunctions);
-    for (FunctionType type : definedFunctions.keySet()) {
-      binder.bindFunctionProvider(type, provider);
+    for (Entry<Kind, Map<FunctionType, FunctionSpec>> entry : definedFunctions.entrySet()) {
+      StatefulFunctionProvider provider = functionProvider(entry.getKey(), entry.getValue());
+      Set<FunctionType> functionTypes = entry.getValue().keySet();
+      for (FunctionType type : functionTypes) {
+        binder.bindFunctionProvider(type, provider);
+      }
+    }
+  }
+
+  private static StatefulFunctionProvider functionProvider(
+      Kind kind, Map<FunctionType, FunctionSpec> definedFunctions) {
+    switch (kind) {
+      case HTTP:
+        return new HttpFunctionProvider(
+            transformValues(definedFunctions, HttpFunctionSpec.class::cast));
+      case GRPC:
+        return new GrpcFunctionProvider(
+            transformValues(definedFunctions, GrpcFunctionSpec.class::cast));
+      default:
+        throw new IllegalStateException("Unexpected value: " + kind);
     }
   }
 
@@ -103,7 +127,6 @@ final class JsonModule implements StatefulFunctionModule {
   // ----------------------------------------------------------------------------------------------------------
   // Ingresses
   // ----------------------------------------------------------------------------------------------------------
-
   private static IngressType ingressType(JsonNode spec) {
     String typeString = Selectors.textAt(spec, Pointers.Ingress.META_TYPE);
     NamespaceNamePair nn = NamespaceNamePair.from(typeString);
@@ -119,7 +142,6 @@ final class JsonModule implements StatefulFunctionModule {
   // ----------------------------------------------------------------------------------------------------------
   // Routers
   // ----------------------------------------------------------------------------------------------------------
-
   private static Router<Message> dynamicRouter(JsonNode router) {
     String addressTemplate = Selectors.textAt(router, Pointers.Routers.SPEC_TARGET);
     String descriptorSetPath = Selectors.textAt(router, Pointers.Routers.SPEC_DESCRIPTOR);
@@ -142,6 +164,10 @@ final class JsonModule implements StatefulFunctionModule {
   private static ProtobufDescriptorMap protobufDescriptorMap(String descriptorSetPath) {
     try {
       URL url = ResourceLocator.findNamedResource(descriptorSetPath);
+      if (url == null) {
+        throw new IllegalArgumentException(
+            "Unable to locate a Protobuf descriptor set at " + descriptorSetPath);
+      }
       return ProtobufDescriptorMap.from(url);
     } catch (IOException e) {
       throw new IllegalStateException(
@@ -168,10 +194,23 @@ final class JsonModule implements StatefulFunctionModule {
   // Functions
   // ----------------------------------------------------------------------------------------------------------
 
-  private static GrpcFunctionSpec parseRemoteFunctionSpec(JsonNode functionNode) {
+  private static FunctionSpec parseFunctionSpec(JsonNode functionNode) {
+    String functionKind = Selectors.textAt(functionNode, Pointers.Functions.META_KIND);
+    FunctionSpec.Kind kind = Kind.valueOf(functionKind.toUpperCase(Locale.getDefault()));
     FunctionType functionType = functionType(functionNode);
-    InetSocketAddress functionAddress = functionAddress(functionNode);
-    return new GrpcFunctionSpec(functionType, functionAddress);
+    switch (kind) {
+      case HTTP:
+        return new HttpFunctionSpec(
+            functionType, functionUri(functionNode), functionStates(functionNode));
+      case GRPC:
+        return new GrpcFunctionSpec(functionType, functionAddress(functionNode));
+      default:
+        throw new IllegalArgumentException("Unrecognized function kind " + functionKind);
+    }
+  }
+
+  private static List<String> functionStates(JsonNode functionNode) {
+    return Selectors.textListAt(functionNode, Pointers.Functions.FUNCTION_STATES);
   }
 
   private static FunctionType functionType(JsonNode functionNode) {
@@ -184,5 +223,14 @@ final class JsonModule implements StatefulFunctionModule {
     String host = Selectors.textAt(functionNode, Pointers.Functions.FUNCTION_HOSTNAME);
     int port = Selectors.integerAt(functionNode, Pointers.Functions.FUNCTION_PORT);
     return new InetSocketAddress(host, port);
+  }
+
+  private static URI functionUri(JsonNode functionNode) {
+    String uri = Selectors.textAt(functionNode, Pointers.Functions.FUNCTION_ENDPOINT);
+    return URI.create(uri);
+  }
+
+  private static Collector<FunctionSpec, ?, Map<FunctionType, FunctionSpec>> groupByFunctionType() {
+    return toMap(FunctionSpec::functionType, Function.identity());
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
@@ -43,7 +43,7 @@ public final class Pointers {
     public static final JsonPointer META_TYPE = JsonPointer.compile("/function/meta/type");
     public static final JsonPointer FUNCTION_HOSTNAME = JsonPointer.compile("/function/spec/host");
     public static final JsonPointer FUNCTION_ENDPOINT =
-            JsonPointer.compile("/function/spec/endpoint");
+        JsonPointer.compile("/function/spec/endpoint");
     public static final JsonPointer FUNCTION_PORT = JsonPointer.compile("/function/spec/port");
     public static final JsonPointer FUNCTION_STATES = JsonPointer.compile("/function/spec/states");
   }
@@ -58,9 +58,9 @@ public final class Pointers {
     public static final JsonPointer SPEC_INGRESS = JsonPointer.compile("/router/spec/ingress");
     public static final JsonPointer SPEC_TARGET = JsonPointer.compile("/router/spec/target");
     public static final JsonPointer SPEC_DESCRIPTOR =
-            JsonPointer.compile("/router/spec/descriptorSet");
+        JsonPointer.compile("/router/spec/descriptorSet");
     public static final JsonPointer SPEC_MESSAGE_TYPE =
-            JsonPointer.compile("/router/spec/messageType");
+        JsonPointer.compile("/router/spec/messageType");
   }
 
   // -------------------------------------------------------------------------------------

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
@@ -39,9 +39,13 @@ public final class Pointers {
   // -------------------------------------------------------------------------------------
 
   public static final class Functions {
+    public static final JsonPointer META_KIND = JsonPointer.compile("/function/meta/kind");
     public static final JsonPointer META_TYPE = JsonPointer.compile("/function/meta/type");
     public static final JsonPointer FUNCTION_HOSTNAME = JsonPointer.compile("/function/spec/host");
+    public static final JsonPointer FUNCTION_ENDPOINT =
+            JsonPointer.compile("/function/spec/endpoint");
     public static final JsonPointer FUNCTION_PORT = JsonPointer.compile("/function/spec/port");
+    public static final JsonPointer FUNCTION_STATES = JsonPointer.compile("/function/spec/states");
   }
 
   // -------------------------------------------------------------------------------------
@@ -54,9 +58,9 @@ public final class Pointers {
     public static final JsonPointer SPEC_INGRESS = JsonPointer.compile("/router/spec/ingress");
     public static final JsonPointer SPEC_TARGET = JsonPointer.compile("/router/spec/target");
     public static final JsonPointer SPEC_DESCRIPTOR =
-        JsonPointer.compile("/router/spec/descriptorSet");
+            JsonPointer.compile("/router/spec/descriptorSet");
     public static final JsonPointer SPEC_MESSAGE_TYPE =
-        JsonPointer.compile("/router/spec/messageType");
+            JsonPointer.compile("/router/spec/messageType");
   }
 
   // -------------------------------------------------------------------------------------

--- a/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
@@ -20,16 +20,17 @@ module:
     functions:
       - function:
           meta:
+            kind: grpc
             type: com.example/hello
           spec:
             host: localhost
             port: 5000
       - function:
           meta:
+            kind: http
             type: com.foo/world
           spec:
-            host: localhost
-            port: 8855
+            endpoint: localhost:5959/statefun
     routers:
       - router:
           meta:


### PR DESCRIPTION
This PR splits the RemoteFunction into two separate remote functions (gRPC and HTTP).
Following this PR, users can specify remote functions in the following way:
```
...
spec:
    functions:
      - function:
          meta:
            kind: grpc
            type: com.example/hello
          spec:
            host: localhost
            port: 5000
      - function:
          meta:
            kind: http
            type: com.foo/world
          spec:
            endpoint: localhost:5959/api/v1/statefun
            states:
                 - seen
``` 

Please note:
1. that the function implementations would come in separate PRs,
and at the moment specifying these functions would throw an `UnSupportedOperationException`.
2. states for the HTTP function, needed to be declared in the YAML (see `states` in the example above)
 