### PR TITLE
[FLINK-16928] Remove requirement for legacy scheduler

### DIFF
--- a/docs/deployment-and-operations/packaging.md
+++ b/docs/deployment-and-operations/packaging.md
@@ -73,7 +73,6 @@ The following configurations are strictly required for running StateFun applicat
 
 {% highlight yaml %}
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
-jobmanager.scheduler: legacy
 execution.checkpointing.max-concurrent-checkpoints: 1
 {% endhighlight %}
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <auto-service.version>1.0-rc6</auto-service.version>
         <protobuf.version>3.7.1</protobuf.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.10.0</flink.version>
+        <flink.version>1.10.1</flink.version>
     </properties>
 
     <dependencies>

--- a/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
@@ -20,4 +20,3 @@ state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
 taskmanager.memory.process.size: 4g
-jobmanager.scheduler: legacy

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import java.util.Set;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 
@@ -43,7 +42,6 @@ public final class StatefulFunctionsConfigValidator {
   static void validate(Configuration configuration) {
     validateParentFirstClassloaderPatterns(configuration);
     validateMaxConcurrentCheckpoints(configuration);
-    validateLegacyScheduler(configuration);
   }
 
   private static void validateParentFirstClassloaderPatterns(Configuration configuration) {
@@ -63,14 +61,6 @@ public final class StatefulFunctionsConfigValidator {
       throw new StatefulFunctionsInvalidConfigException(
           ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS,
           "Value must be 1, Stateful Functions does not support concurrent checkpoints.");
-    }
-  }
-
-  private static void validateLegacyScheduler(Configuration configuration) {
-    String configuredScheduler = configuration.get(JobManagerOptions.SCHEDULER);
-    if (!"legacy".equalsIgnoreCase(configuredScheduler)) {
-      throw new StatefulFunctionsInvalidConfigException(
-          JobManagerOptions.SCHEDULER, "Currently the only supported scheduler is 'legacy'");
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.statefun.flink.core;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
@@ -45,7 +44,6 @@ public class StatefulFunctionsConfigTest {
     configuration.set(
         CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
         "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
-    configuration.set(JobManagerOptions.SCHEDULER, "legacy");
     configuration.set(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, 1);
     configuration.setString("statefun.module.global-config.key1", "value1");
     configuration.setString("statefun.module.global-config.key2", "value2");
@@ -60,15 +58,6 @@ public class StatefulFunctionsConfigTest {
         stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key1", "value1"));
     Assert.assertThat(
         stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key2", "value2"));
-  }
-
-  @Test(expected = StatefulFunctionsInvalidConfigException.class)
-  public void testMissingScheduler() {
-    Configuration configuration = validConfiguration();
-
-    configuration.removeConfig(JobManagerOptions.SCHEDULER);
-
-    new StatefulFunctionsConfig(configuration);
   }
 
   @Test(expected = StatefulFunctionsInvalidConfigException.class)
@@ -90,7 +79,6 @@ public class StatefulFunctionsConfigTest {
         CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
         "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
     configuration.set(ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, 1);
-    configuration.set(JobManagerOptions.SCHEDULER, "legacy");
     return configuration;
   }
 }

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:1.10.0
+FROM flink:1.10.1
 
 ENV ROLE worker
 ENV MASTER_HOST localhost

--- a/tools/docker/flink-distribution-template/conf/flink-conf.yaml
+++ b/tools/docker/flink-distribution-template/conf/flink-conf.yaml
@@ -20,7 +20,6 @@
 
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
 execution.checkpointing.max-concurrent-checkpoints: 1
-jobmanager.scheduler: legacy
 
 #==============================================================================
 # Recommended configurations. Users may change according to their needs.

--- a/tools/k8s/templates/config-map.yaml
+++ b/tools/k8s/templates/config-map.yaml
@@ -34,7 +34,6 @@ data:
     execution.checkpointing.interval: {{ .Values.checkpoint.interval }}
     taskmanager.memory.process.size: {{ .Values.worker.jvm_mem }}
     parallelism.default: {{ .Values.worker.replicas }}
-    jobmanager.scheduler: legacy
 
   log4j-console.properties: |+
     log4j.rootLogger=INFO, console


### PR DESCRIPTION
This PR is based on #111, which upgrades the Flink version to 1.10.1.

After upgrading Flink to 1.10.1, https://issues.apache.org/jira/browse/FLINK-16927 will be resolved and therefore allowing us to no longer require the use of the legacy scheduler.

This PR removes the requirement and removes the configuration from all `flink-conf`s and docs.

---

## Verifying

I suggest waiting until #108 is merged, and rebase this PR on top of that to verify that the new scheduler is indeed working for failure recovery with the newly introduced E2E there.