### PR TITLE
[FLINK-16569] [python] Allow empty keys for Python SDK's generic Kafka egress record builder

### DIFF
--- a/statefun-python-sdk/statefun/__init__.py
+++ b/statefun-python-sdk/statefun/__init__.py
@@ -19,4 +19,4 @@
 from statefun.core import StatefulFunctions
 from statefun.request_reply import RequestReplyHandler
 
-from statefun.core import kafka_egress_builder
+from statefun.core import kafka_generic_egress_record_builder

--- a/statefun-python-sdk/statefun/core.py
+++ b/statefun-python-sdk/statefun/core.py
@@ -189,7 +189,7 @@ class StatefulFunctions:
         return self.functions[(namespace, type)]
 
 
-def kafka_egress_builder(topic: str, key: str, value):
+def kafka_generic_egress_record_builder(topic: str, key: str, value):
     """
     Build a ProtobufMessage that can be emitted to a Protobuf based egress.
 

--- a/statefun-python-sdk/statefun/core.py
+++ b/statefun-python-sdk/statefun/core.py
@@ -189,23 +189,22 @@ class StatefulFunctions:
         return self.functions[(namespace, type)]
 
 
-def kafka_generic_egress_record_builder(topic: str, key: str, value):
+def kafka_generic_egress_record_builder(topic: str, value, key: str = None):
     """
     Build a ProtobufMessage that can be emitted to a Protobuf based egress.
 
     :param topic: The kafka detention topic for that record
-    :param key: the utf8 encoded string key to produce
+    :param key: the utf8 encoded string key to produce (can be empty)
     :param value: the Protobuf value to produce
     :return: A Protobuf message represents the record to be produced via the kafka procurer.
     """
     if not topic:
         raise ValueError("A destination Kafka topic is missing")
-    if not key:
-        raise ValueError("A key is missing")
     if not value:
         raise ValueError("Missing value")
     record = KafkaProducerRecord()
     record.topic = topic
-    record.key = key
     record.value_bytes = value.SerializeToString()
+    if key is not None:
+        record.key = key
     return record

--- a/statefun-python-sdk/tests/request_reply_test.py
+++ b/statefun-python-sdk/tests/request_reply_test.py
@@ -127,6 +127,8 @@ class RequestReplyTestCase(unittest.TestCase):
             # kafka egress
             context.pack_and_send_egress("sdk/kafka",
                                          kafka_generic_egress_record_builder(topic="hello", key=u"hello world", value=seen))
+            context.pack_and_send_egress("sdk/kafka",
+                                         kafka_generic_egress_record_builder(topic="hello", value=seen))
 
         #
         # build the invocation

--- a/statefun-python-sdk/tests/request_reply_test.py
+++ b/statefun-python-sdk/tests/request_reply_test.py
@@ -25,7 +25,7 @@ from google.protobuf.any_pb2 import Any
 from tests.examples_pb2 import LoginEvent, SeenCount
 from statefun.request_reply_pb2 import ToFunction, FromFunction
 from statefun import RequestReplyHandler
-from statefun.core import StatefulFunctions, kafka_egress_builder
+from statefun.core import StatefulFunctions, kafka_generic_egress_record_builder
 
 
 class InvocationBuilder(object):
@@ -126,7 +126,7 @@ class RequestReplyTestCase(unittest.TestCase):
 
             # kafka egress
             context.pack_and_send_egress("sdk/kafka",
-                                         kafka_egress_builder(topic="hello", key=u"hello world", value=seen))
+                                         kafka_generic_egress_record_builder(topic="hello", key=u"hello world", value=seen))
 
         #
         # build the invocation


### PR DESCRIPTION
### Changelog

* Renames `kafka_egress_builder` to `kafka_generic_egress_record_builder`
** The method builds a record, not a egress
** The builder is specific for the generic Kafka egress, hence the additional mention in the name

* Allow empty keys in `kafka_generic_egress_record_builder`, since that is supported by the YAML generic Kafka egress

---

Verified by `python3 -m unittest tests`