### PR TITLE
[FLINK-16886][FLINK-16898][k8s] Adjust Helm charts

### DIFF
--- a/tools/k8s/templates/master-deployment.yaml
+++ b/tools/k8s/templates/master-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: {{ .Values.statefun_image }}
+          image: {{ .Values.master.image }}
           env:
             - name: ROLE
               value: master

--- a/tools/k8s/templates/worker-deployment.yaml
+++ b/tools/k8s/templates/worker-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             requests:
               memory: "{{ .Values.worker.container_mem }}"
           ports:
-            - containerPort: 6123
+            - containerPort: 6122
               name: rpc
             - containerPort: 6124
               name: blob
@@ -49,7 +49,7 @@ spec:
               name: ui
           livenessProbe:
             tcpSocket:
-              port: 6123
+              port: 6122
             initialDelaySeconds: 30
             periodSeconds: 60
           volumeMounts:

--- a/tools/k8s/templates/worker-deployment.yaml
+++ b/tools/k8s/templates/worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: {{ .Values.statefun_image }}
+          image: {{ .Values.worker.image }}
           env:
             - name: ROLE
               value: worker


### PR DESCRIPTION
### This PR adjust the `Helm` chart templates in the following ways:

1) `values.yaml` parameterize stateful function master and worker image names 
(`master.image` and `worker.image`). We should use them instead of `statefun_image` that can be unbound if not explicitly added.

2) Uses `6122` port for liveness checks for the workers (TaskManagers) instead of 6123.


