### PR TITLE
[FLINK-16226] Add Backpressure to HttpFunction

### DIFF
--- a/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/Selectors.java
+++ b/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/Selectors.java
@@ -52,6 +52,17 @@ public final class Selectors {
     return node.asInt();
   }
 
+  public static OptionalInt optionalIntegerAt(JsonNode node, JsonPointer pointer) {
+    node = node.at(pointer);
+    if (node.isMissingNode()) {
+      return OptionalInt.empty();
+    }
+    if (!node.isInt()) {
+      throw new WrongTypeException(pointer, "not an integer");
+    }
+    return OptionalInt.of(node.asInt());
+  }
+
   public static Iterable<? extends JsonNode> listAt(JsonNode node, JsonPointer pointer) {
     node = node.at(pointer);
     if (node.isMissingNode()) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
@@ -29,13 +29,19 @@ public final class HttpFunctionSpec implements FunctionSpec {
   private final URI endpoint;
   private final List<String> states;
   private final Duration maxRequestDuration;
+  private final int maxBatchSize;
 
   public HttpFunctionSpec(
-      FunctionType functionType, URI endpoint, List<String> states, Duration maxRequestDuration) {
+      FunctionType functionType,
+      URI endpoint,
+      List<String> states,
+      Duration maxRequestDuration,
+      int maxBatchSize) {
     this.functionType = Objects.requireNonNull(functionType);
     this.endpoint = Objects.requireNonNull(endpoint);
     this.states = Objects.requireNonNull(states);
     this.maxRequestDuration = Objects.requireNonNull(maxRequestDuration);
+    this.maxBatchSize = maxBatchSize;
   }
 
   @Override
@@ -58,5 +64,9 @@ public final class HttpFunctionSpec implements FunctionSpec {
 
   public Duration maxRequestDuration() {
     return maxRequestDuration;
+  }
+
+  public int maxBatchSize() {
+    return maxBatchSize;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -62,6 +62,7 @@ import org.apache.flink.util.TimeUtils;
 
 final class JsonModule implements StatefulFunctionModule {
   private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
+  private static final Integer DEFAULT_MAX_HTTP_BATCH_SIZE = 1000;
   private final JsonNode spec;
   private final URL moduleUrl;
 
@@ -212,12 +213,18 @@ final class JsonModule implements StatefulFunctionModule {
             functionType,
             functionUri(functionNode),
             functionStates(functionNode),
-            maxRequestDuration(functionNode));
+            maxRequestDuration(functionNode),
+            maxBatchSize(functionNode));
       case GRPC:
         return new GrpcFunctionSpec(functionType, functionAddress(functionNode));
       default:
         throw new IllegalArgumentException("Unrecognized function kind " + functionKind);
     }
+  }
+
+  private static int maxBatchSize(JsonNode functionNode) {
+    return Selectors.optionalIntegerAt(functionNode, Functions.FUNCTION_MAX_HTTP_BATCH_SIZE)
+        .orElse(DEFAULT_MAX_HTTP_BATCH_SIZE);
   }
 
   private static Duration maxRequestDuration(JsonNode functionNode) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
@@ -48,6 +48,8 @@ public final class Pointers {
     public static final JsonPointer FUNCTION_STATES = JsonPointer.compile("/function/spec/states");
     public static final JsonPointer FUNCTION_TIMEOUT =
         JsonPointer.compile("/function/spec/timeout");
+    public static final JsonPointer FUNCTION_MAX_HTTP_BATCH_SIZE =
+        JsonPointer.compile("/function/spec/maxBatchSize");
   }
 
   // -------------------------------------------------------------------------------------


### PR DESCRIPTION
## This PR uses the back pressure mechanism introduced in #29 to support back pressure in `HttpFunction`.

## Background  
When an Http remote function (`HttpFunction`) invokes a function remotely for a specific address, it would wait for a response to come back asynchronously. While it waits for 
the response, new messages for that address might arrive, the `HttpFunction` start logging these requests in a persisted state, and when the original request completes the `HttpFunction` would batch these requests and send it off as a single request.

In order to keep that state under control, the `HttpFunction` needs to limit the maximum allowed batch size, this PR provides that.
 

## User supplied property
The first part of this PR adds a property `maxBatchSize` to the function spec in `module.yaml`

```
- function:
          meta:
            kind: http
            type: org.foo/bar
          spec:
           ...
            maxBatch: 10
``` 

This would indicate that the max batch size that would be sent, per address, for the function `org.foo/bar` is limited to 10 messages. Users can also omit that value and then the default value of 1,000 is selected.

