### PR TITLE
[FLINK-16853][legal] Update the version of protobuf-java from 3.8.0 to 3.7.1 in the NOTICE file of module statefun-flink-distribution

### DIFF
--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -36,4 +36,4 @@ See bundled license files under "META-INF/licenses" for details.
 - com.esotericsoftware.kryo:kryo:2.24.0
 - com.esotericsoftware.minlog:minlog:1.2
 - com.github.luben:zstd-jni:1.3.8-1
-- com.google.protobuf:protobuf-java:3.8.0
+- com.google.protobuf:protobuf-java:3.7.1


### PR DESCRIPTION
In the NOTICE file, the version of protobuf-java should be 3.7.1.