### PR TITLE
 [FLINK-16518] [kafka] Set client properties as strings in KafkaSinkProvider

### DIFF
--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSinkProvider.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/KafkaSinkProvider.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer.Semantic;
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
 public class KafkaSinkProvider implements SinkProvider {
 
@@ -39,11 +40,13 @@ public class KafkaSinkProvider implements SinkProvider {
 
     Properties properties = new Properties();
     properties.putAll(spec.properties());
-    properties.put("bootstrap.servers", spec.kafkaAddress());
+    properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.kafkaAddress());
 
     Semantic producerSemantic = semanticFromSpec(spec);
     if (producerSemantic == Semantic.EXACTLY_ONCE) {
-      properties.put("transaction.timeout.ms", spec.transactionTimeoutDuration().toMillis());
+      properties.setProperty(
+          ProducerConfig.TRANSACTION_TIMEOUT_CONFIG,
+          String.valueOf(spec.transactionTimeoutDuration().toMillis()));
     }
 
     return new FlinkKafkaProducer<>(

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaEgressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaEgressBuilder.java
@@ -59,10 +59,10 @@ public final class KafkaEgressBuilder<OutT> {
   }
 
   /** A configuration property for the KafkaProducer. */
-  public KafkaEgressBuilder<OutT> withProperty(String key, Object value) {
+  public KafkaEgressBuilder<OutT> withProperty(String key, String value) {
     Objects.requireNonNull(key);
     Objects.requireNonNull(value);
-    properties.put(key, value);
+    properties.setProperty(key, value);
     return this;
   }
 

--- a/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
+++ b/statefun-kafka-io/src/main/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilder.java
@@ -93,7 +93,9 @@ public final class KafkaIngressBuilder<T> {
 
   /** A configuration property for the KafkaProducer. */
   public KafkaIngressBuilder<T> withProperty(String name, String value) {
-    this.properties.put(name, value);
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(value);
+    this.properties.setProperty(name, value);
     return this;
   }
 


### PR DESCRIPTION
The put method is strongly discourage to be used on `Properties` as a bad practice, since it allows putting non-string values.

This has already caused a bug, where a long was put into the properties, while Kafka was expecting an integer:
```
org.apache.kafka.common.config.ConfigException: Invalid value 100000 for configuration transaction.timeout.ms: Expected value to be a 32-bit integer, but it was a java.lang.Long
	at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:669)
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:471)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:464)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:62)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:75)
	at org.apache.kafka.clients.producer.ProducerConfig.<init>(ProducerConfig.java:396)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:326)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:298)
	at org.apache.flink.streaming.connectors.kafka.internal.FlinkKafkaInternalProducer.<init>(FlinkKafkaInternalProducer.java:76)
```