### PR TITLE
[hotfix] Make the namespace to match GreetStatefulFunction

### DIFF
--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/example/GreetStatefulFunctionBootstrapExample.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/example/GreetStatefulFunctionBootstrapExample.java
@@ -43,7 +43,7 @@ import org.apache.flink.statefun.sdk.state.PersistedValue;
  */
 public class GreetStatefulFunctionBootstrapExample {
 
-  private static final FunctionType GREETER_FUNCTION_TYPE = new FunctionType("foo.bar", "greeter");
+  private static final FunctionType GREETER_FUNCTION_TYPE = new FunctionType("apache", "greeter");
 
   public static void main(String[] args) throws Exception {
     final ParameterTool params = ParameterTool.fromArgs(args);


### PR DESCRIPTION
The `GreetStatefulFunctionBootstrapExample` example creates a savepoint for the Greeter example, but it uses the wrong function type (it uses `foo.bar` as namespace)
but the Greeter function uses `apache` as the namespace.