### PR TITLE
[FLINK-16159] [tests, build] Add verification integration test + integrate with Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@ under the License.
         <module>statefun-quickstart</module>
         <module>statefun-docs</module>
         <module>statefun-testutil</module>
+        <module>statefun-end-to-end-tests</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@ under the License.
         <module>statefun-quickstart</module>
         <module>statefun-docs</module>
         <module>statefun-testutil</module>
+
+        <!--
+            Always build the end-to-end tests module last,
+            since the module builds the base Stateful Functions image with the
+            built project artifacts before running the end-to-end tests.
+        -->
         <module>statefun-end-to-end-tests</module>
     </modules>
 

--- a/statefun-end-to-end-tests/pom.xml
+++ b/statefun-end-to-end-tests/pom.xml
@@ -31,4 +31,49 @@ under the License.
     <modules>
         <module>statefun-sanity-itcase</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <!--
+                Build profile for running end-to-end tests in this module.
+                This first builds the base Stateful Functions image before running the ITCases.
+                Docker must be installed for this profile to work.
+            -->
+            <id>run-end-to-end-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>${user.dir}/tools/docker/build-stateful-functions.sh</executable>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.22.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/statefun-end-to-end-tests/pom.xml
+++ b/statefun-end-to-end-tests/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-end-to-end-tests</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>statefun-sanity-itcase</module>
+    </modules>
+</project>

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/pom.xml
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-end-to-end-tests</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-sanity-itcase</artifactId>
+
+    <properties>
+        <testcontainers.version>1.12.5</testcontainers.version>
+    </properties>
+
+    <dependencies>
+        <!-- Stateful Functions -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-kafka-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Protobuf -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>${protoc-jar-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.apache.flink.statefun.examples.greeter.generated</excludePackageNames>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/Constants.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/Constants.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Command;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.StateSnapshot;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+
+final class Constants {
+
+  private Constants() {}
+
+  static final String KAFKA_BROKER_HOST = "kafka-broker";
+
+  static final IngressIdentifier<Command> COMMAND_INGRESS_ID =
+      new IngressIdentifier<>(Command.class, "org.apache.flink.itcases.sanity", "commands");
+  static final EgressIdentifier<StateSnapshot> STATE_SNAPSHOT_EGRESS_ID =
+      new EgressIdentifier<>(
+          "org.apache.flink.itcases.sanity", "state-snapshots", StateSnapshot.class);
+
+  static final FunctionType[] FUNCTION_TYPES =
+      new FunctionType[] {
+        new FunctionType("org.apache.flink.itcases.sanity", "t0"),
+        new FunctionType("org.apache.flink.itcases.sanity", "t1")
+      };
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/FnCommandResolver.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/FnCommandResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import static org.apache.flink.statefun.itcases.sanity.Utils.toSdkAddress;
+
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Command;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.FnAddress;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Modify;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Noop;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Send;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.StateSnapshot;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.annotations.Persisted;
+import org.apache.flink.statefun.sdk.match.MatchBinder;
+import org.apache.flink.statefun.sdk.match.StatefulMatchFunction;
+import org.apache.flink.statefun.sdk.state.PersistedValue;
+
+/**
+ * Simple stateful function that performs actions according to the command received.
+ *
+ * <ul>
+ *   <li>{@link Noop} command: does not do anything.
+ *   <li>{@link Send} command: sends a specified command to another function.
+ *   <li>{@link Modify} command: increments state value by a specified amount, and then reflects the
+ *       new state value to an egress as a {@link StateSnapshot} message.
+ * </ul>
+ */
+public final class FnCommandResolver extends StatefulMatchFunction {
+
+  /** Represents the {@link FunctionType} that this function is bound to. */
+  private final int fnTypeIndex;
+
+  FnCommandResolver(int fnTypeIndex) {
+    this.fnTypeIndex = fnTypeIndex;
+  }
+
+  @Persisted
+  private final PersistedValue<Integer> state = PersistedValue.of("state", Integer.class);
+
+  @Override
+  public void configure(MatchBinder binder) {
+    binder
+        .predicate(Command.class, Command::hasNoop, this::noop)
+        .predicate(Command.class, Command::hasSend, this::send)
+        .predicate(Command.class, Command::hasModify, this::modify);
+  }
+
+  private void send(Context context, Command command) {
+    for (Command send : command.getSend().getCommandToSendList()) {
+      Address to = toSdkAddress(send.getTarget());
+      context.send(to, send);
+    }
+  }
+
+  private void modify(Context context, Command command) {
+    Modify modify = command.getModify();
+
+    final int nextState =
+        state.updateAndGet(old -> old == null ? modify.getDelta() : old + modify.getDelta());
+
+    // reflect state changes to egress
+    final FnAddress self = selfFnAddress(context);
+    final StateSnapshot result =
+        StateSnapshot.newBuilder().setFrom(self).setState(nextState).build();
+
+    context.send(Constants.STATE_SNAPSHOT_EGRESS_ID, result);
+  }
+
+  @SuppressWarnings("unused")
+  private void noop(Context context, Object ignored) {
+    // nothing to do
+  }
+
+  private FnAddress selfFnAddress(Context context) {
+    return FnAddress.newBuilder().setType(fnTypeIndex).setId(context.self().id()).build();
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/KafkaIO.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/KafkaIO.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import java.util.Objects;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Command;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.StateSnapshot;
+import org.apache.flink.statefun.sdk.io.EgressSpec;
+import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaEgressBuilder;
+import org.apache.flink.statefun.sdk.kafka.KafkaEgressSerializer;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+final class KafkaIO {
+
+  static final String COMMAND_TOPIC_NAME = "commands";
+  static final String STATE_SNAPSHOTS_TOPIC_NAME = "state-snapshots";
+
+  private final String kafkaAddress;
+
+  KafkaIO(String kafkaAddress) {
+    this.kafkaAddress = Objects.requireNonNull(kafkaAddress);
+  }
+
+  IngressSpec<Command> getIngressSpec() {
+    return KafkaIngressBuilder.forIdentifier(Constants.COMMAND_INGRESS_ID)
+        .withKafkaAddress(kafkaAddress)
+        .withConsumerGroupId("sanity-itcase")
+        .withTopic(COMMAND_TOPIC_NAME)
+        .withDeserializer(CommandKafkaDeserializer.class)
+        .withStartupPosition(KafkaIngressStartupPosition.fromEarliest())
+        .build();
+  }
+
+  EgressSpec<StateSnapshot> getEgressSpec() {
+    return KafkaEgressBuilder.forIdentifier(Constants.STATE_SNAPSHOT_EGRESS_ID)
+        .withKafkaAddress(kafkaAddress)
+        .withSerializer(StateSnapshotKafkaSerializer.class)
+        .build();
+  }
+
+  private static final class CommandKafkaDeserializer implements KafkaIngressDeserializer<Command> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Command deserialize(ConsumerRecord<byte[], byte[]> input) {
+      try {
+        return Command.parseFrom(input.value());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static final class StateSnapshotKafkaSerializer
+      implements KafkaEgressSerializer<StateSnapshot> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public ProducerRecord<byte[], byte[]> serialize(StateSnapshot stateSnapshot) {
+      final byte[] key = stateSnapshot.getFrom().toByteArray();
+      final byte[] value = stateSnapshot.toByteArray();
+
+      return new ProducerRecord<>(STATE_SNAPSHOTS_TOPIC_NAME, key, value);
+    }
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationModule.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationModule.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import static org.apache.flink.statefun.itcases.sanity.Utils.toSdkAddress;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+
+/**
+ * A simple application used for sanity verification.
+ *
+ * <p>The application reads commands from a Kafka ingress, binds multiple functions that reacts to
+ * the commands (see class-level Javadoc) of {@link SanityVerificationModule} for a full description
+ * on the set of commands), and reflects any state updates in the functions back to a Kafka egress.
+ */
+@AutoService(StatefulFunctionModule.class)
+public class SanityVerificationModule implements StatefulFunctionModule {
+
+  private static final String KAFKA_ADDRESS = Constants.KAFKA_BROKER_HOST + ":9092";
+
+  @Override
+  public void configure(Map<String, String> globalConfiguration, Binder binder) {
+    configureKafkaIO(binder);
+    configureCommandRouter(binder);
+    configureCommandResolverFunctions(binder);
+  }
+
+  private static void configureKafkaIO(Binder binder) {
+    final KafkaIO kafkaIO = new KafkaIO(KAFKA_ADDRESS);
+    binder.bindIngress(kafkaIO.getIngressSpec());
+    binder.bindEgress(kafkaIO.getEgressSpec());
+  }
+
+  private static void configureCommandRouter(Binder binder) {
+    binder.bindIngressRouter(
+        Constants.COMMAND_INGRESS_ID,
+        (command, downstream) -> {
+          Address target = toSdkAddress(command.getTarget());
+          downstream.forward(target, command);
+        });
+  }
+
+  private static void configureCommandResolverFunctions(Binder binder) {
+    int index = 0;
+    for (FunctionType functionType : Constants.FUNCTION_TYPES) {
+      final int typeIndex = index;
+      binder.bindFunctionProvider(functionType, ignored -> new FnCommandResolver(typeIndex));
+      index++;
+    }
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/Utils.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/Utils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import static org.apache.flink.statefun.itcases.sanity.Constants.FUNCTION_TYPES;
+
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+
+final class Utils {
+
+  private Utils() {}
+
+  static Address toSdkAddress(VerificationMessages.FnAddress target) {
+    FunctionType targetType = FUNCTION_TYPES[target.getType()];
+    return new Address(targetType, target.getId());
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/protobuf/verification-messages.proto
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/protobuf/verification-messages.proto
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package org.apache.flink.statefun.itcases.sanity;
+option java_package = "org.apache.flink.statefun.itcases.sanity.generated";
+option java_multiple_files = false;
+
+/*
+ * A command is addressed to a specific target funcction and triggers some action by that target.
+ * Commands can be nested to an arbitrary depth.
+ */
+message Command {
+    FnAddress target = 1;
+
+    oneof kind {
+        Noop noop = 2;
+        Send send = 3;
+        Modify modify = 4;
+    }
+}
+
+/*
+ * Sent by functions to egress after modifying its state.
+ */
+message StateSnapshot {
+    FnAddress from = 1;
+    int32 state = 2;
+}
+
+/*
+ * Target function address of commands.
+ */
+message FnAddress {
+    int32 type = 1;
+    string id = 2;
+}
+
+/*
+ * Modify the function's state by adding @delta to it's state.
+ */
+message Modify {
+    int32 delta = 1;
+}
+
+/*
+ * Send 1 or more commands to different recipients.
+ */
+message Send {
+    repeated Command commandToSend = 2;
+}
+
+/*
+ * A dummy command, does not require any action by the recipient.
+ */
+message Noop {
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationITCase.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationITCase.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Command;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.FnAddress;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Modify;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Noop;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Send;
+import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.StateSnapshot;
+import org.apache.flink.statefun.itcases.sanity.testutils.StatefulFunctionsAppContainers;
+import org.apache.flink.statefun.itcases.sanity.testutils.kafka.KafkaIOVerifier;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+/**
+ * Sanity verification end-to-end test based on the {@link SanityVerificationModule} application.
+ *
+ * <p>The test setups Kafka brokers and the verification application using Docker, sends a few
+ * commands to Kafka to be consumed by the application, and finally verifies that outputs sent to
+ * Kafka from the application are correct.
+ */
+public class SanityVerificationITCase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SanityVerificationITCase.class);
+
+  private static final String CONFLUENT_PLATFORM_VERSION = "5.0.3";
+
+  @Rule
+  public KafkaContainer kafka =
+      new KafkaContainer(CONFLUENT_PLATFORM_VERSION)
+          .withNetworkAliases(Constants.KAFKA_BROKER_HOST);
+
+  @Rule
+  public StatefulFunctionsAppContainers verificationApp =
+      new StatefulFunctionsAppContainers("sanity-verification", 2)
+          .dependsOn(kafka)
+          .exposeMasterLogs(LOG);
+
+  @Test(timeout = 60_000L)
+  public void run() throws Exception {
+    final String kafkaAddress = kafka.getBootstrapServers();
+
+    final Producer<FnAddress, Command> commandProducer = kafkaCommandProducer(kafkaAddress);
+    final Consumer<FnAddress, StateSnapshot> stateSnapshotConsumer =
+        kafkaStateSnapshotConsumer(kafkaAddress);
+
+    final KafkaIOVerifier<FnAddress, Command, FnAddress, StateSnapshot> verifier =
+        new KafkaIOVerifier<>(commandProducer, stateSnapshotConsumer);
+
+    assertThat(
+        verifier.sending(
+            producerRecord(modifyAction(fnAddress(0, "id-1"), 100)),
+            producerRecord(modifyAction(fnAddress(0, "id-2"), 300)),
+            producerRecord(modifyAction(fnAddress(1, "id-3"), 200)),
+            producerRecord(
+                sendAction(fnAddress(1, "id-2"), modifyAction(fnAddress(0, "id-2"), 50))),
+            producerRecord(sendAction(fnAddress(0, "id-1"), noOpAction(fnAddress(1, "id-1"))))),
+        verifier.resultsInOrder(
+            is(stateSnapshot(fnAddress(0, "id-1"), 100)),
+            is(stateSnapshot(fnAddress(0, "id-2"), 300)),
+            is(stateSnapshot(fnAddress(1, "id-3"), 200)),
+            is(stateSnapshot(fnAddress(0, "id-2"), 350))));
+  }
+
+  // =================================================================================
+  //  Kafka IO utility classes and methods
+  // =================================================================================
+
+  private static Producer<FnAddress, Command> kafkaCommandProducer(String bootstrapServers) {
+    Properties props = new Properties();
+    props.put("bootstrap.servers", bootstrapServers);
+
+    return new KafkaProducer<>(
+        props, new ProtobufSerDe<>(FnAddress.parser()), new ProtobufSerDe<>(Command.parser()));
+  }
+
+  private static Consumer<FnAddress, StateSnapshot> kafkaStateSnapshotConsumer(
+      String bootstrapServers) {
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty("bootstrap.servers", bootstrapServers);
+    consumerProps.setProperty("group.id", "sanity-itcase");
+    consumerProps.setProperty("auto.offset.reset", "earliest");
+
+    KafkaConsumer<FnAddress, StateSnapshot> consumer =
+        new KafkaConsumer<>(
+            consumerProps,
+            new ProtobufSerDe<>(FnAddress.parser()),
+            new ProtobufSerDe<>(StateSnapshot.parser()));
+    consumer.subscribe(Collections.singletonList(KafkaIO.STATE_SNAPSHOTS_TOPIC_NAME));
+
+    return consumer;
+  }
+
+  private static final class ProtobufSerDe<T extends Message>
+      implements Serializer<T>, Deserializer<T> {
+
+    private final Parser<T> parser;
+
+    ProtobufSerDe(Parser<T> parser) {
+      this.parser = Objects.requireNonNull(parser);
+    }
+
+    @Override
+    public byte[] serialize(String s, T command) {
+      return command.toByteArray();
+    }
+
+    @Override
+    public T deserialize(String s, byte[] bytes) {
+      try {
+        return parser.parseFrom(bytes);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void configure(Map<String, ?> map, boolean b) {}
+  }
+
+  private static ProducerRecord<FnAddress, Command> producerRecord(Command command) {
+    return new ProducerRecord<>(KafkaIO.COMMAND_TOPIC_NAME, command.getTarget(), command);
+  }
+
+  // =================================================================================
+  //  Protobuf message building utilities
+  // =================================================================================
+
+  private static StateSnapshot stateSnapshot(FnAddress fromFnAddress, int stateSnapshotValue) {
+    return StateSnapshot.newBuilder().setFrom(fromFnAddress).setState(stateSnapshotValue).build();
+  }
+
+  private static Command sendAction(FnAddress targetAddress, Command commandToSend) {
+    final Send sendAction = Send.newBuilder().addCommandToSend(commandToSend).build();
+
+    return Command.newBuilder().setTarget(targetAddress).setSend(sendAction).build();
+  }
+
+  private static Command modifyAction(FnAddress targetAddress, int stateValueDelta) {
+    final Modify modifyAction = Modify.newBuilder().setDelta(stateValueDelta).build();
+
+    return Command.newBuilder().setTarget(targetAddress).setModify(modifyAction).build();
+  }
+
+  private static Command noOpAction(FnAddress targetAddress) {
+    return Command.newBuilder().setTarget(targetAddress).setNoop(Noop.getDefaultInstance()).build();
+  }
+
+  private static FnAddress fnAddress(int typeIndex, String fnId) {
+    if (typeIndex > Constants.FUNCTION_TYPES.length - 1) {
+      throw new IndexOutOfBoundsException(
+          "Type index is out of bounds. Max index: " + (Constants.FUNCTION_TYPES.length - 1));
+    }
+    return FnAddress.newBuilder().setType(typeIndex).setId(fnId).build();
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/testutils/StatefulFunctionsAppContainers.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/testutils/StatefulFunctionsAppContainers.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity.testutils;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * A JUnit {@link org.junit.rules.TestRule} that setups a containerized Stateful Functions
+ * application using <a href="https://www.testcontainers.org/">Testcontainers</a>. This allows
+ * composing end-to-end tests for Stateful Functions applications easier, by managing the
+ * containerized application as an external test resource whose lifecycle is integrated with the
+ * JUnit test framework.
+ *
+ * <h2>Example usage</h2>
+ *
+ * <pre>{@code
+ * public class MyITCase {
+ *
+ *     {@code @Rule}
+ *     public StatefulFunctionsAppContainers myApp =
+ *         new StatefulFunctionsAppContainers("app-name", 3);
+ *
+ *     {@code @Test}
+ *     public void runTest() {
+ *         // the containers for the app, including master and workers, will already be running
+ *         // before the test is run; implement your test logic against the app
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>In most cases you'd also need to start an additional system for the test, for example starting
+ * a container that runs Kafka from which the application depends on as an ingress or egress. The
+ * following demonstrates adding a Kafka container to the setup:
+ *
+ * <pre>{@code
+ * public class MyKafkaITCase {
+ *
+ *     {@code @Rule}
+ *     public KafkaContainer kafka = new KafkaContainer();
+ *
+ *     {@code @Rule}
+ *     public StatefulFunctionsAppContainers myApp =
+ *         new StatefulFunctionsAppContainers("app-name", 3)
+ *             .dependsOn(kafka);
+ *
+ *     ...
+ * }
+ * }</pre>
+ *
+ * <p>Application master and worker containers will always be started after containers that are
+ * added using {@link #dependsOn(GenericContainer)} have started. Moreover, containers being
+ * depended on will also be setup such that they share the same network with the master and workers,
+ * so that they can freely communicate with each other.
+ *
+ * <h2>Prerequisites</h2>
+ *
+ * <p>Since Testcontainers uses Docker, it is required that you have Docker installed for this test
+ * rule to work.
+ *
+ * <p>When building the Docker image for the Stateful Functions application under test, the
+ * following files are added to the build context:
+ *
+ * <uL>
+ *   <li>The {@code Dockerfile} found at path {@code /Dockerfile} in the classpath. This is required
+ *       to be present. A simple way is to add the Dockerfile to the test resources directory. This
+ *       will be added to the root of the Docker image build context.
+ *   <li>The {@code flink-conf.yaml} found at path {@code /flink-conf.yaml} in the classpath, if
+ *       any. You can also add this to the test resources directory. This will be added to the root
+ *       of the Docker image build context.
+ *   <li>All built artifacts under the generated {@code target} folder for the project module that
+ *       the test resides in. This is required to be present, so this entails that the tests can
+ *       only be ran after artifacts are built. The built artifacts are added to the root of the
+ *       Docker image build context.
+ * </uL>
+ */
+public final class StatefulFunctionsAppContainers extends ExternalResource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StatefulFunctionsAppContainers.class);
+
+  private static final String MASTER_HOST = "statefun-app-master";
+  private static final String WORKER_HOST_PREFIX = "statefun-app-worker";
+
+  private final Network network;
+  private final GenericContainer master;
+  private final List<GenericContainer> workers;
+
+  public StatefulFunctionsAppContainers(String appName, int numWorkers) {
+    if (appName == null || appName.isEmpty()) {
+      throw new IllegalArgumentException(
+          "App name must be non-empty. This is used as the application image name.");
+    }
+    if (numWorkers < 1) {
+      throw new IllegalArgumentException("Must have at least 1 worker.");
+    }
+
+    this.network = Network.newNetwork();
+
+    final ImageFromDockerfile appImage = appImage(appName);
+    this.master = masterContainer(appImage, network);
+    this.workers = workerContainers(appImage, numWorkers, network);
+  }
+
+  public StatefulFunctionsAppContainers dependsOn(GenericContainer container) {
+    container.withNetwork(network);
+    master.dependsOn(container);
+    return this;
+  }
+
+  public StatefulFunctionsAppContainers exposeMasterLogs(Logger logger) {
+    master.withLogConsumer(new Slf4jLogConsumer(logger, true));
+    return this;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    master.start();
+    workers.forEach(GenericContainer::start);
+  }
+
+  @Override
+  protected void after() {
+    master.stop();
+    workers.forEach(GenericContainer::stop);
+  }
+
+  private static ImageFromDockerfile appImage(String appName) {
+    final Path targetDirPath = Paths.get(System.getProperty("user.dir") + "/target/");
+    LOG.info("Building app image with built artifacts located at: {}", targetDirPath);
+
+    final ImageFromDockerfile appImage =
+        new ImageFromDockerfile(appName)
+            .withFileFromClasspath("Dockerfile", "Dockerfile")
+            .withFileFromPath(".", targetDirPath);
+    if (flinkConfYamlExists()) {
+      appImage.withFileFromClasspath("flink-conf.yaml", "flink-conf.yaml");
+    }
+
+    return appImage;
+  }
+
+  private static boolean flinkConfYamlExists() {
+    final URL flinkConfUrl = StatefulFunctionsAppContainers.class.getResource("/flink-conf.yaml");
+    return flinkConfUrl != null;
+  }
+
+  private static GenericContainer masterContainer(ImageFromDockerfile appImage, Network network) {
+    return new GenericContainer(appImage)
+        .withNetwork(network)
+        .withNetworkAliases(MASTER_HOST)
+        .withEnv("ROLE", "master")
+        .withEnv("MASTER_HOST", MASTER_HOST);
+  }
+
+  private static List<GenericContainer> workerContainers(
+      ImageFromDockerfile appImage, int numWorkers, Network network) {
+    final List<GenericContainer> workers = new ArrayList<>(numWorkers);
+
+    for (int i = 0; i < numWorkers; i++) {
+      workers.add(
+          new GenericContainer(appImage)
+              .withNetwork(network)
+              .withNetworkAliases(workerHostOf(i))
+              .withEnv("ROLE", "worker")
+              .withEnv("MASTER_HOST", MASTER_HOST));
+    }
+
+    return workers;
+  }
+
+  private static String workerHostOf(int workerIndex) {
+    return WORKER_HOST_PREFIX + "-" + workerIndex;
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/testutils/kafka/KafkaIOVerifier.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/testutils/kafka/KafkaIOVerifier.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.itcases.sanity.testutils.kafka;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * A utility to make test assertions by means of writing inputs to Kafka, and then matching on
+ * outputs read from Kafka.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * KafkaProducer<String, Integer> producer = ...
+ * KafkaConsumer<String, Boolean> consumer = ...
+ *
+ * KafkaIOVerifier<String, Integer, String, Boolean> verifier =
+ *     new KafkaIOVerifier(producer, consumer);
+ *
+ * assertThat(
+ *     verifier.sending(
+ *         new ProducerRecord<>("topic", "key-1", 1991),
+ *         new ProducerRecord<>("topic", "key-2", 1108)
+ *     ), verifier.resultsInOrder(
+ *         true, false, true, true
+ *     )
+ * );
+ * }</pre>
+ *
+ * @param <PK> key type of input records written to Kafka
+ * @param <PV> value type of input records written to Kafka
+ * @param <CK> key type of output records read from Kafka
+ * @param <CV> value type of output records read from Kafka
+ */
+public final class KafkaIOVerifier<PK, PV, CK, CV> {
+
+  private final Producer<PK, PV> producer;
+  private final Consumer<CK, CV> consumer;
+
+  /**
+   * Creates a verifier.
+   *
+   * @param producer producer to use to write input records to Kafka.
+   * @param consumer consumer to use for reading output records from Kafka.
+   */
+  public KafkaIOVerifier(Producer<PK, PV> producer, Consumer<CK, CV> consumer) {
+    this.producer = Objects.requireNonNull(producer);
+    this.consumer = Objects.requireNonNull(consumer);
+  }
+
+  /**
+   * Writes to Kafka multiple assertion input producer records, in the given order.
+   *
+   * <p>The results of calling this method should be asserted using {@link
+   * #resultsInOrder(Matcher[])}. In the background, the provided Kafka consumer will be used to
+   * continuously poll output records. For each assertion input provided via this method, you must
+   * consequently use {@link #resultsInOrder(Matcher[])} to complete the assertion, which then stops
+   * the consumer from polling Kafka.
+   *
+   * @param assertionInputs assertion input producer records to send to Kafka.
+   * @return resulting outputs consumed from Kafka that can be asserted using {@link
+   *     #resultsInOrder(Matcher[])}.
+   */
+  @SafeVarargs
+  public final OutputsHandoff<CV> sending(ProducerRecord<PK, PV>... assertionInputs) {
+    CompletableFuture.runAsync(
+        () -> {
+          for (ProducerRecord<PK, PV> input : assertionInputs) {
+            producer.send(input);
+          }
+          producer.flush();
+        });
+
+    final OutputsHandoff<CV> outputsHandoff = new OutputsHandoff<>();
+
+    CompletableFuture.runAsync(
+        () -> {
+          while (!outputsHandoff.isVerified()) {
+            ConsumerRecords<CK, CV> consumerRecords = consumer.poll(Duration.ofMillis(100));
+            for (ConsumerRecord<CK, CV> record : consumerRecords) {
+              outputsHandoff.add(record.value());
+            }
+          }
+        });
+
+    return outputsHandoff;
+  }
+
+  /**
+   * Matcher for verifying the outputs as a result of calling {@link #sending(ProducerRecord[])}.
+   *
+   * @param expectedResults matchers for the expected results.
+   * @return a matcher for verifying the output of calling {@link #sending(ProducerRecord[])}.
+   */
+  @SafeVarargs
+  public final Matcher<OutputsHandoff<CV>> resultsInOrder(Matcher<CV>... expectedResults) {
+    return new TypeSafeMatcher<OutputsHandoff<CV>>() {
+      @Override
+      protected boolean matchesSafely(OutputsHandoff<CV> outputHandoff) {
+        try {
+          for (Matcher<CV> r : expectedResults) {
+            CV output = outputHandoff.take();
+            if (!r.matches(output)) {
+              return false;
+            }
+          }
+
+          // any dangling unexpected output should count as a mismatch
+          // TODO should we poll with timeout for a stronger verification?
+          return outputHandoff.peek() == null;
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        } finally {
+          outputHandoff.verified();
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {}
+    };
+  }
+
+  private static final class OutputsHandoff<T> extends LinkedBlockingQueue<T> {
+    private volatile boolean isVerified;
+
+    boolean isVerified() {
+      return isVerified;
+    }
+
+    void verified() {
+      this.isVerified = true;
+    }
+  }
+}

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/Dockerfile
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/Dockerfile
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM statefun
+
+RUN mkdir -p /opt/statefun/modules/statefun-sanity-itcase
+COPY statefun-sanity-itcase*.jar /opt/statefun/modules/statefun-sanity-itcase/
+COPY flink-conf.yaml $FLINK_HOME/conf/flink-conf.yaml

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/flink-conf.yaml
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/flink-conf.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is the base for the Apache Flink configuration
+
+# this allows us to test local as well as remote function messaging
+parallelism.default: 2
+
+classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+state.backend: rocksdb
+state.backend.rocksdb.timer-service.factory: ROCKSDB
+state.checkpoints.dir: file:///checkpoint-dir
+state.backend.incremental: true
+taskmanager.memory.process.size: 4g

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/log4j.properties
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+# Log all infos in the given file
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n


### PR DESCRIPTION
This PR achieves the following goals:
- Adds a `statefun-integration-tests` module that is meant to maintain integration tests in the future.
- Adds `statefun-sanity-itcase` to the integration tests module, which includes a simple application used for sanity verification and a JUnit-driven test that performs the verification over a docker setup.
- Adds a Maven build profile so that the integration tests can be run with a simple command: `mvn clean verify -Prun-integration-tests`

---

### The verification app and test

The verification app (`SanityVerificationModule`) is a simple application used for sanity verification.
- The application reads commands from a Kafka ingress
- Has multiple functions binded (currently 2 in this PR) that reacts to the commands (see class-level Javadoc) of `SanityVerificationModule` for a full description on the set of commands)
- Reflects any state updates in the functions back to a Kafka egress.

The Junit-driven test does the following:
- Uses Testcontainers (https://www.testcontainers.org/) to start a Kafka broker, builds the image for the verification app on the fly and also starts a master + worker container for the app.
- Writes some commands to the Kafka ingress topic
- Reads state outputs for the Kafka egress topic, and verifies that they are correct

Right now the test scenario does not have any randomization to it.
We may consider to add that in the future as a follow-up.

---

### Maven `run-integration-tests` build profile and structure setup

With this PR, to add new container-based integration tests in the future, a developer has to do the following:
- Add a new sub-module under `statefun-integration-tests`
- Add source code for the Stateful Functions application to test against
- Add a test class named with the pattern `*ITCase` that setups the containers using testcontainers, and implements the test verification logic as a JUnit test. The classname pattern is important because only then would it be skipped by the unit test phase, and only kicks in with the `run-integration-tests` profile.

To build while also running the integration tests, one simply does:
`mvn clean verify -Prun-integration-tests` in the project root directory.

This always re-builds the base Stateful Functions image before running the ITCases.

---

### Integrating with CI

This is not yet integrated with CI.
We want to do that after we have more confidence that the tests are reliable.
Once we decide to do that, it would be as simple as enabling the build profile in the build commands.