### PR TITLE
 [FLINK-16926][core] Reconfigure StreamExecutionEnvironment

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -120,6 +120,8 @@ public class StatefulFunctionsConfig implements Serializable {
     }
   }
 
+  private final Configuration flinkConfiguration;
+
   private MessageFactoryType factoryType;
 
   private String flinkJobName;
@@ -139,6 +141,7 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public StatefulFunctionsConfig(Configuration configuration) {
     StatefulFunctionsConfigValidator.validate(configuration);
+    this.flinkConfiguration = configuration;
 
     this.factoryType = configuration.get(USER_MESSAGE_SERIALIZER);
     this.flinkJobName = configuration.get(FLINK_JOB_NAME);
@@ -239,5 +242,13 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public void setGlobalConfiguration(String key, String value) {
     this.globalConfigurations.put(key, value);
+  }
+
+  /**
+   * Returns the underlying Flink configuration that used to initialize this {@link
+   * StatefulFunctionsConfig}.
+   */
+  public Configuration getFlinkConfiguration() {
+    return flinkConfiguration;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.statefun.flink.core.translation.FlinkUniverse;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.environment.StreamPlanEnvironment;
 
 public class StatefulFunctionsJob {
 
@@ -52,6 +53,7 @@ public class StatefulFunctionsJob {
     Objects.requireNonNull(stateFunConfig);
 
     setDefaultContextClassLoaderIfAbsent();
+    configureExecutionEnvironment(env, stateFunConfig);
 
     env.getConfig().enableObjectReuse();
 
@@ -67,6 +69,20 @@ public class StatefulFunctionsJob {
     flinkUniverse.configure(env);
 
     env.execute(stateFunConfig.getFlinkJobName());
+  }
+
+  private static void configureExecutionEnvironment(
+      StreamExecutionEnvironment env, StatefulFunctionsConfig stateFunConfig) {
+    if (!(env instanceof StreamPlanEnvironment)) {
+      return;
+    }
+    // This is a workaround until FLINK-16560 would be resolved.
+    // When submitting the Job via StatefulFunctionsClusterEntryPoint (an adopted version of a
+    // JobClusterEntryPoint) The resulting StreamExecutionEnvironment is started with an empty
+    // configuration object, hence might miss important config options set at flink-conf.yaml.
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    Objects.requireNonNull(contextClassLoader);
+    env.configure(stateFunConfig.getFlinkConfiguration(), contextClassLoader);
   }
 
   private static void setDefaultContextClassLoaderIfAbsent() {


### PR DESCRIPTION
### This PR adds a workaround for FLINK-16560.

When starting a statefun Job via `StatefulFunctionsClusterEntryPoint` (an adopted version of a
`JobClusterEntryPoint`) the provided ExecutionEnvironment is initialized with an empty configuration. As a result the ExecutionEnvironment might be missing important configuration options set at `flink-conf.yaml`.

The workaround is to use the configuration obtained from `GlobalConfiguration.loadConfiguration()` to re-configure the execution environment provided.
