### PR TITLE
[FLINK-16318] Use DynamicallyRegisteredTypes for PersistedTable and PersistedBuffer

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkState.java
@@ -74,8 +74,8 @@ public final class FlinkState implements State {
         runtimeContext.getMapState(
             new MapStateDescriptor<>(
                 flinkStateName(functionType, persistedTable.name()),
-                persistedTable.keyType(),
-                persistedTable.valueType()));
+                types.registerType(persistedTable.keyType()),
+                types.registerType(persistedTable.valueType())));
     return new FlinkTableAccessor<>(handle);
   }
 
@@ -86,7 +86,7 @@ public final class FlinkState implements State {
         runtimeContext.getListState(
             new ListStateDescriptor<>(
                 flinkStateName(functionType, persistedAppendingBuffer.name()),
-                persistedAppendingBuffer.elementType()));
+                types.registerType(persistedAppendingBuffer.elementType())));
     return new FlinkAppendingBufferAccessor<>(handle);
   }
 


### PR DESCRIPTION
This PR fixes a bug where the `PersistedAppendingBuffer` and the `PersistedTable`, didn't use statefun provided `TypeInformation`.