### PR TITLE
[FLINK-16558] [doc] Reword project website tagline

### DIFF
--- a/statefun-docs/docs/_templates/layout.html
+++ b/statefun-docs/docs/_templates/layout.html
@@ -8,6 +8,6 @@
 
 	{{ super() }}
 
-	<p style="font-size:100%;margin-top:30px;margin-bottom:5px;text-align:left"> A framework for stateful distributed applications by the original creators of Apache Flink<sup>®</sup>.</p>
+	<p style="font-size:100%;margin-top:30px;margin-bottom:5px;text-align:left"> A framework for stateful distributed polyglot applications, powered by Apache Flink<sup>®</sup>.</p>
 
 {% endblock %}


### PR DESCRIPTION
This PR changes the project tagline in the docs to:

![image](https://user-images.githubusercontent.com/5284370/76483039-ed52a880-6450-11ea-974f-eb8caaabf7df.png)

It previously read: "A framework for stateful distributed applications by the original creators of Apache Flink®." which seems a bit outdated now, since the project is maintained by the community as a whole.