### PR TITLE
[FLINK-17712] [build] Upgrade Flink version to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <auto-service.version>1.0-rc6</auto-service.version>
         <protobuf.version>3.7.1</protobuf.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.10.0</flink.version>
+        <flink.version>1.10.1</flink.version>
     </properties>
 
     <dependencies>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:1.10.0
+FROM flink:1.10.1
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
This should also be backported to `release-2.0`.