### PR TITLE
[FLINK-16254] Support -p / --parallelism command option

### DIFF
--- a/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfiguration.java
+++ b/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfiguration.java
@@ -37,6 +37,8 @@ final class StatefulFunctionsClusterConfiguration extends EntrypointClusterConfi
 
   @Nullable private final JobID jobId;
 
+  private final int parallelism;
+
   StatefulFunctionsClusterConfiguration(
       @Nonnull String configDir,
       @Nonnull Properties dynamicProperties,
@@ -44,11 +46,13 @@ final class StatefulFunctionsClusterConfiguration extends EntrypointClusterConfi
       @Nullable String hostname,
       int restPort,
       @Nonnull SavepointRestoreSettings savepointRestoreSettings,
-      @Nullable JobID jobId) {
+      @Nullable JobID jobId,
+      int parallelism) {
     super(configDir, dynamicProperties, args, hostname, restPort);
     this.savepointRestoreSettings =
         requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
     this.jobId = jobId;
+    this.parallelism = parallelism;
   }
 
   @Nonnull
@@ -59,5 +63,9 @@ final class StatefulFunctionsClusterConfiguration extends EntrypointClusterConfi
   @Nullable
   JobID getJobId() {
     return jobId;
+  }
+
+  public int getParallelism() {
+    return parallelism;
   }
 }

--- a/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfigurationParserFactory.java
+++ b/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfigurationParserFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.flink.launcher;
 
+import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.HOST_OPTION;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
@@ -77,6 +79,7 @@ public class StatefulFunctionsClusterConfigurationParserFactory
     options.addOption(REST_PORT_OPTION);
     options.addOption(JOB_ID_OPTION);
     options.addOption(DYNAMIC_PROPERTY_OPTION);
+    options.addOption(PARALLELISM_OPTION);
     options.addOption(CliFrontendParser.SAVEPOINT_PATH_OPTION);
     options.addOption(CliFrontendParser.SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
@@ -91,6 +94,7 @@ public class StatefulFunctionsClusterConfigurationParserFactory
         commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
     final int restPort = getRestPort(commandLine);
     final String hostname = commandLine.getOptionValue(HOST_OPTION.getOpt());
+    final int parallelism = getParallelism(commandLine);
     final SavepointRestoreSettings savepointRestoreSettings =
         CliFrontendParser.createSavepointRestoreSettings(commandLine);
     final JobID jobId = getJobId(commandLine);
@@ -102,7 +106,8 @@ public class StatefulFunctionsClusterConfigurationParserFactory
         hostname,
         restPort,
         savepointRestoreSettings,
-        jobId);
+        jobId,
+        parallelism);
   }
 
   private int getRestPort(CommandLine commandLine) throws FlinkParseException {
@@ -111,6 +116,17 @@ public class StatefulFunctionsClusterConfigurationParserFactory
       return Integer.parseInt(restPortString);
     } catch (NumberFormatException e) {
       throw createFlinkParseException(REST_PORT_OPTION, e);
+    }
+  }
+
+  private int getParallelism(CommandLine commandLine) throws FlinkParseException {
+    final String parallelismString =
+        commandLine.getOptionValue(
+            PARALLELISM_OPTION.getOpt(), String.valueOf(ExecutionConfig.PARALLELISM_DEFAULT));
+    try {
+      return Integer.parseInt(parallelismString);
+    } catch (NumberFormatException e) {
+      throw createFlinkParseException(PARALLELISM_OPTION, e);
     }
   }
 }

--- a/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
+++ b/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
@@ -47,18 +47,22 @@ public final class StatefulFunctionsClusterEntryPoint extends JobClusterEntrypoi
 
   @Nonnull private final SavepointRestoreSettings savepointRestoreSettings;
 
+  private final int parallelism;
+
   @Nonnull private final String[] programArguments;
 
   private StatefulFunctionsClusterEntryPoint(
       Configuration configuration,
       @Nonnull JobID jobId,
       @Nonnull SavepointRestoreSettings savepointRestoreSettings,
+      int parallelism,
       @Nonnull String[] programArguments) {
     super(configuration);
     this.jobId = requireNonNull(jobId, "jobId");
     this.savepointRestoreSettings =
         requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
     this.programArguments = requireNonNull(programArguments, "programArguments");
+    this.parallelism = parallelism;
   }
 
   public static void main(String[] args) {
@@ -89,6 +93,7 @@ public final class StatefulFunctionsClusterEntryPoint extends JobClusterEntrypoi
             resolveJobIdForCluster(
                 Optional.ofNullable(clusterConfiguration.getJobId()), configuration),
             clusterConfiguration.getSavepointRestoreSettings(),
+            clusterConfiguration.getParallelism(),
             clusterConfiguration.getArgs());
 
     ClusterEntrypoint.runClusterEntrypoint(entrypoint);
@@ -141,6 +146,7 @@ public final class StatefulFunctionsClusterEntryPoint extends JobClusterEntrypoi
       createDispatcherResourceManagerComponentFactory(Configuration configuration) {
     return DefaultDispatcherResourceManagerComponentFactory.createJobComponentFactory(
         StandaloneResourceManagerFactory.INSTANCE,
-        new StatefulFunctionsJobGraphRetriever(jobId, savepointRestoreSettings, programArguments));
+        new StatefulFunctionsJobGraphRetriever(
+            jobId, savepointRestoreSettings, parallelism, programArguments));
   }
 }


### PR DESCRIPTION
This PR adds support for specifying parallelism for Stateful Function applications using the `-p / --parallelism` command.

The new behaviour as as follows:
- If `-p` is defined in the command line, then that value is always used as the parallelism.
- Otherwise, the `parallelism.default` value in `flink-conf.yaml` is used, which by default is 1 if not present.

---

### Changelog

- 27e7abc Adds parsing logic of the parallelism option from the command line, and adds the property to `StatefulFunctionsClusterConfiguration`.
- 07c8dd2 Resolves the parallelism to use in `StatefulFunctionsJobGraphRetriever`, and uses the resolved value to create the JobGraph.
- ee61047 Adapt the E2E tests, so that they use the `-p` command to specify parallelism.

---

### Verfying

The changes to the E2E tests in ee61047 verifies this change: `mvn clean verify -Prun-e2e-tests`