### PR TITLE
[FLINK-16396] [kafka] Add Protobuf message for YAML-ized Kafka egress

### DIFF
--- a/statefun-flink/statefun-flink-io/src/main/protobuf/kafka-egress.proto
+++ b/statefun-flink/statefun-flink-io/src/main/protobuf/kafka-egress.proto
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package org.apache.flink.statefun.flink.io;
+option java_package = "org.apache.flink.statefun.flink.io.generated";
+option java_multiple_files = true;
+
+message KafkaProducerRecord {
+    string key = 1;
+    bytes value_bytes = 2;
+    string topic = 3;
+}


### PR DESCRIPTION
This adds a Protobuf message to be used by the YAML-ized Kafka egress (WIP).
I'm eagerly opening this PR already because there's a dependency in the Python SDK that would require this definition in place.