### PR TITLE
[FLINK-16854][legal] Correct dependency versions in the NOTICE file of module statefun-ridesharing-example-simulator

### DIFF
--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/src/main/resources/META-INF/NOTICE
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/src/main/resources/META-INF/NOTICE
@@ -41,9 +41,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.9
 - com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.9
 - com.fasterxml:classmate:1.4.0
-- org.hibernate.validator:hibernate-validator:6.0.17
+- org.hibernate.validator:hibernate-validator:6.0.17.Final
 - javax.validation:validation-api:2.0.1.Final
-- org.jboss.logging:jboss-logging:3.3.2
+- org.jboss.logging:jboss-logging:3.3.2.Final
 - org.apache.kafka:kafka-clients:2.0.1
 - org.lz4:lz4-java:1.4.1
 - org.xerial.snappy:snappy-java:1.1.7.1
@@ -51,7 +51,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:28.0-jre
 - com.google.guava:failureaccess:1.0.1
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.code.findbugs:jsr305:3.0.2:compile
+- com.google.code.findbugs:jsr305:3.0.2
 - com.google.errorprone:error_prone_annotations:2.3.2
 - com.google.j2objc:j2objc-annotations:1.3
 - com.google.auto.service:auto-service-annotations:1.0-rc6


### PR DESCRIPTION
There are some dependencies with a wrong version in the NOTICE file:
```
com.google.code.findbugs:jsr305:3.0.2:compile (Remove compile)
org.hibernate.validator:hibernate-validator:6.0.17 (Version should be 6.0.17.Final)
org.jboss.logging:jboss-logging:3.3.2  (Version should be 3.3.2.Final)
```