### PR TITLE
[Flink-17644] Add state expiration to the Java SDK

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/ExpirationUtil.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/ExpirationUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.state;
+
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.StateTtlConfig.Builder;
+import org.apache.flink.api.common.state.StateTtlConfig.StateVisibility;
+import org.apache.flink.api.common.state.StateTtlConfig.TtlTimeCharacteristic;
+import org.apache.flink.api.common.state.StateTtlConfig.UpdateType;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.statefun.sdk.state.Expiration;
+import org.apache.flink.statefun.sdk.state.Expiration.Mode;
+
+final class ExpirationUtil {
+  private ExpirationUtil() {}
+
+  static void configureStateTtl(StateDescriptor<?, ?> handle, Expiration expiration) {
+    if (expiration.mode() == Mode.NONE) {
+      return;
+    }
+    StateTtlConfig ttlConfig = from(expiration);
+    handle.enableTimeToLive(ttlConfig);
+  }
+
+  private static StateTtlConfig from(Expiration expiration) {
+    final long millis = expiration.duration().toMillis();
+    Builder builder = StateTtlConfig.newBuilder(Time.milliseconds(millis));
+    builder.setTtlTimeCharacteristic(TtlTimeCharacteristic.ProcessingTime);
+    builder.setStateVisibility(StateVisibility.NeverReturnExpired);
+    switch (expiration.mode()) {
+      case AFTER_WRITE:
+        {
+          builder.setUpdateType(UpdateType.OnCreateAndWrite);
+          break;
+        }
+      case AFTER_READ_OR_WRITE:
+        {
+          builder.setUpdateType(UpdateType.OnReadAndWrite);
+          break;
+        }
+      default:
+        throw new IllegalArgumentException("Unknown expiration mode " + expiration.mode());
+    }
+    return builder.build();
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.state;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * State Expiration Configuration
+ *
+ * <p>This class defines the way state can be auto expired by the runtime. State expiration (also
+ * known as state TTL) can be used to keep state from growing arbitrarily by assigning an expiration
+ * date to a {@link PersistedAppendingBuffer}, {@link PersistedValue} or a {@link PersistedTable}.
+ *
+ * <p>State can be expired after a duration had passed since either from the last write to the
+ * state, or the last read.
+ */
+public final class Expiration {
+  public enum Mode {
+    NONE,
+    AFTER_WRITE,
+    AFTER_READ_OR_WRITE;
+  }
+
+  /**
+   * Returns an Expiration configuration that would expire a @duration after the last write.
+   *
+   * @param duration a duration to wait before considering the state expired.
+   */
+  public static Expiration expireAfterWriting(Duration duration) {
+    return new Expiration(Mode.AFTER_WRITE, duration);
+  }
+
+  /**
+   * Returns an Expiration configuration that would expire a @duration after the last write or read.
+   *
+   * @param duration a duration to wait before considering the state expired.
+   */
+  public static Expiration expireAfterReadingOrWriting(Duration duration) {
+    return new Expiration(Mode.AFTER_READ_OR_WRITE, duration);
+  }
+
+  public static Expiration expireAfter(Duration duration, Mode mode) {
+    return new Expiration(mode, duration);
+  }
+
+  /** @return Returns a disabled expiration */
+  public static Expiration none() {
+    return new Expiration(Mode.NONE, Duration.ZERO);
+  }
+
+  private final Mode mode;
+  private final Duration duration;
+
+  public Expiration(Mode mode, Duration duration) {
+    this.mode = Objects.requireNonNull(mode);
+    this.duration = Objects.requireNonNull(duration);
+  }
+
+  public Mode mode() {
+    return mode;
+  }
+
+  public Duration duration() {
+    return duration;
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
@@ -68,7 +68,7 @@ public final class Expiration {
   private final Mode mode;
   private final Duration duration;
 
-  public Expiration(Mode mode, Duration duration) {
+  private Expiration(Mode mode, Duration duration) {
     this.mode = Objects.requireNonNull(mode);
     this.duration = Objects.requireNonNull(duration);
   }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
@@ -40,12 +40,17 @@ import org.apache.flink.statefun.sdk.annotations.Persisted;
 public final class PersistedAppendingBuffer<E> {
   private final String name;
   private final Class<E> elementType;
+  private final Expiration expiration;
   private AppendingBufferAccessor<E> accessor;
 
   private PersistedAppendingBuffer(
-      String name, Class<E> elementType, AppendingBufferAccessor<E> accessor) {
+      String name,
+      Class<E> elementType,
+      Expiration expiration,
+      AppendingBufferAccessor<E> accessor) {
     this.name = Objects.requireNonNull(name);
     this.elementType = Objects.requireNonNull(elementType);
+    this.expiration = Objects.requireNonNull(expiration);
     this.accessor = Objects.requireNonNull(accessor);
   }
 
@@ -60,7 +65,24 @@ public final class PersistedAppendingBuffer<E> {
    * @return a {@code PersistedAppendingBuffer} instance.
    */
   public static <E> PersistedAppendingBuffer<E> of(String name, Class<E> elementType) {
-    return new PersistedAppendingBuffer<>(name, elementType, new NonFaultTolerantAccessor<>());
+    return of(name, elementType, Expiration.none());
+  }
+
+  /**
+   * Creates a {@link PersistedAppendingBuffer} instance that may be used to access persisted state
+   * managed by the system. Access to the persisted buffer is identified by an unique name and type
+   * of the elements. These may not change across multiple executions of the application.
+   *
+   * @param name the unique name of the persisted buffer state
+   * @param elementType the type of the elements of this {@code PersistedAppendingBuffer}.
+   * @param expiration state expiration configuration.
+   * @param <E> the type of the elements.
+   * @return a {@code PersistedAppendingBuffer} instance.
+   */
+  public static <E> PersistedAppendingBuffer<E> of(
+      String name, Class<E> elementType, Expiration expiration) {
+    return new PersistedAppendingBuffer<>(
+        name, elementType, expiration, new NonFaultTolerantAccessor<>());
   }
 
   /**
@@ -79,6 +101,10 @@ public final class PersistedAppendingBuffer<E> {
    */
   public Class<E> elementType() {
     return elementType;
+  }
+
+  public Expiration expiration() {
+    return expiration;
   }
 
   /**

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -40,13 +40,19 @@ public final class PersistedTable<K, V> {
   private final String name;
   private final Class<K> keyType;
   private final Class<V> valueType;
+  private final Expiration expiration;
   private TableAccessor<K, V> accessor;
 
   private PersistedTable(
-      String name, Class<K> keyType, Class<V> valueType, TableAccessor<K, V> accessor) {
+      String name,
+      Class<K> keyType,
+      Class<V> valueType,
+      Expiration expiration,
+      TableAccessor<K, V> accessor) {
     this.name = Objects.requireNonNull(name);
     this.keyType = Objects.requireNonNull(keyType);
     this.valueType = Objects.requireNonNull(valueType);
+    this.expiration = Objects.requireNonNull(expiration);
     this.accessor = Objects.requireNonNull(accessor);
   }
 
@@ -63,7 +69,26 @@ public final class PersistedTable<K, V> {
    * @return a {@code PersistedTable} instance.
    */
   public static <K, V> PersistedTable<K, V> of(String name, Class<K> keyType, Class<V> valueType) {
-    return new PersistedTable<>(name, keyType, valueType, new NonFaultTolerantAccessor<>());
+    return of(name, keyType, valueType, Expiration.none());
+  }
+
+  /**
+   * Creates a {@link PersistedTable} instance that may be used to access persisted state managed by
+   * the system. Access to the persisted table is identified by an unique name, type of the key, and
+   * type of the value. These may not change across multiple executions of the application.
+   *
+   * @param name the unique name of the persisted state.
+   * @param keyType the type of the state keys of this {@code PersistedTable}.
+   * @param valueType the type of the state values of this {@code PersistedTale}.
+   * @param expiration state expiration configuration.
+   * @param <K> the type of the state keys.
+   * @param <V> the type of the state values.
+   * @return a {@code PersistedTable} instance.
+   */
+  public static <K, V> PersistedTable<K, V> of(
+      String name, Class<K> keyType, Class<V> valueType, Expiration expiration) {
+    return new PersistedTable<>(
+        name, keyType, valueType, expiration, new NonFaultTolerantAccessor<>());
   }
 
   /**
@@ -91,6 +116,10 @@ public final class PersistedTable<K, V> {
    */
   public Class<V> valueType() {
     return valueType;
+  }
+
+  public Expiration expiration() {
+    return expiration;
   }
 
   /**

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
@@ -37,11 +37,13 @@ import org.apache.flink.statefun.sdk.annotations.Persisted;
 public final class PersistedValue<T> {
   private final String name;
   private final Class<T> type;
+  private final Expiration expiration;
   private Accessor<T> accessor;
 
-  private PersistedValue(String name, Class<T> type, Accessor<T> accessor) {
+  private PersistedValue(String name, Class<T> type, Expiration expiration, Accessor<T> accessor) {
     this.name = Objects.requireNonNull(name);
     this.type = Objects.requireNonNull(type);
+    this.expiration = Objects.requireNonNull(expiration);
     this.accessor = Objects.requireNonNull(accessor);
   }
 
@@ -56,7 +58,22 @@ public final class PersistedValue<T> {
    * @return a {@code PersistedValue} instance.
    */
   public static <T> PersistedValue<T> of(String name, Class<T> type) {
-    return new PersistedValue<>(name, type, new NonFaultTolerantAccessor<>());
+    return of(name, type, Expiration.none());
+  }
+
+  /**
+   * Creates a {@link PersistedValue} instance that may be used to access persisted state managed by
+   * the system. Access to the persisted value is identified by an unique name and type of the
+   * value. These may not change across multiple executions of the application.
+   *
+   * @param name the unique name of the persisted state.
+   * @param type the type of the state values of this {@code PersistedValue}.
+   * @param expiration state expiration configuration.
+   * @param <T> the type of the state values.
+   * @return a {@code PersistedValue} instance.
+   */
+  public static <T> PersistedValue<T> of(String name, Class<T> type, Expiration expiration) {
+    return new PersistedValue<>(name, type, expiration, new NonFaultTolerantAccessor<>());
   }
 
   /**
@@ -75,6 +92,10 @@ public final class PersistedValue<T> {
    */
   public Class<T> type() {
     return type;
+  }
+
+  public Expiration expiration() {
+    return expiration;
   }
 
   /**


### PR DESCRIPTION
This PR adds state expiration (state TTL in Flink land) to the persisted states in the Java SDK. follow up PR would expose that to the model.yaml.

There are two types of expirations:
* expiration after the last write
* expiration after the last write or read

The change was verified manually by modifying the Greeter example to 
expire it’s state 5 seconds after writing.