### PR TITLE
[FLINK-17060][docs] Replace "{flink}" with the Apache Flink trademark

### DIFF
--- a/docs/io-module/index.md
+++ b/docs/io-module/index.md
@@ -27,7 +27,7 @@ under the License.
 -->
 
 Stateful Functions' I/O modules allow functions to receive and send messages to external systems.
-Based on the concept of Ingress (input) and Egress (output) points, and built on top of the {flink} connector ecosystem, I/O modules enable functions to interact with the outside world through the style of message passing.
+Based on the concept of Ingress (input) and Egress (output) points, and built on top of the Apache Flink® connector ecosystem, I/O modules enable functions to interact with the outside world through the style of message passing.
 
 * This will be replaced by the TOC
 {:toc}

--- a/docs/sdk/modules.md
+++ b/docs/sdk/modules.md
@@ -35,7 +35,7 @@ Stateful Functions supports two types of modules: Embedded and Remote.
 
 ## Embedded Module
 
-Embedded modules are co-located with, and embedded within, the {flink} runtime.
+Embedded modules are co-located with, and embedded within, the Apache Flink® runtime.
 
 This module type only supports JVM based languages and are defined by implementing the ``StatefulFunctionModule`` interface.
 Embedded modules offer a single configuration method where stateful functions are bound to the system based on their [function type]({{ site.baseurl }}/concepts/logical.html#function-address).
@@ -70,7 +70,7 @@ org.apache.flink.statefun.docs.BasicFunctionModule
 
 ## Remote Module
 
-Remote modules are run as external processes from the {flink} runtime; in the same container, as a sidecar, or other external location.
+Remote modules are run as external processes from the Apache Flink® runtime; in the same container, as a sidecar, or other external location.
 
 This module type can support any number of language SDK's.
 Remote modules are registered with the system via ``YAML`` configuration files.


### PR DESCRIPTION
Replace "{flink}" with the Apache Flink trademark