### PR TITLE
[FLINK-16396] [kafka] Allow null keys for the YAML generic Kafka egress

### DIFF
--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/GenericKafkaEgressSerializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/GenericKafkaEgressSerializer.java
@@ -57,9 +57,14 @@ public final class GenericKafkaEgressSerializer implements KafkaEgressSerializer
 
   private static ProducerRecord<byte[], byte[]> toProducerRecord(
       KafkaProducerRecord protobufProducerRecord) {
-    return new ProducerRecord<>(
-        protobufProducerRecord.getTopic(),
-        protobufProducerRecord.getKey().getBytes(StandardCharsets.UTF_8),
-        protobufProducerRecord.getValueBytes().toByteArray());
+    final String key = protobufProducerRecord.getKey();
+    final String topic = protobufProducerRecord.getTopic();
+    final byte[] valueBytes = protobufProducerRecord.getValueBytes().toByteArray();
+
+    if (key == null) {
+      return new ProducerRecord<>(topic, valueBytes);
+    } else {
+      return new ProducerRecord<>(topic, key.getBytes(StandardCharsets.UTF_8), valueBytes);
+    }
   }
 }


### PR DESCRIPTION
A followup-fix for #46, which allows the key to be `null`.
In this case, Kafka will perform round-robin partitioning (assuming the user did not configure a partitioner in the Kafka client properties) on the written producer records.