### PR TITLE
[FLINK-16838] Change base image name and apply versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ submitted to a Flink cluster.
 Below is an example Dockerfile for building an image for an application called `statefun-example`:
 
 ```
-FROM statefun
+FROM flink-statefun[:version-tag]
 
 RUN mkdir -p /opt/statefun/modules/statefun-example
 COPY target/statefun-example*jar /opt/statefun/modules/statefun-example/

--- a/docs/deployment-and-operations/packaging.md
+++ b/docs/deployment-and-operations/packaging.md
@@ -38,7 +38,7 @@ The provided base image allows teams to package their applications with all the 
 Below is an example Dockerfile for building a Stateful Functions image with both an [embedded module]({{ site.baseurl }}/sdk/modules.html#embedded-module) and a [remote module]({{ site.baseurl }}/sdk/modules.html#remote-module) for an application called ``statefun-example``.
 
 {% highlight dockerfile %}
-FROM statefun
+FROM flink-statefun:{{ site.version }}
 
 RUN mkdir -p /opt/statefun/modules/statefun-example
 RUN mkdir -p /opt/statefun/modules/remote

--- a/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/Dockerfile
+++ b/statefun-e2e-tests/statefun-routable-kafka-e2e/src/test/resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/statefun-routable-kafka-e2e
 COPY statefun-routable-kafka-e2e*.jar /opt/statefun/modules/statefun-routable-kafka-e2e/

--- a/statefun-e2e-tests/statefun-sanity-e2e/src/test/resources/Dockerfile
+++ b/statefun-e2e-tests/statefun-sanity-e2e/src/test/resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/statefun-sanity-e2e
 COPY statefun-sanity-e2e*.jar /opt/statefun/modules/statefun-sanity-e2e/

--- a/statefun-examples/statefun-greeter-example/Dockerfile
+++ b/statefun-examples/statefun-greeter-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/statefun-greeter-example
 COPY target/statefun-greeter-example*jar /opt/statefun/modules/statefun-greeter-example/

--- a/statefun-examples/statefun-python-greeter/Dockerfile
+++ b/statefun-examples/statefun-python-greeter/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-python-k8s/Dockerfile.statefun
+++ b/statefun-examples/statefun-python-k8s/Dockerfile.statefun
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
+++ b/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/statefun-ridesharing-example
 COPY statefun-ridesharing-example-functions/target/statefun-ridesharing-example*jar /opt/statefun/modules/statefun-ridesharing-example/

--- a/statefun-examples/statefun-shopping-cart-example/Dockerfile
+++ b/statefun-examples/statefun-shopping-cart-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:2.1-SNAPSHOT
 
 RUN mkdir -p /opt/statefun/modules/statefun-shopping-cart-example
 COPY target/statefun-shopping-cart-example*jar /opt/statefun/modules/statefun-shopping-cart-example/

--- a/statefun-quickstart/src/main/resources/archetype-resources/Dockerfile
+++ b/statefun-quickstart/src/main/resources/archetype-resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM statefun
+FROM flink-statefun:@project.version@
 
 RUN mkdir -p /opt/statefun/modules/${artifactId}
 COPY target/${artifactId}*jar /opt/statefun/modules/${artifactId}/

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,22 @@
+# Stateful Functions Docker Image
+
+This directory contains scripts to build images using the current source version.
+
+The scripts here assumes that distribution and core artifacts are already built from the current source, and adds them to the image build context.
+Therefore, before executing the scripts, make sure to build the project first using `mvn clean package -DskipTests`.
+
+## Building the image
+
+```
+./build-stateful-functions.sh
+```
+
+This builds the `flink-statefun` image, tagged with the current source version.
+
+## Code examples and E2E tests
+
+There are several [examples](../../statefun-examples) and [end-to-end tests](../../statefun-e2e-tests) that rely
+on images built with the corresponding source version.
+
+For released versions, the required image should be available in the Docker Hub registry.
+For snapshots / unstable versions, you would need to build the image locally with the scripts here.

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+VERSION_TAG=2.1-SNAPSHOT
+
 #
 # setup the environment 
 #
@@ -56,7 +58,7 @@ cp ${core_jar} ${docker_context_flink}/lib/statefun-flink-core.jar
 cd ${docker_context_root}
 cp ${basedir}/Dockerfile ${docker_context_root}
 cp ${basedir}/docker-entry-point.sh ${docker_context_root}
-docker build . -t statefun
+docker build . -t flink-statefun:${VERSION_TAG}
 
 # clean again
 rm -rf ${docker_context_root}

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -17,6 +17,10 @@
 
 set -e
 
+#
+# Do not change the name of this variable;
+# it is referenced in the tools/releasing/update_branch_version.sh script
+#
 VERSION_TAG=2.1-SNAPSHOT
 
 #

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -73,6 +73,10 @@ perl -pi -e "s#version: $OLD_VERSION#version: $NEW_VERSION#" tools/k8s/Chart.yam
 perl -pi -e "s#version: \"$OLD_VERSION\"#version: \"$NEW_VERSION\"#" docs/_config.yml
 perl -pi -e "s#version_title: \"$OLD_VERSION\"#version_title: \"$NEW_VERSION\"#" docs/_config.yml
 
+# change Stateful Functions image version tags in all Dockerfiles and image build script
+find . -name 'Dockerfile*' -type f -exec perl -pi -e "s#FROM flink-statefun:$OLD_VERSION#FROM flink-statefun:$NEW_VERSION#" {} \;
+perl -pi -e "s#VERSION_TAG=$OLD_VERSION#VERSION_TAG=$NEW_VERSION#" tools/docker/build-stateful-functions.sh
+
 git commit -am "[release] Update version to ${NEW_VERSION}"
 
 NEW_VERSION_COMMIT_HASH=`git rev-parse HEAD`


### PR DESCRIPTION
This PR has the following end-goal in mind:
- Examples / E2E tests / quickstart archetype built or run from snapshot versions (i.e. from `master` or `release-2.0` branches) should always run against a locally-built StateFun base image, built from the source of said snapshot version.
- Released examples / E2E tests / quickstart archetypes, should not require users to locally build a StateFun image, assuming that we will have official images published to Docker Hub.

This PR does a few things to accomplish that:

1. Let the image build script `tools/docker/build-distribution.sh` build images tagged with the current source version. i.e.,
`2.1-SNAPSHOT` when built from the snapshot `master` branch, `2.0-SNAPSHOT` when built from the snapshot `release-2.0` branch, or
simply `2.0.0` if built from a officially released source distribution

2. Update Dockerfiles of all examples / E2E tests / quickstart archetype to use a specific version tag. This has the effect that, if those were built from a released distribution, the image may be pulled directly from Docker Hub (when we publish the images after the release). Otherwise, if those were built from a snapshot version, they would use a locally-built snapshot image.

On the side, this PR also uses the opportunity to rename the image name from `statefun` to `flink-statefun`, with the following reasoning:
- It would be more consistent with the naming convention of other distributions, like the Python SDK
- Lets the image name to show association with Flink

---

## Verifying

I verified the changes by:
- Running all the examples that used images built from StateFun base image, and all ran without problems
- Run all end-to-end tests, using `mvn clean verify -Prun-e2e-tests`
- Created new project from quickstart archetype - the generated skeleton project has the correct Dockerfile:
```
FROM flink-statefun:2.1-SNAPSHOT

RUN mkdir -p /opt/statefun/modules/my-app
COPY target/my-app*jar /opt/statefun/modules/my-app/
```