### PR TITLE
[FLINK-16106] Add PersistedList state primitive

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/BoundState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/BoundState.java
@@ -20,6 +20,7 @@ package org.apache.flink.statefun.flink.core.state;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
@@ -31,11 +32,15 @@ public class BoundState {
 
   private final List<PersistedValue<?>> persistedValues;
   private final List<PersistedTable<?, ?>> persistedTables;
+  private final List<PersistedAppendingBuffer<?>> persistedAppendingBuffers;
 
   private BoundState(
-      List<PersistedValue<?>> persistedValues, List<PersistedTable<?, ?>> persistedTables) {
+      List<PersistedValue<?>> persistedValues,
+      List<PersistedTable<?, ?>> persistedTables,
+      List<PersistedAppendingBuffer<?>> persistedAppendingBuffers) {
     this.persistedValues = Objects.requireNonNull(persistedValues);
     this.persistedTables = Objects.requireNonNull(persistedTables);
+    this.persistedAppendingBuffers = Objects.requireNonNull(persistedAppendingBuffers);
   }
 
   @SuppressWarnings("unused")
@@ -48,10 +53,15 @@ public class BoundState {
     return persistedTables;
   }
 
+  public List<PersistedAppendingBuffer<?>> getPersistedAppendingBuffers() {
+    return persistedAppendingBuffers;
+  }
+
   @SuppressWarnings("UnusedReturnValue")
   public static final class Builder {
     private List<PersistedValue<?>> persistedValues = new ArrayList<>();
     private List<PersistedTable<?, ?>> persistedTables = new ArrayList<>();
+    private List<PersistedAppendingBuffer<?>> persistedAppendingBuffers = new ArrayList<>();
 
     private Builder() {}
 
@@ -65,8 +75,13 @@ public class BoundState {
       return this;
     }
 
+    public Builder withPersistedList(PersistedAppendingBuffer<?> persistedAppendingBuffer) {
+      this.persistedAppendingBuffers.add(persistedAppendingBuffer);
+      return this;
+    }
+
     public BoundState build() {
-      return new BoundState(persistedValues, persistedTables);
+      return new BoundState(persistedValues, persistedTables, persistedAppendingBuffers);
     }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessor.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.state;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
+
+final class FlinkAppendingBufferAccessor<E> implements AppendingBufferAccessor<E> {
+
+  private final ListState<E> handle;
+
+  FlinkAppendingBufferAccessor(ListState<E> handle) {
+    this.handle = Objects.requireNonNull(handle);
+  }
+
+  @Override
+  public void append(E element) {
+    try {
+      this.handle.add(element);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void appendAll(List<E> elements) {
+    try {
+      this.handle.addAll(elements);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void replaceWith(List<E> elements) {
+    try {
+      this.handle.update(elements);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nullable
+  @Override
+  public Iterable<E> view() {
+    try {
+      return this.handle.get();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void clear() {
+    try {
+      this.handle.clear();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
@@ -19,6 +19,8 @@ package org.apache.flink.statefun.flink.core.state;
 
 import java.util.Objects;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -32,6 +34,8 @@ import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -73,6 +77,17 @@ public final class FlinkState implements State {
                 persistedTable.keyType(),
                 persistedTable.valueType()));
     return new FlinkTableAccessor<>(handle);
+  }
+
+  @Override
+  public <E> AppendingBufferAccessor<E> createFlinkStateAppendingBufferAccessor(
+      FunctionType functionType, PersistedAppendingBuffer<E> persistedAppendingBuffer) {
+    ListState<E> handle =
+        runtimeContext.getListState(
+            new ListStateDescriptor<>(
+                flinkStateName(functionType, persistedAppendingBuffer.name()),
+                persistedAppendingBuffer.elementType()));
+    return new FlinkAppendingBufferAccessor<>(handle);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
@@ -76,7 +77,9 @@ final class PersistedStates {
   }
 
   private static boolean isPersistedState(Class<?> fieldType) {
-    return fieldType == PersistedValue.class || fieldType == PersistedTable.class;
+    return fieldType == PersistedValue.class
+        || fieldType == PersistedTable.class
+        || fieldType == PersistedAppendingBuffer.class;
   }
 
   private static Object getPersistedValueReflectively(Object instance, Field persistedField) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -36,10 +36,10 @@ final class PersistedStates {
   static List<?> findReflectively(@Nullable Object instance) {
     PersistedStates visitor = new PersistedStates();
     visitor.visit(instance);
-    return visitor.getPersistedValues();
+    return visitor.getPersistedStates();
   }
 
-  private final List<Object> persistedValues = new ArrayList<>();
+  private final List<Object> persistedStates = new ArrayList<>();
 
   private void visit(@Nullable Object instance) {
     if (instance == null) {
@@ -50,29 +50,29 @@ final class PersistedStates {
     }
   }
 
-  private List<Object> getPersistedValues() {
-    return persistedValues;
+  private List<Object> getPersistedStates() {
+    return persistedStates;
   }
 
   private void visitField(@Nonnull Object instance, @Nonnull Field field) {
     if (Modifier.isStatic(field.getModifiers())) {
       throw new IllegalArgumentException(
-          "Static persisted values are not legal in: "
+          "Static persisted states are not legal in: "
               + field.getType()
               + " on "
               + instance.getClass().getName());
     }
-    Object persistedValue = getPersistedValueReflectively(instance, field);
-    if (persistedValue == null) {
+    Object persistedState = getPersistedStateReflectively(instance, field);
+    if (persistedState == null) {
       throw new IllegalStateException(
           "The field " + field + " of a " + instance.getClass().getName() + " was not initialized");
     }
     Class<?> fieldType = field.getType();
     if (isPersistedState(fieldType)) {
-      persistedValues.add(persistedValue);
+      persistedStates.add(persistedState);
     } else {
-      List<?> innerFields = findReflectively(persistedValue);
-      persistedValues.addAll(innerFields);
+      List<?> innerFields = findReflectively(persistedState);
+      persistedStates.addAll(innerFields);
     }
   }
 
@@ -82,7 +82,7 @@ final class PersistedStates {
         || fieldType == PersistedAppendingBuffer.class;
   }
 
-  private static Object getPersistedValueReflectively(Object instance, Field persistedField) {
+  private static Object getPersistedStateReflectively(Object instance, Field persistedField) {
     try {
       persistedField.setAccessible(true);
       return persistedField.get(instance);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
@@ -20,6 +20,8 @@ package org.apache.flink.statefun.flink.core.state;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -31,6 +33,9 @@ public interface State {
 
   <K, V> TableAccessor<K, V> createFlinkStateTableAccessor(
       FunctionType functionType, PersistedTable<K, V> persistedTable);
+
+  <E> AppendingBufferAccessor<E> createFlinkStateAppendingBufferAccessor(
+      FunctionType functionType, PersistedAppendingBuffer<E> persistedAppendingBuffer);
 
   void setCurrentKey(Address address);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/StateBinder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/StateBinder.java
@@ -26,6 +26,8 @@ import org.apache.flink.statefun.flink.core.state.BoundState.Builder;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
 import org.apache.flink.statefun.sdk.state.ApiExtension;
+import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -53,6 +55,13 @@ public final class StateBinder {
             state.createFlinkStateTableAccessor(functionType, persistedTable);
         setAccessorRaw(persistedTable, accessor);
         builder.withPersistedTable(persistedTable);
+      } else if (persisted instanceof PersistedAppendingBuffer) {
+        PersistedAppendingBuffer<?> persistedAppendingBuffer =
+            (PersistedAppendingBuffer<?>) persisted;
+        AppendingBufferAccessor<?> accessor =
+            state.createFlinkStateAppendingBufferAccessor(functionType, persistedAppendingBuffer);
+        setAccessorRaw(persistedAppendingBuffer, accessor);
+        builder.withPersistedList(persistedAppendingBuffer);
       } else {
         throw new IllegalArgumentException("Unknown persisted field " + persisted);
       }
@@ -68,5 +77,12 @@ public final class StateBinder {
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static void setAccessorRaw(PersistedValue<?> persistedValue, Accessor<?> accessor) {
     ApiExtension.setPersistedValueAccessor((PersistedValue) persistedValue, accessor);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static void setAccessorRaw(
+      PersistedAppendingBuffer<?> persistedAppendingBuffer, AppendingBufferAccessor<?> accessor) {
+    ApiExtension.setPersistedAppendingBufferAccessor(
+        (PersistedAppendingBuffer) persistedAppendingBuffer, accessor);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
@@ -27,4 +27,9 @@ public class ApiExtension {
       PersistedTable<K, V> persistedTable, TableAccessor<K, V> accessor) {
     persistedTable.setAccessor(accessor);
   }
+
+  public static <E> void setPersistedAppendingBufferAccessor(
+      PersistedAppendingBuffer<E> persistedAppendingBuffer, AppendingBufferAccessor<E> accessor) {
+    persistedAppendingBuffer.setAccessor(accessor);
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
@@ -87,6 +87,13 @@ public class StateBinderTest {
   }
 
   @Test
+  public void bindPersistedAppendingBuffer() {
+    binderUnderTest.bind(TestUtils.FUNCTION_TYPE, new PersistedAppendingBufferState());
+
+    assertThat(state.boundNames, hasItems("buffer"));
+  }
+
+  @Test
   public void bindComposedState() {
     binderUnderTest.bind(TestUtils.FUNCTION_TYPE, new OuterClass());
 
@@ -139,6 +146,12 @@ public class StateBinderTest {
     @Persisted
     @SuppressWarnings("unused")
     PersistedTable<String, byte[]> value = PersistedTable.of("table", String.class, byte[].class);
+  }
+
+  static final class PersistedAppendingBufferState {
+    @Persisted
+    @SuppressWarnings("unused")
+    PersistedAppendingBuffer<Boolean> value = PersistedAppendingBuffer.of("buffer", Boolean.class);
   }
 
   static final class InnerClass {

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
@@ -33,6 +33,8 @@ import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.state.Accessor;
+import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
+import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -187,6 +189,12 @@ public class StateBootstrapperTest {
     @Override
     public <K, V> TableAccessor<K, V> createFlinkStateTableAccessor(
         FunctionType functionType, PersistedTable<K, V> persistedTable) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <E> AppendingBufferAccessor<E> createFlinkStateAppendingBufferAccessor(
+        FunctionType functionType, PersistedAppendingBuffer<E> persistedAppendingBuffer) {
       throw new UnsupportedOperationException();
     }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/AppendingBufferAccessor.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/AppendingBufferAccessor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.state;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+public interface AppendingBufferAccessor<E> {
+
+  void append(E element);
+
+  void appendAll(List<E> elements);
+
+  void replaceWith(List<E> elements);
+
+  @Nullable
+  Iterable<E> view();
+
+  void clear();
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.state;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.annotations.ForRuntime;
+import org.apache.flink.statefun.sdk.annotations.Persisted;
+
+/**
+ * A {@link PersistedAppendingBuffer} is an append-only buffer registered within {@link
+ * StatefulFunction}s and is persisted and maintained by the system for fault-tolerance. Persisted
+ * elements in the buffer may only be updated with bulk replacements.
+ *
+ * <p>Created persisted buffers must be registered by using the {@link Persisted} annotation. Please
+ * see the class-level Javadoc of {@link StatefulFunction} for an example on how to do that.
+ *
+ * @see StatefulFunction
+ * @param <E> type of the list elements.
+ */
+public final class PersistedAppendingBuffer<E> {
+  private final String name;
+  private final Class<E> elementType;
+  private AppendingBufferAccessor<E> accessor;
+
+  private PersistedAppendingBuffer(
+      String name, Class<E> elementType, AppendingBufferAccessor<E> accessor) {
+    this.name = Objects.requireNonNull(name);
+    this.elementType = Objects.requireNonNull(elementType);
+    this.accessor = Objects.requireNonNull(accessor);
+  }
+
+  /**
+   * Creates a {@link PersistedAppendingBuffer} instance that may be used to access persisted state
+   * managed by the system. Access to the persisted buffer is identified by an unique name and type
+   * of the elements. These may not change across multiple executions of the application.
+   *
+   * @param name the unique name of the persisted buffer state
+   * @param elementType the type of the elements of this {@code PersistedAppendingBuffer}.
+   * @param <E> the type of the elements.
+   * @return a {@code PersistedAppendingBuffer} instance.
+   */
+  public static <E> PersistedAppendingBuffer<E> of(String name, Class<E> elementType) {
+    return new PersistedAppendingBuffer<>(name, elementType, new NonFaultTolerantAccessor<>());
+  }
+
+  /**
+   * Returns the unique name of the persisted buffer.
+   *
+   * @return unique name of the persisted buffer.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the type of the persisted buffer elements.
+   *
+   * @return the type of the persisted buffer elements.
+   */
+  public Class<E> elementType() {
+    return elementType;
+  }
+
+  /**
+   * Appends an element to the persisted buffer.
+   *
+   * <p>If {@code null} is passed in, then this method has no effect and the persisted buffer
+   * remains the same.
+   *
+   * @param element the element to add to the persisted buffer.
+   */
+  public void append(@Nullable E element) {
+    if (element != null) {
+      accessor.append(element);
+    }
+  }
+
+  /**
+   * Adds all elements of a list to the persisted buffer.
+   *
+   * <p>If {@code null} or an empty list is passed in, then this method has no effect and the
+   * persisted buffer remains the same.
+   *
+   * @param elements a list of elements to add to the persisted buffer.
+   */
+  public void appendAll(@Nullable List<E> elements) {
+    if (elements != null && !elements.isEmpty()) {
+      accessor.appendAll(elements);
+    }
+  }
+
+  /**
+   * Replace the elements in the persisted buffer with the provided list of elements.
+   *
+   * <p>If an empty list or {@code null} is passed in, this method will have the same effect as
+   * {@link #clear()}.
+   *
+   * @param elements list of elements to replace the elements in the persisted buffer with.
+   */
+  public void replaceWith(@Nullable List<E> elements) {
+    if (elements != null && !elements.isEmpty()) {
+      accessor.replaceWith(elements);
+    } else {
+      accessor.clear();
+    }
+  }
+
+  /**
+   * Gets the elements of the persisted buffer as an {@link Iterable}.
+   *
+   * <p>This may return {@code null} if the buffer is empty or had been cleared (with {@link
+   * #clear()}).
+   *
+   * <p>Note that any modifications to the view does not modify the elements in the persisted
+   * buffer. To modify elements in the persisted buffer, you must use {@link #replaceWith(List)}.
+   *
+   * @return a modifiable view, as an {@link Iterable}, of the elements of the persisted buffer, or
+   *     {@code null} if the buffer is empty or had been cleared.
+   */
+  @Nullable
+  public Iterable<E> view() {
+    return accessor.view();
+  }
+
+  /** Clears all elements in the persisted buffer. */
+  public void clear() {
+    accessor.clear();
+  }
+
+  @ForRuntime
+  void setAccessor(AppendingBufferAccessor<E> newAccessor) {
+    this.accessor = Objects.requireNonNull(newAccessor);
+  }
+
+  private static final class NonFaultTolerantAccessor<E> implements AppendingBufferAccessor<E> {
+    private List<E> list;
+
+    @Override
+    public void append(E element) {
+      if (list == null) {
+        list = new ArrayList<>();
+      }
+      list.add(element);
+    }
+
+    @Override
+    public void appendAll(List<E> elements) {
+      if (list == null) {
+        list = new ArrayList<>();
+      }
+      list.addAll(elements);
+    }
+
+    @Override
+    public void replaceWith(List<E> elements) {
+      list = elements;
+    }
+
+    @Nullable
+    @Override
+    public Iterable<E> view() {
+      return list;
+    }
+
+    @Override
+    public void clear() {
+      list = null;
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a `PersistedList` state primitive to Stateful Functions.

- 3491fea: Adds the user-facing SDK classes
- 69e8ce6: Introduces the Flink-based accessor for `PersistedList`
- fc190ca: Completes the addition by letting the `StateBinder` support `PersistedList`

---

This can be verified by the new test `StateBinderTest#bindPersistedList()`.