### PR TITLE
[FLINK-16899][example][py-k8s] Adjust module.yaml to reflect the service definition 

### DIFF
--- a/statefun-examples/statefun-python-k8s-example/module.yaml
+++ b/statefun-examples/statefun-python-k8s-example/module.yaml
@@ -23,7 +23,7 @@ module:
             kind: http
             type: k8s-demo/greeter
           spec:
-            endpoint: http://python-worker:8000/statefun
+            endpoint: http://statefun-python:8000/statefun
             states:
               - seen_count
             maxNumBatchRequests: 500


### PR DESCRIPTION
This PR adjusts the Python k8s example, in the following way:

The Python stateful function worker is accessible on `http://statefun-python:8000`,
as defined at `python-worker-service.yaml` (at `.metadata.name`).
Yet `module.yaml` refers to a different endpoint, this PR fixes it.
