### PR TITLE
[FLINK-16149][hotfix][core] Use GlobalConfiguration.loadConfiguration() on StreamPlanEnvironment

### DIFF
--- a/statefun-end-to-end-tests/statefun-sanity-itcase/pom.xml
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/pom.xml
@@ -29,6 +29,7 @@ under the License.
 
     <properties>
         <testcontainers.version>1.12.5</testcontainers.version>
+        <flink.version>1.10.0</flink.version>
     </properties>
 
     <dependencies>
@@ -82,6 +83,14 @@ under the License.
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Flink Config -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationModule.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/main/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationModule.java
@@ -36,17 +36,20 @@ import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 @AutoService(StatefulFunctionModule.class)
 public class SanityVerificationModule implements StatefulFunctionModule {
 
-  private static final String KAFKA_ADDRESS = Constants.KAFKA_BROKER_HOST + ":9092";
-
   @Override
   public void configure(Map<String, String> globalConfiguration, Binder binder) {
-    configureKafkaIO(binder);
+    String kafkaAddress = globalConfiguration.get("kafka-broker");
+    if (kafkaAddress == null) {
+      throw new IllegalStateException("Missing required global configuration kafka-broker");
+    }
+
+    configureKafkaIO(kafkaAddress + ":9092", binder);
     configureCommandRouter(binder);
     configureCommandResolverFunctions(binder);
   }
 
-  private static void configureKafkaIO(Binder binder) {
-    final KafkaIO kafkaIO = new KafkaIO(KAFKA_ADDRESS);
+  private static void configureKafkaIO(String kafkaAddress, Binder binder) {
+    final KafkaIO kafkaIO = new KafkaIO(kafkaAddress);
     binder.bindIngress(kafkaIO.getIngressSpec());
     binder.bindEgress(kafkaIO.getEgressSpec());
   }

--- a/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationITCase.java
+++ b/statefun-end-to-end-tests/statefun-sanity-itcase/src/test/java/org/apache/flink/statefun/itcases/sanity/SanityVerificationITCase.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Command;
 import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.FnAddress;
 import org.apache.flink.statefun.itcases.sanity.generated.VerificationMessages.Modify;
@@ -61,6 +62,12 @@ public class SanityVerificationITCase {
 
   private static final String CONFLUENT_PLATFORM_VERSION = "5.0.3";
 
+  private static final Configuration flinkConf = new Configuration();
+
+  static {
+    flinkConf.setString("statefun.module.global-config.kafka-broker", Constants.KAFKA_BROKER_HOST);
+  }
+
   @Rule
   public KafkaContainer kafka =
       new KafkaContainer(CONFLUENT_PLATFORM_VERSION)
@@ -68,7 +75,7 @@ public class SanityVerificationITCase {
 
   @Rule
   public StatefulFunctionsAppContainers verificationApp =
-      new StatefulFunctionsAppContainers("sanity-verification", 2)
+      new StatefulFunctionsAppContainers("sanity-verification", 2, flinkConf)
           .dependsOn(kafka)
           .exposeMasterLogs(LOG);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -30,11 +30,13 @@ import java.util.Objects;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.environment.StreamPlanEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 
 /** Configuration that captures all stateful function related settings. */
@@ -103,8 +105,10 @@ public class StatefulFunctionsConfig implements Serializable {
     return new StatefulFunctionsConfig(configuration);
   }
 
-  @SuppressWarnings("JavaReflectionMemberAccess")
   private static Configuration getConfiguration(StreamExecutionEnvironment env) {
+    if (env instanceof StreamPlanEnvironment) {
+      return GlobalConfiguration.loadConfiguration();
+    }
     try {
       Method getConfiguration =
           StreamExecutionEnvironment.class.getDeclaredMethod("getConfiguration");


### PR DESCRIPTION
This is a follow up to #27 

Because the statefun-flink-launcher is based on JobClusterEntrypoint it
pulls the StreamGraph using a StreamPlanEnvironment. In this case, the
StreamExecutionEnviornment configuration is set to an empty object.

The only way to pull the actual flink-conf in this case is via
GlobalConfiguration.loadConfiguration(). This is safe because
StreamPlanEnvironment implies job based deployment. In all other cases
the configuration is still pulled via reflection.

I've tested this using statefun images and deploying against a local session cluster setting different configurations and verifying that they were used at runtime. 

cc @tzulitai @igalshilman 