### PR TITLE
[FLINK-19001] Add data stream api interoperability 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@ under the License.
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
         <flink.version>1.11.1</flink.version>
+        <scala.binary.version>2.11</scala.binary.version>
         <root.dir>${rootDir}</root.dir>
     </properties>
 

--- a/statefun-examples/pom.xml
+++ b/statefun-examples/pom.xml
@@ -37,6 +37,7 @@ under the License.
         <module>statefun-shopping-cart-example</module>
         <module>statefun-async-example</module>
         <module>statefun-state-processor-example</module>
+        <module>statefun-flink-datastream-example</module>
     </modules>
 
 </project>

--- a/statefun-examples/statefun-flink-datastream-example/pom.xml
+++ b/statefun-examples/statefun-flink-datastream-example/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-examples</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>2.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-flink-datastream-example</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-flink-datastream</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <exclusions>
+                <!-- The following exclusion is needed since this artifacts pulls two different versions
+                     of slf4j, and thus failing the maven convergence plugging.
+                 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+
+
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/statefun-examples/statefun-flink-datastream-example/pom.xml
+++ b/statefun-examples/statefun-flink-datastream-example/pom.xml
@@ -33,10 +33,23 @@ under the License.
             <artifactId>statefun-flink-datastream</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <exclusions>
+                <!-- The following exclusion is needed since this artifacts pulls two different versions
+                     of slf4j, and thus failing the maven convergence plugging.
+                 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <exclusions>
                 <!-- The following exclusion is needed since this artifacts pulls two different versions

