### PR TITLE
[FLINK-17963] [core] Revert execution environment patching in StatefulFunctionsJob

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -120,8 +120,6 @@ public class StatefulFunctionsConfig implements Serializable {
     }
   }
 
-  private final Configuration flinkConfiguration;
-
   private MessageFactoryType factoryType;
 
   private String flinkJobName;
@@ -141,7 +139,6 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public StatefulFunctionsConfig(Configuration configuration) {
     StatefulFunctionsConfigValidator.validate(configuration);
-    this.flinkConfiguration = configuration;
 
     this.factoryType = configuration.get(USER_MESSAGE_SERIALIZER);
     this.flinkJobName = configuration.get(FLINK_JOB_NAME);
@@ -242,13 +239,5 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public void setGlobalConfiguration(String key, String value) {
     this.globalConfigurations.put(key, value);
-  }
-
-  /**
-   * Returns the underlying Flink configuration that used to initialize this {@link
-   * StatefulFunctionsConfig}.
-   */
-  public Configuration getFlinkConfiguration() {
-    return flinkConfiguration;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.statefun.flink.core.translation.FlinkUniverse;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.environment.StreamPlanEnvironment;
 
 public class StatefulFunctionsJob {
 
@@ -53,7 +52,6 @@ public class StatefulFunctionsJob {
     Objects.requireNonNull(stateFunConfig);
 
     setDefaultContextClassLoaderIfAbsent();
-    configureExecutionEnvironment(env, stateFunConfig);
 
     env.getConfig().enableObjectReuse();
 
@@ -69,20 +67,6 @@ public class StatefulFunctionsJob {
     flinkUniverse.configure(env);
 
     env.execute(stateFunConfig.getFlinkJobName());
-  }
-
-  private static void configureExecutionEnvironment(
-      StreamExecutionEnvironment env, StatefulFunctionsConfig stateFunConfig) {
-    if (!(env instanceof StreamPlanEnvironment)) {
-      return;
-    }
-    // This is a workaround until FLINK-16560 would be resolved.
-    // When submitting the Job via StatefulFunctionsClusterEntryPoint (an adopted version of a
-    // JobClusterEntryPoint) The resulting StreamExecutionEnvironment is started with an empty
-    // configuration object, hence might miss important config options set at flink-conf.yaml.
-    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-    Objects.requireNonNull(contextClassLoader);
-    env.configure(stateFunConfig.getFlinkConfiguration(), contextClassLoader);
   }
 
   private static void setDefaultContextClassLoaderIfAbsent() {


### PR DESCRIPTION
This is a revert of FLINK-16926, which was a temporary workaround for the problem back in Flink 1.10.0 where values present in flink-conf.yaml were not being respected via the StreamPlanEnvironment, which was used when using a JobClusterEntrypoint to start the job.

## Verifying

The end-to-end tests cover this, as they use flink-conf.yaml files with checkpointing configuration set. If the configuration were not being respected, then the exactly-once E2E test would fail.