### PR TITLE
[hotfix][bugfix] The generic ingress requires an utf-8 key.

### DIFF
--- a/statefun-examples/statefun-python-k8s/event-generator.py
+++ b/statefun-examples/statefun-python-k8s/event-generator.py
@@ -41,7 +41,8 @@ def produce(events, address):
     for _ in range(events):
         event = LoginEvent()
         event.user_name = random_user(4)
-        producer.send('logins', event.SerializeToString())
+        key = event.user_name.encode('utf-8')
+        producer.send('logins', key=key, value=event.SerializeToString())
     producer.flush()
     producer.close()
 


### PR DESCRIPTION
This PR fixes a bug in the `event-generator` at `statefun-python-k8s` example.

The `statefun.kafka.io/routable-protobuf-ingress` excepts a UTF-8 key to be present,
this PR adds that key to the records produced in the `event-generator.py`