### PR TITLE
[FLINK-16290][http] Add validation to the HTTP endpoint schema

### DIFF
--- a/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
@@ -30,7 +30,7 @@ module:
             kind: http
             type: com.foo/world
           spec:
-            endpoint: localhost:5959/statefun
+            endpoint: http://localhost:5959/statefun
             states:
               - seen_count
             maxNumBatchRequests: 10000


### PR DESCRIPTION
This PR adds a check for the user supplied endpoint (in `module.yaml`) to be a uri with
a schema, that is either `http` or `https`.
Failing to do so, would cause a `NPE` at runtime due to the way okhttp`s `HttpUrl` handles URIs with a missing schema.