### PR TITLE
[FLINK-19095] [remote] Allow state expiration mode for remote function state

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/StateSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/StateSpec.java
@@ -19,30 +19,30 @@
 package org.apache.flink.statefun.flink.core.httpfn;
 
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.Objects;
+import org.apache.flink.statefun.sdk.state.Expiration;
 
 public final class StateSpec implements Serializable {
 
   private static final long serialVersionUID = 1;
 
   private final String name;
-  private final Duration ttlDuration;
+  private final Expiration ttlExpiration;
 
   public StateSpec(String name) {
-    this(name, Duration.ZERO);
+    this(name, Expiration.none());
   }
 
-  public StateSpec(String name, Duration ttlDuration) {
+  public StateSpec(String name, Expiration ttlExpiration) {
     this.name = Objects.requireNonNull(name);
-    this.ttlDuration = Objects.requireNonNull(ttlDuration);
+    this.ttlExpiration = Objects.requireNonNull(ttlExpiration);
   }
 
   public String name() {
     return name;
   }
 
-  public Duration ttlDuration() {
-    return ttlDuration;
+  public Expiration ttlExpiration() {
+    return ttlExpiration;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.statefun.flink.core.reqreply;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,6 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
-import org.apache.flink.statefun.sdk.state.Expiration;
 import org.apache.flink.statefun.sdk.state.PersistedStateRegistry;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 
@@ -55,14 +53,7 @@ public final class PersistedRemoteFunctionValues {
   }
 
   private PersistedValue<byte[]> createStateHandle(StateSpec stateSpec) {
-    final String stateName = stateSpec.name();
-    final Duration stateTtlDuration = stateSpec.ttlDuration();
-    final Expiration stateExpirationConfig =
-        (stateTtlDuration.equals(Duration.ZERO))
-            ? Expiration.none()
-            : Expiration.expireAfterReadingOrWriting(stateTtlDuration);
-
-    return stateRegistry.registerValue(stateName, byte[].class, stateExpirationConfig);
+    return stateRegistry.registerValue(stateSpec.name(), byte[].class, stateSpec.ttlExpiration());
   }
 
   private PersistedValue<byte[]> getStateHandleOrThrow(String stateName) {

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v2_0/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v2_0/module.yaml
@@ -36,6 +36,7 @@ module:
             states:
               - name: seen_count
                 expireAfter: 60000millisecond
+                expireMode: after-invoke
             maxNumBatchRequests: 10000
       - function:
           meta:

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -24,6 +24,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionSpec;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.state.Expiration;
 
 /** A Builder for RequestReply remote function type. */
 public class RequestReplyFunctionBuilder {
@@ -53,7 +54,7 @@ public class RequestReplyFunctionBuilder {
    * @return this builder.
    */
   public RequestReplyFunctionBuilder withPersistedState(String name) {
-    builder.withState(new StateSpec(name, Duration.ZERO));
+    builder.withState(new StateSpec(name, Expiration.none()));
     return this;
   }
 
@@ -61,11 +62,11 @@ public class RequestReplyFunctionBuilder {
    * Declares a remote function state, with expiration.
    *
    * @param name the name of the state to be used remotely.
-   * @param expireAfter the duration after which this state might be deleted.
+   * @param ttlExpiration the expiration mode for which this state might be deleted.
    * @return this builder.
    */
-  public RequestReplyFunctionBuilder withExpiringState(String name, Duration expireAfter) {
-    builder.withState(new StateSpec(name, expireAfter));
+  public RequestReplyFunctionBuilder withExpiringState(String name, Expiration ttlExpiration) {
+    builder.withState(new StateSpec(name, ttlExpiration));
     return this;
   }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.statefun.sdk.state;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Objects;
 import org.apache.flink.statefun.sdk.annotations.ForRuntime;
@@ -32,7 +33,10 @@ import org.apache.flink.statefun.sdk.annotations.ForRuntime;
  * <p>State can be expired after a duration had passed since either from the last write to the
  * state, or the last read.
  */
-public final class Expiration {
+public final class Expiration implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
   public enum Mode {
     NONE,
     AFTER_WRITE,


### PR DESCRIPTION
Before this PR, since state was multiplexed, we didn't allow state to have individual state expiration modes, and everything was defaulted to expire with "after-read-and-write" mode.

Now with state de-multiplexed, it is possible to allow this, with the following configuration:

```
functions:
    function:
        spec:
            states:
                - name: xxxx
                  expireAfter: 60000millisecond
                  expireMode: [after-invoke | after-write]
```

Note that I named the usual `after-read-or-write` module as `after-invoke` in the remote function case.
This is due to the fact that they are semantically equivalent in the remote function case, and naming it as such seems to be less confusing for users using remote functions.