### PR TITLE
[FLINK-16752] Fix Ridesharing example

### DIFF
--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
@@ -121,6 +121,14 @@ under the License.
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Changing the maven parent from spring-boot to statefun-parent
had missed a default configuration of the spring-boot-maven-plugin
that triggers the repackage goal.