### PR TITLE
[FLINK-16123] Add auto-routable Protobuf Kafka ingress

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -50,7 +50,9 @@ import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionProvider;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionSpec;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionSpec.Kind;
 import org.apache.flink.statefun.flink.core.jsonmodule.Pointers.Functions;
+import org.apache.flink.statefun.flink.core.protorouter.AutoRoutableProtobufRouter;
 import org.apache.flink.statefun.flink.core.protorouter.ProtobufRouter;
+import org.apache.flink.statefun.flink.io.kafka.ProtobufKafkaIngressTypes;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.IngressType;
@@ -130,6 +132,10 @@ final class JsonModule implements StatefulFunctionModule {
 
       JsonIngressSpec<Message> ingressSpec = new JsonIngressSpec<>(type, id, ingress);
       binder.bindIngress(ingressSpec);
+
+      if (type.equals(ProtobufKafkaIngressTypes.ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE)) {
+        binder.bindIngressRouter(id, new AutoRoutableProtobufRouter());
+      }
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/protorouter/AutoRoutableProtobufRouter.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/protorouter/AutoRoutableProtobufRouter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.protorouter;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
+import org.apache.flink.statefun.flink.io.kafka.ProtobufKafkaIngressTypes;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.io.Router;
+
+/**
+ * A {@link Router} that recognizes messages of type {@link AutoRoutable}.
+ *
+ * <p>For each incoming {@code AutoRoutable}, this router forwards the wrapped payload to the
+ * configured target addresses as a Protobuf {@link Any} message. This should only be attached to
+ * ingress types of {@link ProtobufKafkaIngressTypes#ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE}.
+ */
+public final class AutoRoutableProtobufRouter implements Router<Message> {
+
+  @Override
+  public void route(Message message, Downstream<Message> downstream) {
+    final AutoRoutable routable = asAutoRoutable(message);
+    for (TargetFunctionType targetFunction : routable.getConfig().getTargetFunctionTypesList()) {
+      downstream.forward(
+          address(targetFunction, routable.getId()),
+          anyPayload(routable.getConfig().getTypeUrl(), routable.getPayloadBytes()));
+    }
+  }
+
+  private static AutoRoutable asAutoRoutable(Message message) {
+    try {
+      return (AutoRoutable) message;
+    } catch (ClassCastException e) {
+      throw new RuntimeException(
+          "This router only expects messages of type " + AutoRoutable.class.getName(), e);
+    }
+  }
+
+  private static Address address(TargetFunctionType targetFunctionType, String id) {
+    return new Address(
+        new FunctionType(targetFunctionType.getNamespace(), targetFunctionType.getType()), id);
+  }
+
+  private static Any anyPayload(String typeUrl, ByteString payloadBytes) {
+    return Any.newBuilder().setTypeUrl(typeUrl).setValue(payloadBytes).build();
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaFlinkIoModule.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaFlinkIoModule.java
@@ -19,7 +19,6 @@ package org.apache.flink.statefun.flink.io.kafka;
 
 import com.google.auto.service.AutoService;
 import java.util.Map;
-
 import org.apache.flink.statefun.flink.io.spi.FlinkIoModule;
 import org.apache.flink.statefun.sdk.kafka.Constants;
 
@@ -31,6 +30,9 @@ public final class KafkaFlinkIoModule implements FlinkIoModule {
     binder.bindSourceProvider(Constants.KAFKA_INGRESS_TYPE, new KafkaSourceProvider());
     binder.bindSourceProvider(
         ProtobufKafkaIngressTypes.PROTOBUF_KAFKA_INGRESS_TYPE, new ProtobufKafkaSourceProvider());
+    binder.bindSourceProvider(
+        ProtobufKafkaIngressTypes.ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE,
+        new RoutableProtobufKafkaSourceProvider());
     binder.bindSinkProvider(Constants.KAFKA_EGRESS_TYPE, new KafkaSinkProvider());
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSpecJsonParser.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSpecJsonParser.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.io.kafka;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.flink.common.json.Selectors;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressAutoResetPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
+import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
+
+/** */
+final class KafkaSpecJsonParser {
+
+  private KafkaSpecJsonParser() {}
+
+  private static final JsonPointer DESCRIPTOR_SET_POINTER =
+      JsonPointer.compile("/ingress/spec/descriptorSet");
+  private static final JsonPointer TOPICS_POINTER = JsonPointer.compile("/ingress/spec/topics");
+  private static final JsonPointer MESSAGE_TYPE_POINTER =
+      JsonPointer.compile("/ingress/spec/messageType");
+  private static final JsonPointer PROPERTIES_POINTER =
+      JsonPointer.compile("/ingress/spec/properties");
+  private static final JsonPointer ADDRESS_POINTER = JsonPointer.compile("/ingress/spec/address");
+  private static final JsonPointer GROUP_ID_POINTER =
+      JsonPointer.compile("/ingress/spec/consumerGroupId");
+  private static final JsonPointer AUTO_RESET_POS_POINTER =
+      JsonPointer.compile("/ingress/spec/autoOffsetResetPosition");
+
+  private static final JsonPointer STARTUP_POS_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition");
+  private static final JsonPointer STARTUP_POS_TYPE_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/type");
+  private static final JsonPointer STARTUP_SPECIFIC_OFFSETS_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/offsets");
+  private static final JsonPointer STARTUP_DATE_POINTER =
+      JsonPointer.compile("/ingress/spec/startupPosition/date");
+
+  private static final String STARTUP_DATE_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS Z";
+  private static final DateTimeFormatter STARTUP_DATE_FORMATTER =
+      DateTimeFormatter.ofPattern(STARTUP_DATE_PATTERN);
+
+  static List<String> topics(JsonNode json) {
+    return Selectors.textListAt(json, TOPICS_POINTER);
+  }
+
+  static Properties kafkaClientProperties(JsonNode json) {
+    Map<String, String> kvs = Selectors.propertiesAt(json, PROPERTIES_POINTER);
+    Properties properties = new Properties();
+    kvs.forEach(properties::put);
+    return properties;
+  }
+
+  static String kafkaAddress(JsonNode json) {
+    return Selectors.textAt(json, ADDRESS_POINTER);
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> KafkaIngressDeserializer<T> deserializer(JsonNode json) {
+    String descriptorSetPath = Selectors.textAt(json, DESCRIPTOR_SET_POINTER);
+    String messageType = Selectors.textAt(json, MESSAGE_TYPE_POINTER);
+    // this cast is safe since we validate that the produced message type (T) is assignable to a
+    // Message.
+    // see asJsonIngressSpec()
+    return (KafkaIngressDeserializer<T>)
+        new ProtobufKafkaIngressDeserializer(descriptorSetPath, messageType);
+  }
+
+  static Optional<String> optionalConsumerGroupId(JsonNode json) {
+    return Selectors.optionalTextAt(json, GROUP_ID_POINTER);
+  }
+
+  static Optional<KafkaIngressAutoResetPosition> optionalAutoOffsetResetPosition(JsonNode json) {
+    Optional<String> conf = Selectors.optionalTextAt(json, AUTO_RESET_POS_POINTER);
+    if (!conf.isPresent()) {
+      return Optional.empty();
+    }
+
+    String autoOffsetResetConfig = conf.get().toUpperCase(Locale.ENGLISH);
+
+    try {
+      return Optional.of(KafkaIngressAutoResetPosition.valueOf(autoOffsetResetConfig));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid autoOffsetResetPosition: "
+              + autoOffsetResetConfig
+              + "; valid values are "
+              + Arrays.toString(KafkaIngressAutoResetPosition.values()),
+          e);
+    }
+  }
+
+  static Optional<KafkaIngressStartupPosition> optionalStartupPosition(JsonNode json) {
+    if (json.at(STARTUP_POS_POINTER).isMissingNode()) {
+      return Optional.empty();
+    }
+
+    String startupType =
+        Selectors.textAt(json, STARTUP_POS_TYPE_POINTER).toLowerCase(Locale.ENGLISH);
+    switch (startupType) {
+      case "group-offsets":
+        return Optional.of(KafkaIngressStartupPosition.fromGroupOffsets());
+      case "earliest":
+        return Optional.of(KafkaIngressStartupPosition.fromEarliest());
+      case "latest":
+        return Optional.of(KafkaIngressStartupPosition.fromLatest());
+      case "specific-offsets":
+        return Optional.of(
+            KafkaIngressStartupPosition.fromSpecificOffsets(specificOffsetsStartupMap(json)));
+      case "date":
+        return Optional.of(KafkaIngressStartupPosition.fromDate(startupDate(json)));
+      default:
+        throw new IllegalArgumentException(
+            "Invalid startup position type: "
+                + startupType
+                + "; valid values are [group-offsets, earliest, latest, specific-offsets, date]");
+    }
+  }
+
+  private static Map<KafkaTopicPartition, Long> specificOffsetsStartupMap(JsonNode json) {
+    Map<String, Long> kvs = Selectors.longPropertiesAt(json, STARTUP_SPECIFIC_OFFSETS_POINTER);
+    Map<KafkaTopicPartition, Long> offsets = new HashMap<>(kvs.size());
+    kvs.forEach(
+        (partition, offset) ->
+            offsets.put(KafkaTopicPartition.fromString(partition), validateOffsetLong(offset)));
+    return offsets;
+  }
+
+  private static ZonedDateTime startupDate(JsonNode json) {
+    String dateStr = Selectors.textAt(json, STARTUP_DATE_POINTER);
+    try {
+      return ZonedDateTime.parse(dateStr, STARTUP_DATE_FORMATTER);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException(
+          "Unable to parse date string for startup position: "
+              + dateStr
+              + "; the date should conform to the pattern "
+              + STARTUP_DATE_PATTERN,
+          e);
+    }
+  }
+
+  private static Long validateOffsetLong(Long offset) {
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          "Invalid offset value: "
+              + offset
+              + "; must be a numeric integer with value between 0 and "
+              + Long.MAX_VALUE);
+    }
+
+    return offset;
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProvider.java
@@ -17,60 +17,26 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.deserializer;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.kafkaAddress;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.kafkaClientProperties;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalAutoOffsetResetPosition;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalConsumerGroupId;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalStartupPosition;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.topics;
+
 import com.google.protobuf.Message;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
-import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.flink.io.spi.SourceProvider;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
-import org.apache.flink.statefun.sdk.kafka.KafkaIngressAutoResetPosition;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilderApiExtension;
-import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
-import org.apache.flink.statefun.sdk.kafka.KafkaIngressStartupPosition;
-import org.apache.flink.statefun.sdk.kafka.KafkaTopicPartition;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 final class ProtobufKafkaSourceProvider implements SourceProvider {
-
-  private static final JsonPointer DESCRIPTOR_SET_POINTER =
-      JsonPointer.compile("/ingress/spec/descriptorSet");
-  private static final JsonPointer TOPICS_POINTER = JsonPointer.compile("/ingress/spec/topics");
-  private static final JsonPointer MESSAGE_TYPE_POINTER =
-      JsonPointer.compile("/ingress/spec/messageType");
-  private static final JsonPointer PROPERTIES_POINTER =
-      JsonPointer.compile("/ingress/spec/properties");
-  private static final JsonPointer ADDRESS_POINTER = JsonPointer.compile("/ingress/spec/address");
-  private static final JsonPointer GROUP_ID_POINTER =
-      JsonPointer.compile("/ingress/spec/consumerGroupId");
-  private static final JsonPointer AUTO_RESET_POS_POINTER =
-      JsonPointer.compile("/ingress/spec/autoOffsetResetPosition");
-
-  private static final JsonPointer STARTUP_POS_POINTER =
-      JsonPointer.compile("/ingress/spec/startupPosition");
-  private static final JsonPointer STARTUP_POS_TYPE_POINTER =
-      JsonPointer.compile("/ingress/spec/startupPosition/type");
-  private static final JsonPointer STARTUP_SPECIFIC_OFFSETS_POINTER =
-      JsonPointer.compile("/ingress/spec/startupPosition/offsets");
-  private static final JsonPointer STARTUP_DATE_POINTER =
-      JsonPointer.compile("/ingress/spec/startupPosition/date");
-
-  private static final String STARTUP_DATE_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS Z";
-  private static final DateTimeFormatter STARTUP_DATE_FORMATTER =
-      DateTimeFormatter.ofPattern(STARTUP_DATE_PATTERN);
 
   private final KafkaSourceProvider delegateProvider = new KafkaSourceProvider();
 
@@ -112,118 +78,5 @@ final class ProtobufKafkaSourceProvider implements SourceProvider {
     KafkaIngressBuilderApiExtension.withDeserializer(kafkaIngressBuilder, deserializer(json));
 
     return kafkaIngressBuilder.build();
-  }
-
-  private static List<String> topics(JsonNode json) {
-    return Selectors.textListAt(json, TOPICS_POINTER);
-  }
-
-  private static Properties kafkaClientProperties(JsonNode json) {
-    Map<String, String> kvs = Selectors.propertiesAt(json, PROPERTIES_POINTER);
-    Properties properties = new Properties();
-    kvs.forEach(properties::put);
-    return properties;
-  }
-
-  private static String kafkaAddress(JsonNode json) {
-    return Selectors.textAt(json, ADDRESS_POINTER);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> KafkaIngressDeserializer<T> deserializer(JsonNode json) {
-    String descriptorSetPath = Selectors.textAt(json, DESCRIPTOR_SET_POINTER);
-    String messageType = Selectors.textAt(json, MESSAGE_TYPE_POINTER);
-    // this cast is safe since we validate that the produced message type (T) is assignable to a
-    // Message.
-    // see asJsonIngressSpec()
-    return (KafkaIngressDeserializer<T>)
-        new ProtobufKafkaIngressDeserializer(descriptorSetPath, messageType);
-  }
-
-  private static Optional<String> optionalConsumerGroupId(JsonNode json) {
-    return Selectors.optionalTextAt(json, GROUP_ID_POINTER);
-  }
-
-  private static Optional<KafkaIngressAutoResetPosition> optionalAutoOffsetResetPosition(
-      JsonNode json) {
-    Optional<String> conf = Selectors.optionalTextAt(json, AUTO_RESET_POS_POINTER);
-    if (!conf.isPresent()) {
-      return Optional.empty();
-    }
-
-    String autoOffsetResetConfig = conf.get().toUpperCase(Locale.ENGLISH);
-
-    try {
-      return Optional.of(KafkaIngressAutoResetPosition.valueOf(autoOffsetResetConfig));
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          "Invalid autoOffsetResetPosition: "
-              + autoOffsetResetConfig
-              + "; valid values are "
-              + Arrays.toString(KafkaIngressAutoResetPosition.values()),
-          e);
-    }
-  }
-
-  private static Optional<KafkaIngressStartupPosition> optionalStartupPosition(JsonNode json) {
-    if (json.at(STARTUP_POS_POINTER).isMissingNode()) {
-      return Optional.empty();
-    }
-
-    String startupType =
-        Selectors.textAt(json, STARTUP_POS_TYPE_POINTER).toLowerCase(Locale.ENGLISH);
-    switch (startupType) {
-      case "group-offsets":
-        return Optional.of(KafkaIngressStartupPosition.fromGroupOffsets());
-      case "earliest":
-        return Optional.of(KafkaIngressStartupPosition.fromEarliest());
-      case "latest":
-        return Optional.of(KafkaIngressStartupPosition.fromLatest());
-      case "specific-offsets":
-        return Optional.of(
-            KafkaIngressStartupPosition.fromSpecificOffsets(specificOffsetsStartupMap(json)));
-      case "date":
-        return Optional.of(KafkaIngressStartupPosition.fromDate(startupDate(json)));
-      default:
-        throw new IllegalArgumentException(
-            "Invalid startup position type: "
-                + startupType
-                + "; valid values are [group-offsets, earliest, latest, specific-offsets, date]");
-    }
-  }
-
-  private static Map<KafkaTopicPartition, Long> specificOffsetsStartupMap(JsonNode json) {
-    Map<String, Long> kvs = Selectors.longPropertiesAt(json, STARTUP_SPECIFIC_OFFSETS_POINTER);
-    Map<KafkaTopicPartition, Long> offsets = new HashMap<>(kvs.size());
-    kvs.forEach(
-        (partition, offset) ->
-            offsets.put(KafkaTopicPartition.fromString(partition), validateOffsetLong(offset)));
-    return offsets;
-  }
-
-  private static ZonedDateTime startupDate(JsonNode json) {
-    String dateStr = Selectors.textAt(json, STARTUP_DATE_POINTER);
-    try {
-      return ZonedDateTime.parse(dateStr, STARTUP_DATE_FORMATTER);
-    } catch (DateTimeParseException e) {
-      throw new IllegalArgumentException(
-          "Unable to parse date string for startup position: "
-              + dateStr
-              + "; the date should conform to the pattern "
-              + STARTUP_DATE_PATTERN,
-          e);
-    }
-  }
-
-  private static Long validateOffsetLong(Long offset) {
-    if (offset < 0) {
-      throw new IllegalArgumentException(
-          "Invalid offset value: "
-              + offset
-              + "; must be a numeric integer with value between 0 and "
-              + Long.MAX_VALUE);
-    }
-
-    return offset;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.io.kafka;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public final class RoutableProtobufKafkaIngressDeserializer
+    implements KafkaIngressDeserializer<Message> {
+
+  private static final long serialVersionUID = 1L;
+
+  private Map<String, RoutingConfig> routingConfigs;
+
+  RoutableProtobufKafkaIngressDeserializer(Map<String, RoutingConfig> routingConfigs) {
+    if (routingConfigs == null || routingConfigs.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Routing config for routable Kafka ingress cannot be empty.");
+    }
+    this.routingConfigs = routingConfigs;
+  }
+
+  @Override
+  public Message deserialize(ConsumerRecord<byte[], byte[]> input) {
+    final String topic = input.topic();
+    final byte[] payload = input.value();
+    final String id = new String(input.key(), StandardCharsets.UTF_8);
+
+    final RoutingConfig routingConfig = routingConfigs.get(topic);
+    if (routingConfig == null) {
+      throw new IllegalStateException(
+          "Consumed a record from topic [" + topic + "], but no routing config was specified.");
+    }
+    return AutoRoutable.newBuilder()
+        .setConfig(routingConfig)
+        .setId(id)
+        .setPayloadBytes(ByteString.copyFrom(payload))
+        .build();
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
@@ -31,7 +31,7 @@ public final class RoutableProtobufKafkaIngressDeserializer
 
   private static final long serialVersionUID = 1L;
 
-  private Map<String, RoutingConfig> routingConfigs;
+  private final Map<String, RoutingConfig> routingConfigs;
 
   RoutableProtobufKafkaIngressDeserializer(Map<String, RoutingConfig> routingConfigs) {
     if (routingConfigs == null || routingConfigs.isEmpty()) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaSourceProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaSourceProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.io.kafka;
+
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.kafkaAddress;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.kafkaClientProperties;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalAutoOffsetResetPosition;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalConsumerGroupId;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.optionalStartupPosition;
+import static org.apache.flink.statefun.flink.io.kafka.KafkaSpecJsonParser.routableTopics;
+
+import com.google.protobuf.Message;
+import java.util.ArrayList;
+import java.util.Map;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
+import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
+import org.apache.flink.statefun.flink.io.spi.SourceProvider;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilder;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressBuilderApiExtension;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
+import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+final class RoutableProtobufKafkaSourceProvider implements SourceProvider {
+
+  private final KafkaSourceProvider delegateProvider = new KafkaSourceProvider();
+
+  @Override
+  public <T> SourceFunction<T> forSpec(IngressSpec<T> spec) {
+    KafkaIngressSpec<T> kafkaIngressSpec = asKafkaIngressSpec(spec);
+    return delegateProvider.forSpec(kafkaIngressSpec);
+  }
+
+  private static <T> KafkaIngressSpec<T> asKafkaIngressSpec(IngressSpec<T> spec) {
+    if (!(spec instanceof JsonIngressSpec)) {
+      throw new IllegalArgumentException("Wrong type " + spec.type());
+    }
+    JsonIngressSpec<T> casted = (JsonIngressSpec<T>) spec;
+
+    IngressIdentifier<T> id = casted.id();
+    Class<T> producedType = casted.id().producedType();
+    if (!Message.class.isAssignableFrom(producedType)) {
+      throw new IllegalArgumentException(
+          "ProtocolBuffer based ingress is only able to produce types that derive from "
+              + Message.class.getName()
+              + " but "
+              + producedType.getName()
+              + " is provided.");
+    }
+
+    JsonNode json = casted.json();
+
+    Map<String, RoutingConfig> routableTopics = routableTopics(json);
+
+    KafkaIngressBuilder<T> kafkaIngressBuilder = KafkaIngressBuilder.forIdentifier(id);
+    kafkaIngressBuilder
+        .withKafkaAddress(kafkaAddress(json))
+        .withProperties(kafkaClientProperties(json))
+        .addTopics(new ArrayList<>(routableTopics.keySet()));
+
+    optionalConsumerGroupId(json).ifPresent(kafkaIngressBuilder::withConsumerGroupId);
+    optionalAutoOffsetResetPosition(json).ifPresent(kafkaIngressBuilder::withAutoResetPosition);
+    optionalStartupPosition(json).ifPresent(kafkaIngressBuilder::withStartupPosition);
+
+    KafkaIngressBuilderApiExtension.withDeserializer(
+        kafkaIngressBuilder, deserializer(routableTopics));
+
+    return kafkaIngressBuilder.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> KafkaIngressDeserializer<T> deserializer(
+      Map<String, RoutingConfig> routingConfig) {
+    // this cast is safe since we've already checked that T is a Message
+    return (KafkaIngressDeserializer<T>)
+        new RoutableProtobufKafkaIngressDeserializer(routingConfig);
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProviderTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaSourceProviderTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
-import org.apache.flink.statefun.sdk.kafka.Constants;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.junit.Test;
@@ -40,7 +39,7 @@ public class ProtobufKafkaSourceProviderTest {
     JsonNode ingressDefinition = fromPath("protobuf-kafka-ingress.yaml");
     JsonIngressSpec<?> spec =
         new JsonIngressSpec<>(
-            Constants.PROTOBUF_KAFKA_INGRESS_TYPE,
+            ProtobufKafkaIngressTypes.PROTOBUF_KAFKA_INGRESS_TYPE,
             new IngressIdentifier<>(Message.class, "foo", "bar"),
             ingressDefinition);
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaSourceProviderTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaSourceProviderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.io.kafka;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import com.google.protobuf.Message;
+import java.io.IOException;
+import java.net.URL;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
+import org.junit.Test;
+
+public class RoutableProtobufKafkaSourceProviderTest {
+
+  @Test
+  public void exampleUsage() {
+    JsonNode ingressDefinition = fromPath("routable-protobuf-kafka-ingress.yaml");
+    JsonIngressSpec<?> spec =
+        new JsonIngressSpec<>(
+            ProtobufKafkaIngressTypes.ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE,
+            new IngressIdentifier<>(Message.class, "foo", "bar"),
+            ingressDefinition);
+
+    RoutableProtobufKafkaSourceProvider provider = new RoutableProtobufKafkaSourceProvider();
+    SourceFunction<?> source = provider.forSpec(spec);
+
+    assertThat(source, instanceOf(FlinkKafkaConsumer.class));
+  }
+
+  private static JsonNode fromPath(String path) {
+    URL moduleUrl = ProtobufKafkaSourceProviderTest.class.getClassLoader().getResource(path);
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    try {
+      return mapper.readTree(moduleUrl);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/resources/routable-protobuf-kafka-ingress.yaml
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/resources/routable-protobuf-kafka-ingress.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ingress:
+  meta:
+    type: org.apache.flink.statefun.sdk.kafka/routable-protobuf-kafka-connector
+    id: com.mycomp.foo/bar
+  spec:
+    address: kafka-broker:9092
+    consumerGroupId: my-group-id
+    topics:
+      - topic: topic-1
+        typeUrl: com.googleapis/com.mycomp.foo.MessageA
+        targets:
+          - com.mycomp.foo/function-1
+          - com.mycomp.foo/function-2
+      - topic: topic-2
+        typeUrl: com.googleapis/com.mycomp.foo.MessageB
+        targets:
+          - com.mycomp.foo/function-2
+    autoOffsetResetPosition: earliest
+    startupPosition:
+      type: earliest
+    properties:
+      - foo.config: bar

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -40,6 +40,20 @@ under the License.
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>${protoc-jar-maven-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
+++ b/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
@@ -15,22 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.statefun.flink.io.kafka;
 
-import com.google.auto.service.AutoService;
-import java.util.Map;
+import org.apache.flink.statefun.sdk.IngressType;
 
-import org.apache.flink.statefun.flink.io.spi.FlinkIoModule;
-import org.apache.flink.statefun.sdk.kafka.Constants;
+public final class ProtobufKafkaIngressTypes {
 
-@AutoService(FlinkIoModule.class)
-public final class KafkaFlinkIoModule implements FlinkIoModule {
+  private ProtobufKafkaIngressTypes() {}
 
-  @Override
-  public void configure(Map<String, String> globalConfiguration, Binder binder) {
-    binder.bindSourceProvider(Constants.KAFKA_INGRESS_TYPE, new KafkaSourceProvider());
-    binder.bindSourceProvider(
-        ProtobufKafkaIngressTypes.PROTOBUF_KAFKA_INGRESS_TYPE, new ProtobufKafkaSourceProvider());
-    binder.bindSinkProvider(Constants.KAFKA_EGRESS_TYPE, new KafkaSinkProvider());
-  }
+    public static final IngressType PROTOBUF_KAFKA_INGRESS_TYPE =
+        new IngressType("org.apache.flink.statefun.sdk.kafka", "protobuf-kafka-connector");
 }

--- a/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
+++ b/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
@@ -24,6 +24,9 @@ public final class ProtobufKafkaIngressTypes {
 
   private ProtobufKafkaIngressTypes() {}
 
-    public static final IngressType PROTOBUF_KAFKA_INGRESS_TYPE =
-        new IngressType("org.apache.flink.statefun.sdk.kafka", "protobuf-kafka-connector");
+  public static final IngressType PROTOBUF_KAFKA_INGRESS_TYPE =
+      new IngressType("org.apache.flink.statefun.sdk.kafka", "protobuf-kafka-connector");
+
+  public static final IngressType ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE =
+      new IngressType("org.apache.flink.statefun.sdk.kafka", "routable-protobuf-kafka-connector");
 }

--- a/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
+++ b/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package org.apache.flink.statefun.flink.io;
+option java_package = "org.apache.flink.statefun.flink.io.generated";
+option java_multiple_files = true;
+
+message AutoRoutable {
+    RoutingConfig config = 1;
+    string id = 2;
+    bytes payload_bytes = 3;
+}
+
+message RoutingConfig {
+    string typeUrl = 1;
+    repeated TargetFunctionType targetFunctionTypes = 2;
+}
+
+message TargetFunctionType {
+    string namespace = 1;
+    string type = 2;
+}

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/Constants.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/Constants.java
@@ -25,8 +25,6 @@ public final class Constants {
       new IngressType("org.apache.flink.statefun.sdk.kafka", "universal-kafka-connector");
   public static final EgressType KAFKA_EGRESS_TYPE =
       new EgressType("org.apache.flink.statefun.sdk.kafka", "universal-kafka-connector");
-  public static final IngressType PROTOBUF_KAFKA_INGRESS_TYPE =
-      new IngressType("org.apache.flink.statefun.sdk.kafka", "protobuf-kafka-connector");;
 
   private Constants() {}
 }


### PR DESCRIPTION
This PR adds support for a Protobuf Kafka ingress that automatically routes values as Protobuf `Any` messages to target functions using the Kafka record's key (as UTF8 strings) as the function id.

The YAML definition looks like the following:
```
ingress:
  meta:
    type: org.apache.flink.statefun.sdk.kafka/routable-protobuf-kafka-connector
    id: com.mycomp.foo/bar
  spec:
    address: kafka-broker:9092
    consumerGroupId: my-group-id
    topics:
      - topic: topic-1
        typeUrl: com.googleapis/com.mycomp.foo.MessageA
        targets:
          - com.mycomp.foo/function-1
          - com.mycomp.foo/function-2
      - topic: topic-2
        typeUrl: com.googleapis/com.mycomp.foo.MessageB
        targets:
          - com.mycomp.foo/function-2
    autoOffsetResetPosition: earliest
    startupPosition:
      type: earliest
    properties:
      - foo.config: bar
```

Summary:
- For each topic, users define the Protobuf type URL of the message type in that topic, and the list of target functions to route records of that topic to.
- Users must use as key the target function ids, as a UTF8 string.

When binding this ingress to a module, `JsonModule` automatically binds a `AutoRoutableProtobufRouter` for the ingress. Therefore, users do not need to explicitly define a router for the ingress in the YAML.

---

### Verifying

- A unit test `RoutableProtobufKafkaSourceProviderTest` is added to demonstrate example YAML and usage.
- An E2E test for the feature will follow-up after this PR.