### PR TITLE
[FLINK-16326] [core] Eagerly validate strictly required Flink configurations

### DIFF
--- a/statefun-examples/statefun-shopping-cart-example/src/main/protobuf/shoppingcart.proto
+++ b/statefun-examples/statefun-shopping-cart-example/src/main/protobuf/shoppingcart.proto
@@ -68,11 +68,3 @@ message ItemAvailability {
     Status status = 1;
     int32 quantity = 2;
 }
-
-// ---------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------
-
-message Basket {
-    map<string, int32> items = 1;
-} 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -25,22 +25,16 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
-import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.environment.StreamPlanEnvironment;
 import org.apache.flink.util.InstantiationUtil;
@@ -144,7 +138,7 @@ public class StatefulFunctionsConfig implements Serializable {
    * @param configuration a configuration to read the values from
    */
   public StatefulFunctionsConfig(Configuration configuration) {
-    validateStrictlyRequiredConfigs(configuration);
+    StatefulFunctionsConfigValidator.validate(configuration);
 
     this.factoryType = configuration.get(USER_MESSAGE_SERIALIZER);
     this.flinkJobName = configuration.get(FLINK_JOB_NAME);
@@ -245,35 +239,5 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public void setGlobalConfiguration(String key, String value) {
     this.globalConfigurations.put(key, value);
-  }
-
-  private static void validateStrictlyRequiredConfigs(Configuration configuration) {
-    final Set<String> parentFirstClassloaderPatterns =
-        parentFirstClassloaderPatterns(configuration);
-    if (!parentFirstClassloaderPatterns.contains("org.apache.flink.statefun")
-        && !parentFirstClassloaderPatterns.contains("org.apache.kafka")
-        && !parentFirstClassloaderPatterns.contains("com.google.protobuf")) {
-      throw new StatefulFunctionsInvalidConfigException(
-          CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
-          "Must contain org.apache.flink.statefun, org.apache.kafka, and com.google.protobuf");
-    }
-
-    final int maxConcurrentCheckpoints =
-        configuration.get(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS);
-    if (maxConcurrentCheckpoints != 1) {
-      throw new StatefulFunctionsInvalidConfigException(
-          ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS,
-          "Value must be 1, since Stateful Functions currently does not support concurrent checkpoints.");
-    }
-  }
-
-  private static Set<String> parentFirstClassloaderPatterns(Configuration configuration) {
-    final String[] split =
-        configuration.get(CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL).split(";");
-    final Set<String> parentFirstClassloaderPatterns = new HashSet<>(split.length);
-    for (String s : split) {
-      parentFirstClassloaderPatterns.add(s.trim().toLowerCase(Locale.ENGLISH));
-    }
-    return parentFirstClassloaderPatterns;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -160,11 +160,6 @@ public class StatefulFunctionsConfig implements Serializable {
     }
   }
 
-  /** Create a new configuration object with default values. */
-  public StatefulFunctionsConfig() {
-    this(new Configuration());
-  }
-
   /** Returns the factory type used to serialize messages. */
   public MessageFactoryType getFactoryType() {
     return factoryType;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+
+public final class StatefulFunctionsConfigValidator {
+
+  private StatefulFunctionsConfigValidator() {}
+
+  public static final List<String> PARENT_FIRST_CLASSLOADER_PATTERNS =
+      Collections.unmodifiableList(
+          Arrays.asList("org.apache.flink.statefun", "org.apache.kafka", "com.google.protobuf"));
+
+  public static final int MAX_CONCURRENT_CHECKPOINTS = 1;
+
+  static void validate(Configuration configuration) {
+    validateParentFirstClassloaderPatterns(configuration);
+    validateMaxConcurrentCheckpoints(configuration);
+  }
+
+  private static void validateParentFirstClassloaderPatterns(Configuration configuration) {
+    final Set<String> parentFirstClassloaderPatterns =
+        parentFirstClassloaderPatterns(configuration);
+    if (!parentFirstClassloaderPatterns.containsAll(PARENT_FIRST_CLASSLOADER_PATTERNS)) {
+      throw new StatefulFunctionsInvalidConfigException(
+          CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+          "Must contain all of " + String.join(", ", PARENT_FIRST_CLASSLOADER_PATTERNS));
+    }
+  }
+
+  private static void validateMaxConcurrentCheckpoints(Configuration configuration) {
+    final int maxConcurrentCheckpoints =
+        configuration.get(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS);
+    if (maxConcurrentCheckpoints != 1) {
+      throw new StatefulFunctionsInvalidConfigException(
+          ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS,
+          "Value must be 1, Stateful Functions does not support concurrent checkpoints.");
+    }
+  }
+
+  private static Set<String> parentFirstClassloaderPatterns(Configuration configuration) {
+    final String[] split =
+        configuration.get(CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL).split(";");
+    final Set<String> parentFirstClassloaderPatterns = new HashSet<>(split.length);
+    for (String s : split) {
+      parentFirstClassloaderPatterns.add(s.trim().toLowerCase(Locale.ENGLISH));
+    }
+    return parentFirstClassloaderPatterns;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/exceptions/StatefulFunctionsInvalidConfigException.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/exceptions/StatefulFunctionsInvalidConfigException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.exceptions;
+
+import org.apache.flink.configuration.ConfigOption;
+
+public final class StatefulFunctionsInvalidConfigException extends IllegalArgumentException {
+
+  private static final long serialVersionUID = 1L;
+
+  public StatefulFunctionsInvalidConfigException(ConfigOption<?> invalidConfig, String message) {
+    super(String.format("Invalid configuration: %s; %s", invalidConfig.key(), message));
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.state;
 
+import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
@@ -54,5 +55,37 @@ final class FlinkTableAccessor<K, V> implements TableAccessor<K, V> {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public Iterable<Map.Entry<K, V>> entries() {
+    try {
+      return handle.entries();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Iterable<K> keys() {
+    try {
+      return handle.keys();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Iterable<V> values() {
+    try {
+      return handle.values();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void clear() {
+    handle.clear();
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
@@ -18,8 +18,11 @@
 package org.apache.flink.statefun.flink.core;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,6 +41,10 @@ public class StatefulFunctionsConfigTest {
         StatefulFunctionsConfig.TOTAL_MEMORY_USED_FOR_FEEDBACK_CHECKPOINTING,
         MemorySize.ofMebiBytes(100));
     configuration.set(StatefulFunctionsConfig.ASYNC_MAX_OPERATIONS_PER_TASK, 100);
+    configuration.set(
+        CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+        "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
+    configuration.set(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, 1);
     configuration.setString("statefun.module.global-config.key1", "value1");
     configuration.setString("statefun.module.global-config.key2", "value2");
 
@@ -51,5 +58,11 @@ public class StatefulFunctionsConfigTest {
         stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key1", "value1"));
     Assert.assertThat(
         stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key2", "value2"));
+  }
+
+  @Test(expected = StatefulFunctionsInvalidConfigException.class)
+  public void invalidStrictFlinkConfigsThrows() {
+    Configuration configuration = new Configuration();
+    new StatefulFunctionsConfig(configuration);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/StateBinderTest.java
@@ -215,6 +215,26 @@ public class StateBinderTest {
         public void remove(K key) {
           map.remove(key);
         }
+
+        @Override
+        public Iterable<Map.Entry<K, V>> entries() {
+          return map.entrySet();
+        }
+
+        @Override
+        public Iterable<K> keys() {
+          return map.keySet();
+        }
+
+        @Override
+        public Iterable<V> values() {
+          return map.values();
+        }
+
+        @Override
+        public void clear() {
+          map.clear();
+        }
       };
     }
 

--- a/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
+++ b/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsJob;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
@@ -36,19 +37,19 @@ import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.io.EgressSpec;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 public class Harness {
-  private final StatefulFunctionsConfig stateFunConfig;
-
   private final Configuration flinkConfig;
+
+  private final Map<String, String> globalConfigurations = new HashMap<>();
 
   private final Map<IngressIdentifier<?>, IngressSpec<?>> overrideIngress = new HashMap<>();
   private final Map<EgressIdentifier<?>, EgressSpec<?>> overrideEgress = new HashMap<>();
 
   public Harness() {
-    stateFunConfig = new StatefulFunctionsConfig();
     flinkConfig = new Configuration();
   }
 
@@ -83,13 +84,14 @@ public class Harness {
   }
 
   public Harness withKryoMessageSerializer() {
-    stateFunConfig.setFactoryType(MessageFactoryType.WITH_KRYO_PAYLOADS);
+    flinkConfig.set(
+        StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER, MessageFactoryType.WITH_KRYO_PAYLOADS);
     return this;
   }
 
   /** Set the name used in the Flink UI. */
   public Harness withFlinkJobName(String flinkJobName) {
-    stateFunConfig.setFlinkJobName(flinkJobName);
+    flinkConfig.set(StatefulFunctionsConfig.FLINK_JOB_NAME, flinkJobName);
     return this;
   }
 
@@ -104,18 +106,21 @@ public class Harness {
    * org.apache.flink.statefun.sdk.spi.StatefulFunctionModule} on configure.
    */
   public Harness withGlobalConfiguration(String key, String value) {
-    stateFunConfig.setGlobalConfiguration(key, value);
+    globalConfigurations.put(key, value);
     return this;
   }
 
   public void start() throws Exception {
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
+    configureStrictlyRequiredFlinkConfigs(flinkConfig);
     // Configure will change the value of a setting only if a corresponding option was set in the
     // underlying configuration. If a key is not present, the current value of a field will remain
     // untouched.
     env.configure(flinkConfig, Thread.currentThread().getContextClassLoader());
 
+    StatefulFunctionsConfig stateFunConfig = new StatefulFunctionsConfig(flinkConfig);
+    stateFunConfig.addAllGlobalConfigurations(globalConfigurations);
     stateFunConfig.setProvider(new HarnessProvider(overrideIngress, overrideEgress));
     StatefulFunctionsJob.main(env, stateFunConfig);
   }
@@ -152,5 +157,12 @@ public class Harness {
     public void accept(T t) {
       System.out.println(t);
     }
+  }
+
+  private static void configureStrictlyRequiredFlinkConfigs(Configuration flinkConfig) {
+    flinkConfig.set(
+        CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+        "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
+    flinkConfig.set(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, 1);
   }
 }

--- a/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
+++ b/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfigValidator;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsJob;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverseProvider;
@@ -162,7 +163,9 @@ public class Harness {
   private static void configureStrictlyRequiredFlinkConfigs(Configuration flinkConfig) {
     flinkConfig.set(
         CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
-        "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
-    flinkConfig.set(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, 1);
+        String.join(";", StatefulFunctionsConfigValidator.PARENT_FIRST_CLASSLOADER_PATTERNS));
+    flinkConfig.set(
+        ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS,
+        StatefulFunctionsConfigValidator.MAX_CONCURRENT_CHECKPOINTS);
   }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -121,6 +121,38 @@ public final class PersistedTable<K, V> {
     accessor.remove(key);
   }
 
+  /**
+   * Gets an {@link Iterable} over all the entries of the persisted table.
+   *
+   * @return An {@link Iterable} of the elements of the persisted table.
+   */
+  public Iterable<Map.Entry<K, V>> entries() {
+    return accessor.entries();
+  }
+
+  /**
+   * Gets an {@link Iterable} over all keys of the persisted table.
+   *
+   * @return An {@link Iterable} of keys in the persisted table.
+   */
+  public Iterable<K> keys() {
+    return accessor.keys();
+  }
+
+  /**
+   * Gets an {@link Iterable} over all values of the persisted table.
+   *
+   * @return An {@link Iterable} of values in the persisted table.
+   */
+  public Iterable<V> values() {
+    return accessor.values();
+  }
+
+  /** Clears all elements in the persisted buffer. */
+  public void clear() {
+    accessor.clear();
+  }
+
   @ForRuntime
   void setAccessor(TableAccessor<K, V> newAccessor) {
     Objects.requireNonNull(newAccessor);
@@ -143,6 +175,26 @@ public final class PersistedTable<K, V> {
     @Override
     public void remove(K key) {
       map.remove(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<K, V>> entries() {
+      return map.entrySet();
+    }
+
+    @Override
+    public Iterable<K> keys() {
+      return map.keySet();
+    }
+
+    @Override
+    public Iterable<V> values() {
+      return map.values();
+    }
+
+    @Override
+    public void clear() {
+      map.clear();
     }
   }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/TableAccessor.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.statefun.sdk.state;
 
+import java.util.Map;
+
 public interface TableAccessor<K, V> {
 
   void set(K key, V value);
@@ -24,4 +26,12 @@ public interface TableAccessor<K, V> {
   V get(K key);
 
   void remove(K key);
+
+  Iterable<Map.Entry<K, V>> entries();
+
+  Iterable<K> keys();
+
+  Iterable<V> values();
+
+  void clear();
 }

--- a/tools/docker/flink-distribution-template/conf/flink-conf.yaml
+++ b/tools/docker/flink-distribution-template/conf/flink-conf.yaml
@@ -14,7 +14,17 @@
 # limitations under the License.
 # This file is the base for the Apache Flink configuration
 
+#==============================================================================
+# Configurations strictly required by Stateful Functions. Do not change.
+#==============================================================================
+
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+execution.checkpointing.max-concurrent-checkpoints: 1
+
+#==============================================================================
+# Recommended configurations. Users may change according to their needs.
+#==============================================================================
+
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir


### PR DESCRIPTION
This PR achieves the following:
- 7850755 .Make it clearer in the base `flink-conf.yaml` template what configurations should not be touched. Also add `execution.checkpointing.max-concurrent-checkpoints: 1` to the template since Stateful Functions currently does not support concurrent checkpoints.
- 5706462 Add eager validation of the strictly required Flink configs to `StatefulFunctionsConfig` class.
- d8c2739 Adapt the Flink Harness to these changes.

---

### Verifying

I've verified this for both Flink Harness executions as well as end-to-end containerized executions.
- For Flink Harness executions, I executed the harness example (which fails without d8c2739).
- For end-to-end executions, I did `mvn clean verify -Prun-e2e-tests`