### PR TITLE
[FLINK-16617][py] Use Protobuf DESCRIPTOR instead of class

### DIFF
--- a/statefun-python-sdk/statefun/core.py
+++ b/statefun-python-sdk/statefun/core.py
@@ -104,7 +104,7 @@ class StatefulFunction(object):
         if self.known_messages is None:
             return None
         for cls in self.known_messages:
-            if any.Is(cls):
+            if any.Is(cls.DESCRIPTOR):
                 instance = cls()
                 any.Unpack(instance)
                 return instance

--- a/statefun-python-sdk/tests/statefun_test.py
+++ b/statefun-python-sdk/tests/statefun_test.py
@@ -18,8 +18,10 @@
 
 import unittest
 
-from statefun.core import StatefulFunctions, StatefulFunction
+from google.protobuf.any_pb2 import Any
 
+from statefun.core import StatefulFunctions, StatefulFunction
+from tests.examples_pb2 import LoginEvent
 
 class StatefulFunctionsTestCase(unittest.TestCase):
 
@@ -46,3 +48,22 @@ class StatefulFunctionsTestCase(unittest.TestCase):
 
         x: StatefulFunction = functions.functions[("org.foo", "greeter")]
         self.assertEqual(x.known_messages, [int])
+
+    def test_unpacking(self):
+        functions = StatefulFunctions()
+
+        @functions.bind("org.foo/greeter")
+        def greeter(context, message: LoginEvent):
+            pass
+
+        greeter_fn = functions.functions[("org.foo", "greeter")]
+
+        # pack the function argument as an Any
+        argument = LoginEvent()
+        any_argument = Any()
+        any_argument.Pack(argument)
+
+        # unpack Any automatically
+        unpacked_argument = greeter_fn.unpack_any(any_argument)
+
+        self.assertEqual(argument, unpacked_argument)


### PR DESCRIPTION
The `any.Is()` method requires a Protobuf descriptor,
instead of a class, this PR fixes it.
