### PR TITLE
[FLINK-16149][hotfix][core] Use GlobalConfigurationLoader on StreamPlanEnvironment

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -30,11 +30,13 @@ import java.util.Objects;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.environment.StreamPlanEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 
 /** Configuration that captures all stateful function related settings. */
@@ -103,8 +105,10 @@ public class StatefulFunctionsConfig implements Serializable {
     return new StatefulFunctionsConfig(configuration);
   }
 
-  @SuppressWarnings("JavaReflectionMemberAccess")
   private static Configuration getConfiguration(StreamExecutionEnvironment env) {
+    if (env instanceof StreamPlanEnvironment) {
+      return GlobalConfiguration.loadConfiguration();
+    }
     try {
       Method getConfiguration =
           StreamExecutionEnvironment.class.getDeclaredMethod("getConfiguration");


### PR DESCRIPTION
This is a follow up to #27 

I noticed when running a container-based deployment that my stateful function-specific configurations were not being respected. Other flink configurations were properly set. 

If you follow the execution path of the stateful-function-launcher, you will see that it calls `PackagedProgramUtils#createJobGraph` which in turn sets an `OptimizerPlanEnvironment`. This is because it uses a Job-based deployment and the OptimizerPlanEnvironment pulls the job graph without executing the job so it can be embedded in the image.

When this execution environment is set, `StreamExecutionEnvironment#getExecutionEnvironment` returns a `StreamPlanEnvironment`. This subclass of `StreamExecutionEnvironment` calls `StreamExecutionEnvironment`'s no-op constructor which sets an empty configuration object. 

Because `StreamPlanEnvironment` implies job-based deployment, we can safely call `GlobalConfiguration#loadConfiguration`. In all other cases we fall back to reflection. 

I have tested this using statefun images and deployed against a session cluster. 

cc @igalshilman @tzulitai 