### PR TITLE
[FLINK-16311] [FLINK-16312] Fix PersistedAppendingBuffer contracts and HttpFunction.onAsyncResult

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessor.java
@@ -19,7 +19,7 @@ package org.apache.flink.statefun.flink.core.state;
 
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
 
@@ -32,7 +32,7 @@ final class FlinkAppendingBufferAccessor<E> implements AppendingBufferAccessor<E
   }
 
   @Override
-  public void append(E element) {
+  public void append(@Nonnull E element) {
     try {
       this.handle.add(element);
     } catch (Exception e) {
@@ -41,7 +41,7 @@ final class FlinkAppendingBufferAccessor<E> implements AppendingBufferAccessor<E
   }
 
   @Override
-  public void appendAll(List<E> elements) {
+  public void appendAll(@Nonnull List<E> elements) {
     try {
       this.handle.addAll(elements);
     } catch (Exception e) {
@@ -50,7 +50,7 @@ final class FlinkAppendingBufferAccessor<E> implements AppendingBufferAccessor<E
   }
 
   @Override
-  public void replaceWith(List<E> elements) {
+  public void replaceWith(@Nonnull List<E> elements) {
     try {
       this.handle.update(elements);
     } catch (Exception e) {
@@ -58,7 +58,7 @@ final class FlinkAppendingBufferAccessor<E> implements AppendingBufferAccessor<E
     }
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public Iterable<E> view() {
     try {

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
@@ -27,7 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
@@ -226,7 +226,7 @@ public class StateBinderTest {
         private List<E> list;
 
         @Override
-        public void append(E element) {
+        public void append(@Nonnull E element) {
           if (list == null) {
             list = new ArrayList<>();
           }
@@ -234,7 +234,7 @@ public class StateBinderTest {
         }
 
         @Override
-        public void appendAll(List<E> elements) {
+        public void appendAll(@Nonnull List<E> elements) {
           if (list == null) {
             list = new ArrayList<>();
           }
@@ -242,11 +242,11 @@ public class StateBinderTest {
         }
 
         @Override
-        public void replaceWith(List<E> elements) {
+        public void replaceWith(@Nonnull List<E> elements) {
           list = elements;
         }
 
-        @Nullable
+        @Nonnull
         @Override
         public Iterable<E> view() {
           return list;

--- a/statefun-sdk/pom.xml
+++ b/statefun-sdk/pom.xml
@@ -37,6 +37,20 @@ under the License.
             <artifactId>jsr305</artifactId>
             <version>${jsr305.version}</version>
         </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/AppendingBufferAccessor.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/AppendingBufferAccessor.java
@@ -18,17 +18,17 @@
 package org.apache.flink.statefun.sdk.state;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public interface AppendingBufferAccessor<E> {
 
-  void append(E element);
+  void append(@Nonnull E element);
 
-  void appendAll(List<E> elements);
+  void appendAll(@Nonnull List<E> elements);
 
-  void replaceWith(List<E> elements);
+  void replaceWith(@Nonnull List<E> elements);
 
-  @Nullable
+  @Nonnull
   Iterable<E> view();
 
   void clear();

--- a/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBufferTest.java
+++ b/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBufferTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.state;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import org.junit.Test;
+
+public class PersistedAppendingBufferTest {
+
+  @Test
+  public void viewOnInit() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    assertFalse(buffer.view().iterator().hasNext());
+  }
+
+  @Test
+  public void append() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+
+    assertThat(buffer.view().iterator().next(), is("element"));
+  }
+
+  @Test
+  public void appendAll() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.appendAll(Arrays.asList("element-1", "element-2"));
+
+    assertThat(buffer.view(), contains("element-1", "element-2"));
+  }
+
+  @Test
+  public void appendAllEmptyList() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+    buffer.appendAll(new ArrayList<>());
+
+    assertThat(buffer.view().iterator().next(), is("element"));
+  }
+
+  @Test
+  public void replaceWith() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+    buffer.replaceWith(Collections.singletonList("element-new"));
+
+    assertThat(buffer.view().iterator().next(), is("element-new"));
+  }
+
+  @Test
+  public void replaceWithEmptyList() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+    buffer.replaceWith(new ArrayList<>());
+
+    assertFalse(buffer.view().iterator().hasNext());
+  }
+
+  @Test
+  public void viewAfterClear() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+    buffer.clear();
+
+    assertFalse(buffer.view().iterator().hasNext());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void viewUnmodifiable() {
+    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
+    buffer.append("element");
+
+    Iterator<String> view = buffer.view().iterator();
+    view.remove();
+  }
+}


### PR DESCRIPTION
The previous contracts for `PersistedAppendingBuffer` were not possible to be provided, since Flink `ListState` never returns `null` when retrieving the list, regardless of if the access was after a clear, or the list was actually just empty.

This PR changes the contract of the `view()` method to always return non-null, and also disallow appending / update the buffer with `null` elements or lists.

---

Following that, since `HttpFunction` was relying on the previous incorrect contracts, it had a problem of endlessly resend 0-sized batch requests.
This PR fixes that as well by relying on the new contracts.