### PR TITLE
[FLINK-16603] Fix quickstart Maven archetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@ under the License.
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <version>0.13</version>
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <phase>verify</phase>
@@ -220,6 +221,8 @@ under the License.
                         <exclude>statefun-docs/docs/_templates/**</exclude>
                         <!-- Generated code  -->
                         <exclude>**/generated/**</exclude>
+                        <!-- Quickstart archetype test configuration -->
+                        <exclude>statefun-quickstart/src/test/resources/projects/testArtifact/goal.txt</exclude>
                         <!-- Bundled license files -->
                         <exclude>**/LICENSE*</exclude>
                         <!-- Python venv -->

--- a/statefun-quickstart/pom.xml
+++ b/statefun-quickstart/pom.xml
@@ -22,6 +22,7 @@ under the License.
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>1.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -59,5 +60,11 @@ under the License.
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/statefun-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/statefun-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,7 +29,7 @@ under the License.
                 <include>**/*.java</include>
             </includes>
         </fileSet>
-        <fileSet encoding="UTF-8">
+        <fileSet filtered="true" encoding="UTF-8">
             <directory>src/main/resources</directory>
         </fileSet>
         <fileSet filtered="true" encoding="UTF-8">

--- a/statefun-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/statefun-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -19,6 +19,8 @@ under the License.
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>

--- a/statefun-quickstart/src/test/resources/projects/testArtifact/archetype.properties
+++ b/statefun-quickstart/src/test/resources/projects/testArtifact/archetype.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+groupId=org.apache.flink.statefun.archetypetest
+artifactId=testArtifact
+version=1.0-SNAPSHOT
+package=org.apache.flink.statefun.archetypetest

--- a/statefun-quickstart/src/test/resources/projects/testArtifact/goal.txt
+++ b/statefun-quickstart/src/test/resources/projects/testArtifact/goal.txt
@@ -1,0 +1,1 @@
+compile


### PR DESCRIPTION
The quickstart Maven archetype was not working due to a few issues:

- the archetype `pom.xml` not being included for filtering, causing the `@project.version@` string not being replaced with the project version.
- the archetype `pom.xml` did not define `modelVersion`

---

### Verifying

An integration-test phase test has been added to verify that projects generated with the archetype can be compiled.