### PR TITLE
[FLINK-16390][sdk] Add view and clear methods to PersistedTable

### DIFF
--- a/statefun-examples/statefun-shopping-cart-example/src/main/protobuf/shoppingcart.proto
+++ b/statefun-examples/statefun-shopping-cart-example/src/main/protobuf/shoppingcart.proto
@@ -68,11 +68,3 @@ message ItemAvailability {
     Status status = 1;
     int32 quantity = 2;
 }
-
-// ---------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------
-
-message Basket {
-    map<string, int32> items = 1;
-} 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.state;
 
+import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -54,5 +55,37 @@ final class FlinkTableAccessor<K, V> implements TableAccessor<K, V> {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public Iterable<Map.Entry<K, V>> entries() {
+    try {
+      return handle.entries();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Iterable<K> keys() {
+    try {
+      return handle.keys();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Iterable<V> values() {
+    try {
+      return handle.values();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void clear() {
+    handle.clear();
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
@@ -215,6 +215,26 @@ public class StateBinderTest {
         public void remove(K key) {
           map.remove(key);
         }
+
+        @Override
+        public Iterable<Map.Entry<K, V>> entries() {
+          return map.entrySet();
+        }
+
+        @Override
+        public Iterable<K> keys() {
+          return map.keySet();
+        }
+
+        @Override
+        public Iterable<V> values() {
+          return map.values();
+        }
+
+        @Override
+        public void clear() {
+          map.clear();
+        }
       };
     }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -121,6 +121,38 @@ public final class PersistedTable<K, V> {
     accessor.remove(key);
   }
 
+  /**
+   * Gets an {@link Iterable} over all the entries of the persisted table.
+   *
+   * @return An {@link Iterable} of the elements of the persisted table.
+   */
+  public Iterable<Map.Entry<K, V>> entries() {
+    return accessor.entries();
+  }
+
+  /**
+   * Gets an {@link Iterable} over all keys of the persisted table.
+   *
+   * @return An {@link Iterable} of keys in the persisted table.
+   */
+  public Iterable<K> keys() {
+    return accessor.keys();
+  }
+
+  /**
+   * Gets an {@link Iterable} over all values of the persisted table.
+   *
+   * @return An {@link Iterable} of values in the persisted table.
+   */
+  public Iterable<V> values() {
+    return accessor.values();
+  }
+
+  /** Clears all elements in the persisted buffer. */
+  public void clear() {
+    accessor.clear();
+  }
+
   @ForRuntime
   void setAccessor(TableAccessor<K, V> newAccessor) {
     Objects.requireNonNull(newAccessor);
@@ -143,6 +175,26 @@ public final class PersistedTable<K, V> {
     @Override
     public void remove(K key) {
       map.remove(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<K, V>> entries() {
+      return map.entrySet();
+    }
+
+    @Override
+    public Iterable<K> keys() {
+      return map.keySet();
+    }
+
+    @Override
+    public Iterable<V> values() {
+      return map.values();
+    }
+
+    @Override
+    public void clear() {
+      map.clear();
     }
   }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.statefun.sdk.state;
 
+import java.util.Map;
+
 public interface TableAccessor<K, V> {
 
   void set(K key, V value);
@@ -24,4 +26,12 @@ public interface TableAccessor<K, V> {
   V get(K key);
 
   void remove(K key);
+
+  Iterable<Map.Entry<K, V>> entries();
+
+  Iterable<K> keys();
+
+  Iterable<V> values();
+
+  void clear();
 }


### PR DESCRIPTION
Adds common collection methods to PersistedTable. These methods are already available on PersistedAppendingBuffer. 

Note: I have `view` return an empty iterable instead of null. This is different than the default return value for `MapState#entries` but is consistent with `PersistedAppendingBuffer#view`. 