### PR TITLE
[FLINK-17690] Python function wrapper omits docstr

### DIFF
--- a/statefun-python-sdk/statefun/core.py
+++ b/statefun-python-sdk/statefun/core.py
@@ -184,6 +184,10 @@ class StatefulFunctions:
             return function
 
         return wrapper
+    
+        def docstr():
+            """Docstr"""
+        return docstr
 
     def for_type(self, namespace, type):
         return self.functions[(namespace, type)]


### PR DESCRIPTION
Use decorator to avoid losing docstr.