### PR TITLE
[FLINK-16398] [kafka] Make Kafka ingress/egress type strings more compact

### DIFF
--- a/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/routable-kafka-ingress-module/module.yaml
+++ b/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/routable-kafka-ingress-module/module.yaml
@@ -20,7 +20,7 @@ module:
     ingresses:
       - ingress:
           meta:
-            type: org.apache.flink.statefun.sdk.kafka/routable-protobuf-kafka-connector
+            type: statefun.kafka.io/routable-protobuf-ingress
             id: org.apache.flink.statefun.e2e/messages
           spec:
             address: kafka-broker:9092

--- a/statefun-flink/statefun-flink-common/src/test/resources/bar-module/module.yaml
+++ b/statefun-flink/statefun-flink-common/src/test/resources/bar-module/module.yaml
@@ -42,7 +42,7 @@ module:
     ingressess:
       - ingress:
           meta:
-            type: org.apache.flink.statefun.sdk.kafka/protobuf-kafka-connector
+            type: statefun.kafka.io/protobuf-ingress
             id: com.mycomp.igal/names
           spec:
             address: kafka-broker:9092

--- a/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
@@ -46,7 +46,7 @@ module:
     ingresses:
       - ingress:
           meta:
-            type: org.apache.flink.statefun.sdk.kafka/protobuf-kafka-connector
+            type: statefun.kafka.io/protobuf-ingress
             id: com.mycomp.igal/names
           spec:
             address: kafka-broker:9092
@@ -59,7 +59,7 @@ module:
     egresses:
       - egress:
           meta:
-            type: org.apache.flink.statefun.sdk.kafka/generic-kafka-egress
+            type: statefun.kafka.io/generic-egress
             id: com.mycomp.foo/bar
           spec:
             address: kafka-broker:9092

--- a/statefun-flink/statefun-flink-io-bundle/src/test/resources/protobuf-kafka-ingress.yaml
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/resources/protobuf-kafka-ingress.yaml
@@ -15,7 +15,7 @@
 
 ingress:
   meta:
-    type: org.apache.flink.statefun.sdk.kafka/protobuf-kafka-connector
+    type: statefun.kafka.io/protobuf-ingress
     id: com.mycomp.igal/names
   spec:
     address: kafka-broker:9092

--- a/statefun-flink/statefun-flink-io-bundle/src/test/resources/routable-protobuf-kafka-ingress.yaml
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/resources/routable-protobuf-kafka-ingress.yaml
@@ -15,7 +15,7 @@
 
 ingress:
   meta:
-    type: org.apache.flink.statefun.sdk.kafka/routable-protobuf-kafka-connector
+    type: statefun.kafka.io/routable-protobuf-ingress
     id: com.mycomp.foo/bar
   spec:
     address: kafka-broker:9092

--- a/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaEgressTypes.java
+++ b/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaEgressTypes.java
@@ -25,5 +25,5 @@ public final class KafkaEgressTypes {
   private KafkaEgressTypes() {}
 
   public static final EgressType GENERIC_KAFKA_EGRESS_TYPE =
-      new EgressType("org.apache.flink.statefun.sdk.kafka", "generic-kafka-egress");
+      new EgressType("statefun.kafka.io", "generic-egress");
 }

--- a/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
+++ b/statefun-flink/statefun-flink-io/src/main/java/org/apache/flink/statefun/flink/io/kafka/ProtobufKafkaIngressTypes.java
@@ -25,8 +25,8 @@ public final class ProtobufKafkaIngressTypes {
   private ProtobufKafkaIngressTypes() {}
 
   public static final IngressType PROTOBUF_KAFKA_INGRESS_TYPE =
-      new IngressType("org.apache.flink.statefun.sdk.kafka", "protobuf-kafka-connector");
+      new IngressType("statefun.kafka.io", "protobuf-ingress");
 
   public static final IngressType ROUTABLE_PROTOBUF_KAFKA_INGRESS_TYPE =
-      new IngressType("org.apache.flink.statefun.sdk.kafka", "routable-protobuf-kafka-connector");
+      new IngressType("statefun.kafka.io", "routable-protobuf-ingress");
 }

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/Constants.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/Constants.java
@@ -22,9 +22,9 @@ import org.apache.flink.statefun.sdk.IngressType;
 
 public final class Constants {
   public static final IngressType KAFKA_INGRESS_TYPE =
-      new IngressType("org.apache.flink.statefun.sdk.kafka", "universal-kafka-connector");
+      new IngressType("statefun.kafka.io", "universal-ingress");
   public static final EgressType KAFKA_EGRESS_TYPE =
-      new EgressType("org.apache.flink.statefun.sdk.kafka", "universal-kafka-connector");
+      new EgressType("statefun.kafka.io", "universal-egress");
 
   private Constants() {}
 }


### PR DESCRIPTION
I decided to go with the pattern:
- Java ingress (egress): `statefun.kafka.io/universal-ingress(egress)`
- Polygplot Protobuf ingress: `statefun.kafka.io/protobuf-ingress`
- Polyglot generic egress: `statefun.kafka.io/generic-egress`

Basically, we mention "Kafka" in the namespace, to also match the artifact name `org.apache.flink:statefun-kafka-io`, and avoid mentioning "Kafka" over and over again in the type names.

---

`mvn clean verify -Prun-e2e-tests` passes locally