### PR TITLE
[FLINK-16415] [core] Add format versioning to YAML-ized modules

### DIFF
--- a/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/routable-kafka-ingress-module/module.yaml
+++ b/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/routable-kafka-ingress-module/module.yaml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "1.0"
+
 module:
   meta:
     type: remote

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+enum FormatVersion {
+  v1_0("1.0");
+
+  private String versionStr;
+
+  FormatVersion(String versionStr) {
+    this.versionStr = versionStr;
+  }
+
+  @Override
+  public String toString() {
+    return versionStr;
+  }
+
+  static FormatVersion fromString(String versionStr) {
+    switch (versionStr) {
+      case "1.0":
+        return v1_0;
+      default:
+        throw new IllegalArgumentException("Unrecognized format version: " + versionStr);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import java.net.URL;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.flink.common.json.Selectors;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+
+final class JsonModuleFactory {
+
+  private JsonModuleFactory() {}
+
+  static StatefulFunctionModule create(JsonNode root, URL moduleUrl) {
+    final FormatVersion formatVersion = formatVersion(root);
+    final JsonNode spec = root.at(Pointers.MODULE_SPEC);
+
+    switch (formatVersion) {
+      case v1_0:
+        return new JsonModule(spec, moduleUrl);
+      default:
+        throw new IllegalArgumentException("Unrecognized format version: " + formatVersion);
+    }
+  }
+
+  private static FormatVersion formatVersion(JsonNode root) {
+    String versionStr = Selectors.textAt(root, Pointers.FORMAT_VERSION);
+    return FormatVersion.fromString(versionStr);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoader.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoader.java
@@ -46,8 +46,7 @@ public final class JsonServiceLoader {
   static StatefulFunctionModule fromUrl(ObjectMapper mapper, URL moduleUrl) {
     try {
       JsonNode root = readAndValidateModuleTree(mapper, moduleUrl);
-      JsonNode spec = root.at(Pointers.MODULE_SPEC);
-      return new JsonModule(spec, moduleUrl);
+      return JsonModuleFactory.create(root, moduleUrl);
     } catch (Throwable t) {
       throw new RuntimeException("Failed loading a module at " + moduleUrl, t);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/Pointers.java
@@ -23,6 +23,8 @@ public final class Pointers {
 
   private Pointers() {}
 
+  public static final JsonPointer FORMAT_VERSION = JsonPointer.compile("/version");
+
   // -------------------------------------------------------------------------------------
   // top level spec definition
   // -------------------------------------------------------------------------------------

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleTest.java
@@ -102,8 +102,7 @@ public class JsonModuleTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    JsonNode spec = json.at("/module/spec");
-    return new JsonModule(spec, moduleUrl);
+    return JsonModuleFactory.create(json, moduleUrl);
   }
 
   private static StatefulFunctionsUniverse emptyUniverse() {

--- a/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/bar-module/module.yaml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "1.0"
+
 module:
   meta:
     type: remote


### PR DESCRIPTION
This PR adds a required `version` field to YAML-ized modules.

The starting format version will be `1.0`, following the conventions of systems like docker-compose.

The changelog commits should be self-explanatory on how this is implemented.
Note: From the looks of the code, the `Pointers` and `JsonModule` classes could use some refactoring, but we can revisit that once we introduce more format versions in the future.

---

### Verifying

The `JsonModuleTest` has been adapted to cover this change.
Same for the E2E test - the `RoutableKafkaE2E` uses a YAML module, so that is covered there as well.