### PR TITLE
[hotfix][docs] Document temporary image registry

### DIFF
--- a/docs/deployment-and-operations/packaging.md
+++ b/docs/deployment-and-operations/packaging.md
@@ -47,6 +47,29 @@ COPY target/statefun-example*jar /opt/statefun/modules/statefun-example/
 COPY module.yaml /opt/statefun/modules/remote/module.yaml
 {% endhighlight %}
 
+{% if site.is_stable %}
+<div class="alert alert-info">
+	The Flink community is currently waiting for the official Docker images to be published to Docker Hub.
+	In the meantime, Ververica has volunteered to make Stateful Function's images available via their public registry: 
+
+	<code class="language-dockerfile" data-lang="dockerfile">
+		<span class="k">FROM</span><span class="s"> ververica/flink-statefun:{{ site.version }}</span>
+	</code>
+
+	You can follow the status of Docker Hub contribution <a href="https://github.com/docker-library/official-images/pull/7749">here</a>.
+</div>
+{% else %}
+<div class="alert alert-info">
+	<strong>Attention:</strong> The Flink community does not publish images for snapshot versions.
+	You can build this version locally by cloning the <a hre="https://github.com/apache/flink-statefun">repo</a> and following
+	the instructions in 
+	
+	<code class="language-dockerfile" data-lang="dockerfile">
+		<span class="s">tools/docker/README.md</span>
+	</code>
+</div>
+{% endif %}
+
 ## Flink Jar
 
 If you prefer to package your job to submit to an existing Flink cluster, simply include ``statefun-flink-distribution`` as a dependency to your application.


### PR DESCRIPTION
While we wait on docker hub, I thought it would be good to document that the images are also available via ververica's registry. I propose backporting this to all release branches. 

<img width="910" alt="Screen Shot 2020-05-28 at 4 35 43 PM" src="https://user-images.githubusercontent.com/1891970/83196498-a09e7580-a101-11ea-8e98-e3f1eb6e44f2.png">