--- a/statefun-examples/statefun-flink-datastream-example/src/main/java/org/apache/flink/statefun/examples/datastream/Example.java
+++ b/statefun-examples/statefun-flink-datastream-example/src/main/java/org/apache/flink/statefun/examples/datastream/Example.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.examples.datastream;
+
+import static org.apache.flink.configuration.CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL;
+import static org.apache.flink.statefun.flink.core.StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER;
+
+import java.util.concurrent.ThreadLocalRandom;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.core.message.RoutableMessageBuilder;
+import org.apache.flink.statefun.flink.datastream.StatefulFunctionDataStreamBuilder;
+import org.apache.flink.statefun.flink.datastream.StatefulFunctionEgressStreams;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.annotations.Persisted;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+public class Example {
+
+  private static final FunctionType GREET = new FunctionType("exmaple", "greet");
+  private static final EgressIdentifier<String> GREETINGS =
+      new EgressIdentifier<>("example", "out", String.class);
+
+  public static void main(String... args) throws Exception {
+
+    // -----------------------------------------------------------------------------------------
+    // set stateful function related configuration in flink-conf.yaml
+    // -----------------------------------------------------------------------------------------
+
+    Configuration configuration = new Configuration();
+    configuration.set(USER_MESSAGE_SERIALIZER, MessageFactoryType.WITH_KRYO_PAYLOADS);
+    configuration.set(
+        ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+        "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
+
+    StatefulFunctionsConfig statefunConfig = new StatefulFunctionsConfig(configuration);
+
+    // -----------------------------------------------------------------------------------------
+    // obtain the stream execution env and create some data streams
+    // -----------------------------------------------------------------------------------------
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    DataStream<RoutableMessage> names =
+        env.addSource(new NameSource())
+            .map(
+                name ->
+                    RoutableMessageBuilder.builder()
+                        .withTargetAddress(GREET, name)
+                        .withMessageBody(name)
+                        .build());
+
+    // -----------------------------------------------------------------------------------------
+    // wire up stateful functions
+    // -----------------------------------------------------------------------------------------
+
+    StatefulFunctionEgressStreams out =
+        StatefulFunctionDataStreamBuilder.builder("example")
+            .withDataStreamAsIngress(names)
+            .withFunctionProvider(GREET, unused -> new MyFunction())
+            .withEgressId(GREETINGS)
+            .withConfiguration(statefunConfig)
+            .build(env);
+
+    // -----------------------------------------------------------------------------------------
+    // obtain the outputs
+    // -----------------------------------------------------------------------------------------
+
+    DataStream<String> output = out.getDataStreamForEgressId(GREETINGS);
+
+    // -----------------------------------------------------------------------------------------
+    // the rest of the pipeline
+    // -----------------------------------------------------------------------------------------
+
+    output
+        .map(
+            new RichMapFunction<String, String>() {
+              @Override
+              public String map(String value) {
+                return "'" + value + "'";
+              }
+            })
+        .addSink(new PrintSinkFunction<>());
+
+    env.execute();
+  }
+
+  private static final class MyFunction implements StatefulFunction {
+
+    @Persisted
+    private final PersistedValue<Integer> seenCount = PersistedValue.of("seen", Integer.class);
+
+    @Override
+    public void invoke(Context context, Object input) {
+      int seen = seenCount.updateAndGet(MyFunction::increment);
+      context.send(GREETINGS, String.format("Hello %s at the %d-th time", input, seen));
+    }
+
+    private static int increment(@Nullable Integer n) {
+      return n == null ? 1 : n + 1;
+    }
+  }
+
+  private static final class NameSource implements SourceFunction<String> {
+
+    private static final long serialVersionUID = 1;
+
+    private volatile boolean canceled;
+
+    @Override
+    public void run(SourceContext<String> ctx) throws InterruptedException {
+      String[] names = {"Stephan", "Igal", "Gordon", "Seth", "Marta"};
+      ThreadLocalRandom random = ThreadLocalRandom.current();
+      while (true) {
+        int index = random.nextInt(names.length);
+        final String name = names[index];
+        synchronized (ctx.getCheckpointLock()) {
+          if (canceled) {
+            return;
+          }
+          ctx.collect(name);
+        }
+        Thread.sleep(1000);
+      }
+    }
+
+    @Override
+    public void cancel() {
+      canceled = true;
+    }
+  }
+}

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -39,10 +39,10 @@ under the License.
         <module>statefun-flink-distribution</module>
         <module>statefun-flink-harness</module>
         <module>statefun-flink-state-processor</module>
+        <module>statefun-flink-datastream</module>
     </modules>
 
     <properties>
-        <scala.binary.version>2.11</scala.binary.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jmh.version>1.21</jmh.version>
         <jsr305-version>1.3.9</jsr305-version>

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -56,6 +56,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- 3rd party -->

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/common/Maps.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/common/Maps.java
@@ -36,6 +36,17 @@ public final class Maps {
     return result;
   }
 
+  public static <K, V, U> Map<U, V> transformKeys(Map<K, V> map, Function<K, U> fn) {
+    Map<U, V> result = new HashMap<>(map.size());
+
+    for (Map.Entry<K, V> entry : map.entrySet()) {
+      U u = fn.apply(entry.getKey());
+      result.put(u, entry.getValue());
+    }
+
+    return result;
+  }
+
   public static <K, V, U> Map<K, U> transformValues(Map<K, V> map, BiFunction<K, V, U> fn) {
     Map<K, U> result = new HashMap<>();
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.httpfn;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -25,7 +26,9 @@ import java.util.Objects;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionSpec;
 import org.apache.flink.statefun.sdk.FunctionType;
 
-public final class HttpFunctionSpec implements FunctionSpec {
+public final class HttpFunctionSpec implements FunctionSpec, Serializable {
+
+  private static final long serialVersionUID = 1;
 
   private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
   private static final Integer DEFAULT_MAX_NUM_BATCH_REQUESTS = 1000;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/StateSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/StateSpec.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.statefun.flink.core.httpfn;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Objects;
 
-public final class StateSpec {
+public final class StateSpec implements Serializable {
+
+  private static final long serialVersionUID = 1;
+
   private final String name;
   private final Duration ttlDuration;
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/Message.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/Message.java
@@ -19,16 +19,9 @@ package org.apache.flink.statefun.flink.core.message;
 
 import java.io.IOException;
 import java.util.OptionalLong;
-import javax.annotation.Nullable;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.statefun.sdk.Address;
 
-public interface Message {
-
-  @Nullable
-  Address source();
-
-  Address target();
+public interface Message extends RoutableMessage {
 
   Object payload(MessageFactory context, ClassLoader targetClassLoader);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessage.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessage.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.statefun.flink.core.message;
 
-import org.apache.flink.statefun.sdk.Address;
-
 import javax.annotation.Nullable;
+import org.apache.flink.statefun.sdk.Address;
 
 /** A message with source and target {@link Address}s. */
 public interface RoutableMessage {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessage.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.message;
+
+import org.apache.flink.statefun.sdk.Address;
+
+import javax.annotation.Nullable;
+
+/** A message with source and target {@link Address}s. */
+public interface RoutableMessage {
+
+  /**
+   * Gets the address of the sender.
+   *
+   * @return the address (optinal) address of the sender.
+   */
+  @Nullable
+  Address source();
+
+  /**
+   * Gets the target address.
+   *
+   * @return the target address that this message is designated to.
+   */
+  Address target();
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessageBuilder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/RoutableMessageBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.message;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+
+/** A {@link RoutableMessage} Builder. */
+public final class RoutableMessageBuilder {
+
+  public static RoutableMessageBuilder builder() {
+    return new RoutableMessageBuilder();
+  }
+
+  @Nullable private Address source;
+  private Address target;
+  private Object payload;
+
+  private RoutableMessageBuilder() {}
+
+  public RoutableMessageBuilder withTargetAddress(FunctionType functionType, String id) {
+    return withTargetAddress(new Address(functionType, id));
+  }
+
+  public RoutableMessageBuilder withTargetAddress(Address target) {
+    this.target = Objects.requireNonNull(target);
+    return this;
+  }
+
+  public RoutableMessageBuilder withSourceAddress(FunctionType functionType, String id) {
+    return withSourceAddress(new Address(functionType, id));
+  }
+
+  public RoutableMessageBuilder withSourceAddress(@Nullable Address from) {
+    this.source = from;
+    return this;
+  }
+
+  public RoutableMessageBuilder withMessageBody(Object payload) {
+    this.payload = Objects.requireNonNull(payload);
+    return this;
+  }
+
+  public RoutableMessage build() {
+    return new SdkMessage(source, target, payload);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslator.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.translation;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverseProvider;
+import org.apache.flink.statefun.flink.core.common.Maps;
+import org.apache.flink.statefun.flink.core.datastream.SerializableStatefulFunctionProvider;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
+import org.apache.flink.statefun.flink.core.message.Message;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.core.types.StaticallyRegisteredTypes;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+public class EmbeddedTranslator {
+  private final StatefulFunctionsConfig configuration;
+  private final FeedbackKey<Message> feedbackKey;
+
+  public EmbeddedTranslator(StatefulFunctionsConfig config, FeedbackKey<Message> feedbackKey) {
+    this.configuration = config;
+    this.feedbackKey = feedbackKey;
+  }
+
+  public Map<EgressIdentifier<?>, DataStream<?>> translate(
+      List<DataStream<RoutableMessage>> ingresses,
+      Iterable<EgressIdentifier<?>> egressesIds,
+      Map<FunctionType, SerializableStatefulFunctionProvider> functions) {
+
+    configuration.setProvider(new EmbeddedUniverseProvider(functions));
+
+    StaticallyRegisteredTypes types = new StaticallyRegisteredTypes(configuration.getFactoryType());
+    Sources sources = Sources.create(types, ingresses);
+    Sinks sinks = Sinks.create(types, egressesIds);
+
+    StatefulFunctionTranslator translator =
+        new StatefulFunctionTranslator(feedbackKey, configuration);
+
+    return translator.translate(sources, sinks);
+  }
+
+  private static class EmbeddedUniverseProvider implements StatefulFunctionsUniverseProvider {
+
+    private static final class SerializableFunctionType implements Serializable {
+
+      private static final long serialVersionUID = 1;
+
+      String namespace;
+      String name;
+
+      static SerializableFunctionType fromSdk(FunctionType functionType) {
+        SerializableFunctionType t = new SerializableFunctionType();
+        t.namespace = functionType.namespace();
+        t.name = functionType.name();
+        return t;
+      }
+
+      static FunctionType toSdk(SerializableFunctionType type) {
+        return new FunctionType(type.namespace, type.name);
+      }
+    }
+
+    private Map<SerializableFunctionType, SerializableStatefulFunctionProvider> functions;
+
+    public EmbeddedUniverseProvider(
+        Map<FunctionType, SerializableStatefulFunctionProvider> functions) {
+      this.functions = Maps.transformKeys(functions, SerializableFunctionType::fromSdk);
+    }
+
+    @Override
+    public StatefulFunctionsUniverse get(
+        ClassLoader classLoader, StatefulFunctionsConfig configuration) {
+
+      StatefulFunctionsUniverse u = new StatefulFunctionsUniverse(configuration.getFactoryType());
+
+      functions.forEach(
+          (type, fn) -> u.bindFunctionProvider(SerializableFunctionType.toSdk(type), fn));
+
+      return u;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslator.java
@@ -21,10 +21,10 @@ package org.apache.flink.statefun.flink.core.translation;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverseProvider;
-import org.apache.flink.statefun.flink.core.common.Maps;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.RoutableMessage;
@@ -66,40 +66,17 @@ public class EmbeddedTranslator {
 
     private static final long serialVersionUID = 1;
 
-    private static final class SerializableFunctionType implements Serializable {
-
-      private static final long serialVersionUID = 1;
-
-      String namespace;
-      String name;
-
-      static SerializableFunctionType fromSdk(FunctionType functionType) {
-        SerializableFunctionType t = new SerializableFunctionType();
-        t.namespace = functionType.namespace();
-        t.name = functionType.name();
-        return t;
-      }
-
-      static FunctionType toSdk(SerializableFunctionType type) {
-        return new FunctionType(type.namespace, type.name);
-      }
-    }
-
-    private Map<SerializableFunctionType, T> functions;
+    private Map<FunctionType, T> functions;
 
     public EmbeddedUniverseProvider(Map<FunctionType, T> functions) {
-      this.functions = Maps.transformKeys(functions, SerializableFunctionType::fromSdk);
+      this.functions = Objects.requireNonNull(functions);
     }
 
     @Override
     public StatefulFunctionsUniverse get(
         ClassLoader classLoader, StatefulFunctionsConfig configuration) {
-
       StatefulFunctionsUniverse u = new StatefulFunctionsUniverse(configuration.getFactoryType());
-
-      functions.forEach(
-          (type, fn) -> u.bindFunctionProvider(SerializableFunctionType.toSdk(type), fn));
-
+      functions.forEach(u::bindFunctionProvider);
       return u;
     }
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/FlinkUniverse.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/FlinkUniverse.java
@@ -19,26 +19,13 @@ package org.apache.flink.statefun.flink.core.translation;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalLong;
-import java.util.function.LongFunction;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
-import org.apache.flink.statefun.flink.core.StatefulFunctionsJobConstants;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
-import org.apache.flink.statefun.flink.core.common.KeyBy;
-import org.apache.flink.statefun.flink.core.common.SerializableFunction;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
-import org.apache.flink.statefun.flink.core.feedback.FeedbackSinkOperator;
-import org.apache.flink.statefun.flink.core.feedback.FeedbackUnionOperatorFactory;
-import org.apache.flink.statefun.flink.core.functions.FunctionGroupDispatchFactory;
 import org.apache.flink.statefun.flink.core.message.Message;
-import org.apache.flink.statefun.flink.core.message.MessageKeySelector;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
-import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.util.OutputTag;
 
 public final class FlinkUniverse {
   private static final FeedbackKey<Message> FEEDBACK_KEY =
@@ -57,90 +44,11 @@ public final class FlinkUniverse {
     Sources sources = Sources.create(env, universe, configuration);
     Sinks sinks = Sinks.create(universe);
 
-    SingleOutputStreamOperator<Message> feedbackUnionOperator =
-        feedbackUnionOperator(sources.unionStream());
+    StatefulFunctionTranslator translator =
+        new StatefulFunctionTranslator(FEEDBACK_KEY, configuration);
 
-    SingleOutputStreamOperator<Message> functionOutputStream =
-        functionOperator(feedbackUnionOperator, sinks.sideOutputTags());
+    Map<EgressIdentifier<?>, DataStream<?>> sideOutputs = translator.translate(sources, sinks);
 
-    SingleOutputStreamOperator<Void> writeBackOut = feedbackOperator(functionOutputStream);
-
-    coLocate(feedbackUnionOperator, functionOutputStream, writeBackOut);
-
-    sinks.consumeFrom(functionOutputStream);
-  }
-
-  private SingleOutputStreamOperator<Message> feedbackUnionOperator(DataStream<Message> input) {
-    TypeInformation<Message> typeInfo = input.getType();
-
-    FeedbackUnionOperatorFactory<Message> factory =
-        new FeedbackUnionOperatorFactory<>(
-            configuration, FEEDBACK_KEY, new IsCheckpointBarrier(), new FeedbackKeySelector());
-
-    return input
-        .keyBy(new MessageKeySelector())
-        .transform(StatefulFunctionsJobConstants.FEEDBACK_UNION_OPERATOR_NAME, typeInfo, factory)
-        .uid(StatefulFunctionsJobConstants.FEEDBACK_UNION_OPERATOR_UID);
-  }
-
-  private SingleOutputStreamOperator<Message> functionOperator(
-      DataStream<Message> input, Map<EgressIdentifier<?>, OutputTag<Object>> sideOutputs) {
-
-    TypeInformation<Message> typeInfo = input.getType();
-
-    FunctionGroupDispatchFactory operatorFactory =
-        new FunctionGroupDispatchFactory(configuration, sideOutputs);
-
-    return DataStreamUtils.reinterpretAsKeyedStream(input, new MessageKeySelector())
-        .transform(StatefulFunctionsJobConstants.FUNCTION_OPERATOR_NAME, typeInfo, operatorFactory)
-        .uid(StatefulFunctionsJobConstants.FUNCTION_OPERATOR_UID);
-  }
-
-  private SingleOutputStreamOperator<Void> feedbackOperator(
-      SingleOutputStreamOperator<Message> functionOut) {
-
-    LongFunction<Message> toMessage = new CheckpointToMessage(universe.messageFactoryType());
-
-    FeedbackSinkOperator<Message> sinkOperator =
-        new FeedbackSinkOperator<>(FEEDBACK_KEY, toMessage);
-
-    return functionOut
-        .keyBy(new MessageKeySelector())
-        .transform(
-            StatefulFunctionsJobConstants.WRITE_BACK_OPERATOR_NAME,
-            TypeInformation.of(Void.class),
-            sinkOperator)
-        .uid(StatefulFunctionsJobConstants.WRITE_BACK_OPERATOR_UID);
-  }
-
-  private static void coLocate(DataStream<?> a, DataStream<?> b, DataStream<?> c) {
-    String stringKey = FEEDBACK_KEY.asColocationKey();
-    a.getTransformation().setCoLocationGroupKey(stringKey);
-    b.getTransformation().setCoLocationGroupKey(stringKey);
-    c.getTransformation().setCoLocationGroupKey(stringKey);
-
-    a.getTransformation().setParallelism(b.getParallelism());
-    c.getTransformation().setParallelism(b.getParallelism());
-  }
-
-  private static final class IsCheckpointBarrier
-      implements SerializableFunction<Message, OptionalLong> {
-
-    private static final long serialVersionUID = 1;
-
-    @Override
-    public OptionalLong apply(Message message) {
-      return message.isBarrierMessage();
-    }
-  }
-
-  private static final class FeedbackKeySelector implements SerializableFunction<Message, String> {
-
-    private static final long serialVersionUID = 1;
-
-    @Override
-    public String apply(Message message) {
-      return KeyBy.apply(message.target());
-    }
+    sinks.consumeFrom(sideOutputs);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/StatefulFunctionTranslator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/StatefulFunctionTranslator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.translation;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.function.LongFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsJobConstants;
+import org.apache.flink.statefun.flink.core.common.KeyBy;
+import org.apache.flink.statefun.flink.core.common.SerializableFunction;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackSinkOperator;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackUnionOperatorFactory;
+import org.apache.flink.statefun.flink.core.functions.FunctionGroupDispatchFactory;
+import org.apache.flink.statefun.flink.core.message.Message;
+import org.apache.flink.statefun.flink.core.message.MessageKeySelector;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+
+final class StatefulFunctionTranslator {
+  private final FeedbackKey<Message> feedbackKey;
+  private final StatefulFunctionsConfig configuration;
+
+  StatefulFunctionTranslator(
+      FeedbackKey<Message> feedbackKey, StatefulFunctionsConfig configuration) {
+    this.feedbackKey = Objects.requireNonNull(feedbackKey);
+    this.configuration = Objects.requireNonNull(configuration);
+  }
+
+  Map<EgressIdentifier<?>, DataStream<?>> translate(Sources sources, Sinks sinks) {
+    SingleOutputStreamOperator<Message> feedbackUnionOperator =
+        feedbackUnionOperator(sources.unionStream());
+
+    SingleOutputStreamOperator<Message> functionOutputStream =
+        functionOperator(feedbackUnionOperator, sinks.sideOutputTags());
+
+    SingleOutputStreamOperator<Void> writeBackOut = feedbackOperator(functionOutputStream);
+
+    coLocate(feedbackUnionOperator, functionOutputStream, writeBackOut);
+
+    return sinks.sideOutputStreams(functionOutputStream);
+  }
+
+  private SingleOutputStreamOperator<Message> feedbackUnionOperator(DataStream<Message> input) {
+    TypeInformation<Message> typeInfo = input.getType();
+
+    FeedbackUnionOperatorFactory<Message> factory =
+        new FeedbackUnionOperatorFactory<>(
+            configuration, feedbackKey, new IsCheckpointBarrier(), new FeedbackKeySelector());
+
+    return input
+        .keyBy(new MessageKeySelector())
+        .transform(StatefulFunctionsJobConstants.FEEDBACK_UNION_OPERATOR_NAME, typeInfo, factory)
+        .uid(StatefulFunctionsJobConstants.FEEDBACK_UNION_OPERATOR_UID);
+  }
+
+  private SingleOutputStreamOperator<Message> functionOperator(
+      DataStream<Message> input, Map<EgressIdentifier<?>, OutputTag<Object>> sideOutputs) {
+
+    TypeInformation<Message> typeInfo = input.getType();
+
+    FunctionGroupDispatchFactory operatorFactory =
+        new FunctionGroupDispatchFactory(configuration, sideOutputs);
+
+    return DataStreamUtils.reinterpretAsKeyedStream(input, new MessageKeySelector())
+        .transform(StatefulFunctionsJobConstants.FUNCTION_OPERATOR_NAME, typeInfo, operatorFactory)
+        .uid(StatefulFunctionsJobConstants.FUNCTION_OPERATOR_UID);
+  }
+
+  private SingleOutputStreamOperator<Void> feedbackOperator(
+      SingleOutputStreamOperator<Message> functionOut) {
+
+    LongFunction<Message> toMessage = new CheckpointToMessage(configuration.getFactoryType());
+
+    FeedbackSinkOperator<Message> sinkOperator = new FeedbackSinkOperator<>(feedbackKey, toMessage);
+
+    return functionOut
+        .keyBy(new MessageKeySelector())
+        .transform(
+            StatefulFunctionsJobConstants.WRITE_BACK_OPERATOR_NAME,
+            TypeInformation.of(Void.class),
+            sinkOperator)
+        .uid(StatefulFunctionsJobConstants.WRITE_BACK_OPERATOR_UID);
+  }
+
+  private void coLocate(DataStream<?> a, DataStream<?> b, DataStream<?> c) {
+    String stringKey = feedbackKey.asColocationKey();
+    a.getTransformation().setCoLocationGroupKey(stringKey);
+    b.getTransformation().setCoLocationGroupKey(stringKey);
+    c.getTransformation().setCoLocationGroupKey(stringKey);
+
+    a.getTransformation().setParallelism(b.getParallelism());
+    c.getTransformation().setParallelism(b.getParallelism());
+  }
+
+  private static final class IsCheckpointBarrier
+      implements SerializableFunction<Message, OptionalLong> {
+
+    private static final long serialVersionUID = 1;
+
+    @Override
+    public OptionalLong apply(Message message) {
+      return message.isBarrierMessage();
+    }
+  }
+
+  private static final class FeedbackKeySelector implements SerializableFunction<Message, String> {
+
+    private static final long serialVersionUID = 1;
+
+    @Override
+    public String apply(Message message) {
+      return KeyBy.apply(message.target());
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>statefun-flink</artifactId>
+        <version>2.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>statefun-flink-datastream</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <!-- statefun-flink -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-flink-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-flink-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+  
+        <!-- The following dependencies are here with scope provided, because: 
+             a) they are transitively required by the statefun-flink-* depencies
+             b) they are provided at runtime, by the embedding application. 
+             
+             Also note that org.slf4j:slf4j-api is excluded from all the artifacts, since maven 
+             convergence plugging fails. 
+           -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+       </dependency>
+        
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <!-- Run shade goal on package phase -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.flink:force-shading</exclude>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>log4j:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- Do not copy the signatures in the META-INF folder.
+                                    Otherwise, this might cause SecurityExceptions when using the JAR. -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.kafka:*</artifact>
+                                    <excludes>
+                                        <exclude>kafka/kafka-version.properties</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <!-- Does not contain anything relevant.
+                                            Cites a binary dependency on jersey, but this is neither reflected in the
+                                            dependency graph, nor are any jersey files bundled. -->
+                                        <exclude>NOTICE</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <!-- required to aggregate all the META-INF/services files -->
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- remove all duplicate licenses -->
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <!-- explicitly include our LICENSE file, located at project root dir -->
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE</resource>
+                                    <file>${basedir}/../../LICENSE</file>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <projectName>Apache Flink Stateful Functions (flink-statefun)</projectName>
+                                    <encoding>UTF-8</encoding>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.net.URI;
+import java.time.Duration;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionSpec;
+import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
+import org.apache.flink.statefun.sdk.FunctionType;
+
+/** A Builder for RequestReply remote function type. */
+public class RequestReplyFunctionBuilder {
+
+  /**
+   * Create a new builder for a remote function with a given type and an endpoint.
+   *
+   * @param functionType the function type that is served remotely.
+   * @param endpoint the endpoint that serves that remote function.
+   * @return a builder.
+   */
+  public static RequestReplyFunctionBuilder requestReplyFunctionBuilder(
+      FunctionType functionType, URI endpoint) {
+    return new RequestReplyFunctionBuilder(functionType, endpoint);
+  }
+
+  private final HttpFunctionSpec.Builder builder;
+
+  private RequestReplyFunctionBuilder(FunctionType functionType, URI endpoint) {
+    this.builder = HttpFunctionSpec.builder(functionType, endpoint);
+  }
+
+  /**
+   * Declares a remote function state.
+   *
+   * @param name the name of the state to be used remotely.
+   * @return this builder.
+   */
+  public RequestReplyFunctionBuilder withPersistedState(String name) {
+    builder.withState(new StateSpec(name, Duration.ZERO));
+    return this;
+  }
+
+  /**
+   * Declares a remote function state, with expiration.
+   *
+   * @param name the name of the state to be used remotely.
+   * @param expireAfter the duration after which this state might be deleted.
+   * @return this builder.
+   */
+  public RequestReplyFunctionBuilder withExpiringState(String name, Duration expireAfter) {
+    builder.withState(new StateSpec(name, expireAfter));
+    return this;
+  }
+
+  /**
+   * Set a maximum request duration.
+   *
+   * @param duration the duration after which the request is considered failed.
+   * @return this builder.
+   */
+  public RequestReplyFunctionBuilder withMaxRequestDuration(Duration duration) {
+    builder.withMaxRequestDuration(duration);
+    return this;
+  }
+
+  /**
+   * Sets the max messages to batch together for a specific address.
+   *
+   * @param maxNumBatchRequests the maximum number of requests to batch for an address.
+   * @return this builder.
+   */
+  public RequestReplyFunctionBuilder withMaxNumBatchRequests(int maxNumBatchRequests) {
+    builder.withMaxNumBatchRequests(maxNumBatchRequests);
+    return this;
+  }
+
+  @Internal
+  HttpFunctionSpec spec() {
+    return builder.build();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionProvider;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionSpec;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+
+@NotThreadSafe
+@Internal
+final class SerializableHttpFunctionProvider implements SerializableStatefulFunctionProvider {
+
+  private static final long serialVersionUID = 1;
+
+  private final Map<FunctionType, HttpFunctionSpec> supportedTypes;
+  private transient @Nullable HttpFunctionProvider delegate;
+
+  SerializableHttpFunctionProvider(Map<FunctionType, HttpFunctionSpec> supportedTypes) {
+    this.supportedTypes = Objects.requireNonNull(supportedTypes);
+  }
+
+  @Override
+  public StatefulFunction functionOfType(FunctionType type) {
+    if (delegate == null) {
+      delegate = new HttpFunctionProvider(supportedTypes);
+    }
+    return delegate.functionOfType(type);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableStatefulFunctionProvider.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableStatefulFunctionProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.io.Serializable;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+
+/** {@inheritDoc} */
+public interface SerializableStatefulFunctionProvider
+    extends StatefulFunctionProvider, Serializable {}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.flink.shaded.guava18.com.google.common.base.Optional;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
+import org.apache.flink.statefun.flink.core.message.Message;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.core.translation.EmbeddedTranslator;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/**
+ * Builder for a Stateful Function Application.
+ *
+ * <p>This builder allows defining all the aspects of a stateful function application. define input
+ * streams as ingresses, define function providers and egress ids.
+ */
+public final class StatefulFunctionDataStreamBuilder {
+
+  public static StatefulFunctionDataStreamBuilder builder(String pipelineName) {
+    FeedbackKey<Message> key = new FeedbackKey<>(pipelineName, 1);
+    return new StatefulFunctionDataStreamBuilder(key);
+  }
+
+  private StatefulFunctionDataStreamBuilder(FeedbackKey<Message> feedbackKey) {
+    this.feedbackKey = Objects.requireNonNull(feedbackKey);
+  }
+
+  private final FeedbackKey<Message> feedbackKey;
+  private final List<DataStream<RoutableMessage>> definedIngresses = new ArrayList<>();
+  private final Map<FunctionType, SerializableStatefulFunctionProvider> functionProviders =
+      new HashMap<>();
+  private final Set<EgressIdentifier<?>> egressesIds = new LinkedHashSet<>();
+
+  @Nullable private StatefulFunctionsConfig config;
+
+  /**
+   * Adds an ingress of incoming messages.
+   *
+   * @param ingress an incoming stream of messages.
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withDataStreamAsIngress(
+      DataStream<RoutableMessage> ingress) {
+    Objects.requireNonNull(ingress);
+    definedIngresses.add(ingress);
+    return this;
+  }
+
+  /**
+   * Adds a function provider to this builder
+   *
+   * @param functionType the type of the function that this provider providers.
+   * @param provider the stateful function provider.
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withFunctionProvider(
+      FunctionType functionType, SerializableStatefulFunctionProvider provider) {
+    Objects.requireNonNull(functionType);
+    Objects.requireNonNull(provider);
+    putAndThrowIfPresent(functionProviders, functionType, provider);
+    return this;
+  }
+
+  /**
+   * Registers an {@link EgressIdentifier}.
+   *
+   * <p>See {@link StatefulFunctionEgressStreams#getDataStreamForEgressId(EgressIdentifier)}.
+   *
+   * @param egressId an ingress id
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withEgressId(EgressIdentifier<?> egressId) {
+    Objects.requireNonNull(egressId);
+    putAndThrowIfPresent(egressesIds, egressId);
+    return this;
+  }
+
+  /**
+   * Set a stateful function configuration.
+   *
+   * @param configuration the stateful function configuration to set.
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withConfiguration(
+      StatefulFunctionsConfig configuration) {
+    Objects.requireNonNull(configuration);
+    this.config = configuration;
+    return this;
+  }
+
+  /**
+   * Adds Stateful Functions operators into the topology.
+   *
+   * @param env the stream execution environment.
+   */
+  public StatefulFunctionEgressStreams build(StreamExecutionEnvironment env) {
+    final StatefulFunctionsConfig config =
+        Optional.fromNullable(this.config).or(() -> StatefulFunctionsConfig.fromEnvironment(env));
+    EmbeddedTranslator embeddedTranslator = new EmbeddedTranslator(config, feedbackKey);
+    Map<EgressIdentifier<?>, DataStream<?>> sideOutputs =
+        embeddedTranslator.translate(definedIngresses, egressesIds, functionProviders);
+    return new StatefulFunctionEgressStreams(sideOutputs);
+  }
+
+  private static <K, V> void putAndThrowIfPresent(Map<K, V> map, K key, V value) {
+    @Nullable V previous = map.put(key, value);
+    if (previous == null) {
+      return;
+    }
+    throw new IllegalStateException(
+        String.format("A binding for the key %s was previously defined.", key));
+  }
+
+  private static <K> void putAndThrowIfPresent(Set<K> set, K key) {
+    if (set.add(key)) {
+      return;
+    }
+    throw new IllegalStateException(
+        String.format("A binding for the key %s was previously defined.", key));
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
@@ -46,6 +46,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  */
 public final class StatefulFunctionDataStreamBuilder {
 
+  /** Creates a {@code StatefulFunctionDataStreamBuilder}. */
   public static StatefulFunctionDataStreamBuilder builder(String pipelineName) {
     FeedbackKey<Message> key = new FeedbackKey<>(pipelineName, 1);
     return new StatefulFunctionDataStreamBuilder(key);

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+public final class StatefulFunctionEgressStreams {
+  private final Map<EgressIdentifier<?>, DataStream<?>> egresses;
+
+  StatefulFunctionEgressStreams(Map<EgressIdentifier<?>, DataStream<?>> egresses) {
+    this.egresses = Objects.requireNonNull(egresses);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> DataStream<T> getDataStreamForEgressId(EgressIdentifier<T> id) {
+    DataStream<?> dataStream = egresses.get(id);
+    if (dataStream == null) {
+      throw new IllegalArgumentException("Unknown data stream for ingress " + id);
+    }
+    return (DataStream<T>) dataStream;
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
@@ -30,11 +30,24 @@ public final class StatefulFunctionEgressStreams {
     this.egresses = Objects.requireNonNull(egresses);
   }
 
+  /**
+   * Returns the {@link DataStream} that represents a stateful functions egress for an {@link
+   * EgressIdentifier}.
+   *
+   * <p>Messages that are sent to an egress with the supplied id, (via {@link
+   * org.apache.flink.statefun.sdk.Context#send(EgressIdentifier, Object)}) would result in the
+   * {@link DataStream} returned from that method.
+   *
+   * @param id the egress id, as provided to {@link
+   *     StatefulFunctionDataStreamBuilder#withEgressId(EgressIdentifier)}.
+   * @param <T> the egress message type.
+   * @return a data stream that represents messages sent to the provided egress.
+   */
   @SuppressWarnings("unchecked")
   public <T> DataStream<T> getDataStreamForEgressId(EgressIdentifier<T> id) {
     DataStream<?> dataStream = egresses.get(id);
     if (dataStream == null) {
-      throw new IllegalArgumentException("Unknown data stream for ingress " + id);
+      throw new IllegalArgumentException("Unknown data stream for egress " + id);
     }
     return (DataStream<T>) dataStream;
   }

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
@@ -20,12 +20,19 @@ package org.apache.flink.statefun.flink.datastream;
 
 import java.util.Map;
 import java.util.Objects;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
+/**
+ * StatefulFunctionEgressStreams - this class holds a handle for every egress stream defined via
+ * {@link StatefulFunctionDataStreamBuilder#withEgressId(EgressIdentifier)}. see {@link
+ * #getDataStreamForEgressId(EgressIdentifier)}.
+ */
 public final class StatefulFunctionEgressStreams {
   private final Map<EgressIdentifier<?>, DataStream<?>> egresses;
 
+  @Internal
   StatefulFunctionEgressStreams(Map<EgressIdentifier<?>, DataStream<?>> egresses) {
     this.egresses = Objects.requireNonNull(egresses);
   }
@@ -45,6 +52,7 @@ public final class StatefulFunctionEgressStreams {
    */
   @SuppressWarnings("unchecked")
   public <T> DataStream<T> getDataStreamForEgressId(EgressIdentifier<T> id) {
+    Objects.requireNonNull(id);
     DataStream<?> dataStream = egresses.get(id);
     if (dataStream == null) {
       throw new IllegalArgumentException("Unknown data stream for egress " + id);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/FunctionType.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/FunctionType.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.sdk;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -28,7 +29,10 @@ import java.util.Objects;
  *
  * @see Address
  */
-public final class FunctionType {
+public final class FunctionType implements Serializable {
+
+  private static final long serialVersionUID = 1;
+
   private final String namespace;
   private final String type;
 


### PR DESCRIPTION
# Add DataStream API interoperability

This PR adds an extension the stateful function SDK that allows embedding stateful function applications into a data stream program. 

This integration allows:
* defining `DataStream`s as StateFun ingresses
* binding one or more stateful functions
* binding remote `RequestReply` functions
* and finally obtaining StateFun egresses as `DataStream`s.

Here is a short example snippet of how to insert a StateFun pipeline into a regular DataStream pipeline.  ([full example](statefun-examples/statefun-flink-datastream-example/src/main/java/org/apache/flink/statefun/examples/datastream/Example.java))

```
  StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
  
  DataStream<String> namesStream = ... ;  

  DataStream<RoutableMessage> names =
        namesStream
            .map(
                name ->
                    RoutableMessageBuilder.builder()
                        .withTargetAddress(GREET, name)
                        .withMessageBody(name)
                        .build());

  ...
  StatefulFunctionEgressStreams out =
        StatefulFunctionDataStreamBuilder.builder("example")
            .withDataStreamAsIngress(names)
            .withFunctionProvider(GREET, unused -> new MyFunction())
            .withRequestReplyRemoteFunction(
                requestReplyFunctionBuilder(
                        REMOTE_GREET, URI.create("http://localhost:5000/statefun"))
                    .withPersistedState("seen_count")
                    .withMaxRequestDuration(Duration.ofSeconds(15))
                    .withMaxNumBatchRequests(500))
            .withEgressId(GREETINGS)
            .withConfiguration(statefunConfig)
            .build(env);
  ...
```

- A `RoutableMessage` is the entry point to the StateFun pipeline.
- Then it is possible to register 1 or more `DataStream<RoutableMessage>` as ingresses.
- StateFun would deliver the `payloads` associated with the `RoutableMessage` to the appropriate stateful function instance. 
- Egress ids has to be explicitly defined, and they can be collected as a `DataStream`  from `StatefulFunctionEgressStreams`.

----

The following is a short description of the changes (not in the same commit order)
* Add a `statefun-flink/statefun-flink-datastream` for the new SDK.
* Added a new example under examples/
* Restructured the translation logic so that it can be used both from the data stream api and the regular statefun sdk.
  
 