### PR TITLE
[FLINK-16879] [build] Disable the source-release-assembly execution goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,41 @@ under the License.
         </dependency>
     </dependencies>
 
+    <profiles>
+        <!--
+            We're reusing the apache-release build profile defined in the Apache Parent POM,
+            with one exclusion: do not run the source-release-assembly execution goal.
+            We have our own scripts to create the source release, which correctly excludes
+            binaries from distribution tarball.
+            The script can be found under tools/releasing/create_source_release.sh.
+        -->
+        <profile>
+            <id>apache-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.apache.resources</groupId>
+                                <artifactId>apache-source-release-assembly-descriptor</artifactId>
+                                <version>1.0.6</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>source-release-assembly</id>
+                                <!-- disable the execution -->
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
We should be using the `apache-release` build profile defined in the Apache Parent POM, with one exclusion: do not run the `source-release-assembly` execution goal.

We have our own scripts to create the source release, which correctly excludes binaries from distribution tarball. That script can be found under `tools/releasing/create_source_release.sh`.

---

## Verifying

Build the project using `mvn clean install -Papache-release`.
Under `project-root/target/`, you should not find any source release packages, only POM files.
