### PR TITLE
 [FLINK-16063] Add simple backpressure

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/AsyncWaiter.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/AsyncWaiter.java
@@ -27,6 +27,13 @@ public interface AsyncWaiter {
    * Signals the runtime to stop invoking the currently executing function with new input until at
    * least one {@link org.apache.flink.statefun.sdk.AsyncOperationResult} belonging to this function
    * would be delivered.
+   *
+   * <p>NOTE: If a function would request to block without actually registering any async operations
+   * either previously or during its current invocation, then it would remain blocked. Since this is
+   * an internal API to be used by the remote functions we don't do anything to prevent that.
+   *
+   * <p>If we would like it to be a part of the SDK then we would have to make sure that we track
+   * every async operation registered per each address.
    */
   void awaitAsyncOperationComplete();
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/AsyncWaiter.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/AsyncWaiter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.backpressure;
+
+import org.apache.flink.annotation.Internal;
+
+@Internal
+public interface AsyncWaiter {
+
+  /**
+   * Signals the runtime to stop invoking the currently executing function with new input until at
+   * least one {@link org.apache.flink.statefun.sdk.AsyncOperationResult} belonging to this function
+   * would be delivered.
+   */
+  void awaitAsyncOperationComplete();
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
@@ -45,7 +45,10 @@ public interface BackPressureValve {
 
   /**
    * Requests to stop processing any further input for that address, as long as there is an
-   * uncompleted async operation (owned by @address).
+   * uncompleted async operation (registered by @address).
+   *
+   * <p>NOTE: The address would unblocked as soon as some (one) async operation registered by that
+   * address completes.
    *
    * @param address the address
    */

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.backpressure;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.Address;
+
+public interface BackPressureValve {
+
+  /**
+   * Indicates rather a back pressure is needed.
+   *
+   * @return true if a back pressure should be applied.
+   */
+  boolean shouldBackPressure();
+
+  /**
+   * Notifies the back pressure mechanism that a async operation was registered via {@link
+   * org.apache.flink.statefun.sdk.Context#registerAsyncOperation(Object, CompletableFuture)}.
+   */
+  void notifyAsyncOperationRegistered();
+
+  /**
+   * Notifies when a async operation, registered by @owningAddress was completed.
+   *
+   * @param owningAddress the owner of the completed async operation.
+   */
+  void notifyAsyncOperationCompleted(Address owningAddress);
+
+  /**
+   * Requests to stop processing any further input for that address, as long as there is an
+   * uncompleted async operation (owned by @address).
+   *
+   * @param address the address
+   */
+  void blockAddress(Address address);
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.backpressure;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashMap;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.Address;
+
+/** A simple Threshold based {@link BackPressureValve}. */
+public final class ThresholdBackPressureValve implements BackPressureValve {
+  private final int maximumPendingAsynchronousOperations;
+
+  private int pendingAsynchronousOperationsCount;
+  private ObjectOpenHashMap<Address, Boolean> blockedAddress = new ObjectOpenHashMap<>();
+
+  /**
+   * Constructs a ThresholdBackPressureValve.
+   *
+   * @param maximumPendingAsynchronousOperations the total allowed async operations to be inflight
+   *     per StreamTask, or {@code -1} to disable back pressure.
+   */
+  public ThresholdBackPressureValve(int maximumPendingAsynchronousOperations) {
+    this.maximumPendingAsynchronousOperations = maximumPendingAsynchronousOperations;
+  }
+
+  public boolean shouldBackPressure() {
+    return totalPendingAsyncOperationsAtCapacity() || hasBlockedAddress();
+  }
+
+  public void blockAddress(Address address) {
+    Objects.requireNonNull(address);
+    blockedAddress.put(address, Boolean.TRUE);
+  }
+
+  public void notifyAsyncOperationRegistered() {
+    pendingAsynchronousOperationsCount++;
+  }
+
+  public void notifyAsyncOperationCompleted(Address owningAddress) {
+    Objects.requireNonNull(owningAddress);
+    pendingAsynchronousOperationsCount--;
+    blockedAddress.remove(owningAddress);
+  }
+
+  private boolean totalPendingAsyncOperationsAtCapacity() {
+    return maximumPendingAsynchronousOperations > 0
+        && pendingAsynchronousOperationsCount >= maximumPendingAsynchronousOperations;
+  }
+
+  private boolean hasBlockedAddress() {
+    return !blockedAddress.isEmpty();
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
@@ -84,7 +84,7 @@ public final class ThresholdBackPressureValve implements BackPressureValve {
   @Override
   public void notifyAsyncOperationCompleted(Address owningAddress) {
     Objects.requireNonNull(owningAddress);
-    pendingAsynchronousOperationsCount--;
+    pendingAsynchronousOperationsCount = Math.max(0, pendingAsynchronousOperationsCount - 1);
     blockedAddressSet.remove(owningAddress);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverses;
+import org.apache.flink.statefun.flink.core.backpressure.ThresholdBackPressureValve;
 import org.apache.flink.statefun.flink.core.common.MailboxExecutorFacade;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
@@ -95,11 +96,15 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
 
     Objects.requireNonNull(mailboxExecutor, "MailboxExecutor is unexpectedly NULL");
 
+    // TODO: once FLINK-16149 would be merged, we should pass the threshold as a configuration.
+    ThresholdBackPressureValve thresholdBackPressureValve = new ThresholdBackPressureValve(1_000);
+
     //
     // the core logic of applying messages to functions.
     //
     this.reductions =
         Reductions.create(
+            thresholdBackPressureValve,
             statefulFunctionsUniverse,
             getRuntimeContext(),
             getKeyedStateBackend(),

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -101,8 +101,8 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
 
     Objects.requireNonNull(mailboxExecutor, "MailboxExecutor is unexpectedly NULL");
 
-    // TODO: once FLINK-16149 would be merged, we should pass the threshold as a configuration.
-    this.backPressureValve = new ThresholdBackPressureValve(-1);
+    this.backPressureValve =
+        new ThresholdBackPressureValve(configuration.getMaxAsyncOperationsPerTask());
 
     //
     // the core logic of applying messages to functions.

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -102,7 +102,7 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
     Objects.requireNonNull(mailboxExecutor, "MailboxExecutor is unexpectedly NULL");
 
     // TODO: once FLINK-16149 would be merged, we should pass the threshold as a configuration.
-    this.backPressureValve = new ThresholdBackPressureValve(1_000);
+    this.backPressureValve = new ThresholdBackPressureValve(-1);
 
     //
     // the core logic of applying messages to functions.

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverses;
+import org.apache.flink.statefun.flink.core.backpressure.BackPressureValve;
 import org.apache.flink.statefun.flink.core.backpressure.ThresholdBackPressureValve;
 import org.apache.flink.statefun.flink.core.common.MailboxExecutorFacade;
 import org.apache.flink.statefun.flink.core.message.Message;
@@ -55,6 +56,7 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
   // -- runtime
   private transient Reductions reductions;
   private transient MailboxExecutor mailboxExecutor;
+  private transient BackPressureValve backPressureValve;
 
   FunctionGroupOperator(
       Map<EgressIdentifier<?>, OutputTag<Object>> sideOutputs,
@@ -72,7 +74,10 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
   // ------------------------------------------------------------------------------------------------------------------
 
   @Override
-  public void processElement(StreamRecord<Message> record) {
+  public void processElement(StreamRecord<Message> record) throws InterruptedException {
+    while (backPressureValve.shouldBackPressure()) {
+      mailboxExecutor.yield();
+    }
     reductions.apply(record.getValue());
   }
 
@@ -97,14 +102,14 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
     Objects.requireNonNull(mailboxExecutor, "MailboxExecutor is unexpectedly NULL");
 
     // TODO: once FLINK-16149 would be merged, we should pass the threshold as a configuration.
-    ThresholdBackPressureValve thresholdBackPressureValve = new ThresholdBackPressureValve(1_000);
+    this.backPressureValve = new ThresholdBackPressureValve(1_000);
 
     //
     // the core logic of applying messages to functions.
     //
     this.reductions =
         Reductions.create(
-            thresholdBackPressureValve,
+            backPressureValve,
             statefulFunctionsUniverse,
             getRuntimeContext(),
             getKeyedStateBackend(),

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -26,6 +26,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
+import org.apache.flink.statefun.flink.core.backpressure.BackPressureValve;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Lazy;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
@@ -51,6 +52,7 @@ final class Reductions {
   }
 
   static Reductions create(
+      BackPressureValve valve,
       StatefulFunctionsUniverse statefulFunctionsUniverse,
       RuntimeContext context,
       KeyedStateBackend<Object> keyedStateBackend,
@@ -115,6 +117,8 @@ final class Reductions {
     // for the async operations
     container.add("async-operations", MapState.class, asyncOperations);
     container.add(AsyncSink.class);
+
+    container.add("backpressure-valve", BackPressureValve.class, valve);
 
     return container.get(Reductions.class);
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.statefun.flink.core.functions;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.flink.core.backpressure.AsyncWaiter;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.flink.core.message.Message;
@@ -28,7 +29,7 @@ import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 
-final class ReusableContext implements ApplyingContext {
+final class ReusableContext implements ApplyingContext, AsyncWaiter {
   private final Partition thisPartition;
   private final LocalSink localSink;
   private final RemoteSink remoteSink;
@@ -113,6 +114,11 @@ final class ReusableContext implements ApplyingContext {
 
     Message message = messageFactory.from(self(), self(), metadata);
     asyncSink.accept(message, future);
+  }
+
+  @Override
+  public void awaitAsyncOperationComplete() {
+    asyncSink.blockAddress(self());
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValveTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValveTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.backpressure;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.flink.statefun.flink.core.TestUtils;
+import org.junit.Test;
+
+public class ThresholdBackPressureValveTest {
+
+  @Test
+  public void simpleUsage() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(2);
+
+    valve.notifyAsyncOperationRegistered();
+    valve.notifyAsyncOperationRegistered();
+
+    assertTrue(valve.shouldBackPressure());
+  }
+
+  @Test
+  public void completedOperationReleaseBackpressure() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(1);
+
+    valve.notifyAsyncOperationRegistered();
+    valve.notifyAsyncOperationCompleted(TestUtils.FUNCTION_1_ADDR);
+
+    assertFalse(valve.shouldBackPressure());
+  }
+
+  @Test
+  public void blockAddressTriggerBackpressure() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(500);
+
+    valve.blockAddress(TestUtils.FUNCTION_1_ADDR);
+
+    assertTrue(valve.shouldBackPressure());
+  }
+
+  @Test
+  public void blockingAndUnblockingAddress() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(500);
+
+    valve.blockAddress(TestUtils.FUNCTION_1_ADDR);
+    valve.notifyAsyncOperationCompleted(TestUtils.FUNCTION_1_ADDR);
+
+    assertFalse(valve.shouldBackPressure());
+  }
+
+  @Test
+  public void unblockingDifferentAddressStillBackpressures() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(500);
+
+    valve.blockAddress(TestUtils.FUNCTION_1_ADDR);
+    valve.notifyAsyncOperationCompleted(TestUtils.FUNCTION_2_ADDR);
+
+    assertTrue(valve.shouldBackPressure());
+  }
+
+  @Test
+  public void blockTwoAddress() {
+    ThresholdBackPressureValve valve = new ThresholdBackPressureValve(500);
+
+    valve.blockAddress(TestUtils.FUNCTION_1_ADDR);
+    valve.blockAddress(TestUtils.FUNCTION_2_ADDR);
+    assertTrue(valve.shouldBackPressure());
+
+    valve.notifyAsyncOperationCompleted(TestUtils.FUNCTION_1_ADDR);
+    assertTrue(valve.shouldBackPressure());
+
+    valve.notifyAsyncOperationCompleted(TestUtils.FUNCTION_2_ADDR);
+    assertFalse(valve.shouldBackPressure());
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.TestUtils;
+import org.apache.flink.statefun.flink.core.backpressure.ThresholdBackPressureValve;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
@@ -88,6 +89,7 @@ public class ReductionsTest {
   public void testFactory() {
     Reductions reductions =
         Reductions.create(
+            new ThresholdBackPressureValve(-1),
             new StatefulFunctionsUniverse(MessageFactoryType.WITH_KRYO_PAYLOADS),
             new FakeRuntimeContext(),
             new FakeKeyedStateBackend(),


### PR DESCRIPTION
# This PR adds a simple backpressure mechanism.
There are two ways that a backpressure can be triggered:
1. When the number of asynchronous operations per task exceeds a predefined threshold[1]
2. When a prebuilt internal function requires to backpressure a specific address[2]
via calling an internal method on `ReusableContext`.

Please note that, currently if a single function instance requires backpressure, then the result is that all other functions scheduled into the same operator are blocked.

[1] currently that threshold is disabled, and it would be wired in once #27 would be merged. 
[2] Although the API allows blocking for a specific address, in the current implementation all the input (for all the addresses) would be blocked.