### PR TITLE
[FLINK-19096] [sdk] Rework PersistedStateRegistry registration methods

### DIFF
--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -180,15 +180,19 @@ public class PersistedStatesTest {
     @Persisted PersistedStateRegistry provider = new PersistedStateRegistry();
 
     DynamicState() {
-      provider.registerValue("in-constructor-value", String.class);
-      provider.registerTable("in-constructor-table", String.class, Integer.class);
-      provider.registerAppendingBuffer("in-constructor-buffer", String.class);
+      provider.registerValue(PersistedValue.of("in-constructor-value", String.class));
+      provider.registerTable(
+          PersistedTable.of("in-constructor-table", String.class, Integer.class));
+      provider.registerAppendingBuffer(
+          PersistedAppendingBuffer.of("in-constructor-buffer", String.class));
     }
 
     void process() {
-      provider.registerValue("post-constructor-value", String.class);
-      provider.registerTable("post-constructor-table", String.class, Integer.class);
-      provider.registerAppendingBuffer("post-constructor-buffer", String.class);
+      provider.registerValue(PersistedValue.of("post-constructor-value", String.class));
+      provider.registerTable(
+          PersistedTable.of("post-constructor-table", String.class, Integer.class));
+      provider.registerAppendingBuffer(
+          PersistedAppendingBuffer.of("post-constructor-buffer", String.class));
     }
   }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
@@ -82,4 +82,9 @@ public final class Expiration {
   public Duration duration() {
     return duration;
   }
+
+  @Override
+  public String toString() {
+    return String.format("Expiration{mode=%s, duration=%s}", mode, duration);
+  }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
@@ -160,6 +160,13 @@ public final class PersistedAppendingBuffer<E> {
     accessor.clear();
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedAppendingBuffer{name=%s, elementType=%s, expiration=%s}",
+        name, elementType.getName(), expiration);
+  }
+
   @ForRuntime
   void setAccessor(AppendingBufferAccessor<E> newAccessor) {
     this.accessor = Objects.requireNonNull(newAccessor);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
@@ -121,9 +121,7 @@ public final class PersistedStateRegistry {
       throw new IllegalStateException(
           String.format(
               "State name '%s' was registered twice; previous registered state object with the same name was a %s, attempting to register a new %s under the same name.",
-              stateName,
-              previousRegistration.getClass().getName(),
-              newStateObject.getClass().getName()));
+              stateName, previousRegistration, newStateObject));
     }
 
     registeredStates.put(stateName, newStateObject);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -182,6 +182,13 @@ public final class PersistedTable<K, V> {
     accessor.clear();
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedTable{name=%s, keyType=%s, valueType=%s, expiration=%s}",
+        name, keyType.getName(), valueType.getName(), expiration);
+  }
+
   @ForRuntime
   void setAccessor(TableAccessor<K, V> newAccessor) {
     Objects.requireNonNull(newAccessor);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
@@ -165,6 +165,12 @@ public final class PersistedValue<T> {
     this.accessor = newAccessor;
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedValue{name=%s, type=%s, expiration=%s}", name, type.getName(), expiration);
+  }
+
   private static final class NonFaultTolerantAccessor<E> implements Accessor<E> {
     private E element;
 

--- a/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
+++ b/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
@@ -26,16 +26,16 @@ public class PersistedStateRegistryTest {
   public void exampleUsage() {
     final PersistedStateRegistry registry = new PersistedStateRegistry();
 
-    registry.registerValue("value", String.class);
-    registry.registerTable("table", String.class, Integer.class);
-    registry.registerAppendingBuffer("buffer", String.class);
+    registry.registerValue(PersistedValue.of("value", String.class));
+    registry.registerTable(PersistedTable.of("table", String.class, Integer.class));
+    registry.registerAppendingBuffer(PersistedAppendingBuffer.of("buffer", String.class));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void reaccessAsWrongStatePrimitiveType() {
+  public void duplicateRegistration() {
     final PersistedStateRegistry registry = new PersistedStateRegistry();
 
-    registry.registerValue("my-state", String.class);
-    registry.registerAppendingBuffer("my-state", String.class);
+    registry.registerValue(PersistedValue.of("my-state", String.class));
+    registry.registerTable(PersistedTable.of("my-state", String.class, Integer.class));
   }
 }


### PR DESCRIPTION
This reworks the `registerValue` / `registerTable` etc. methods on `PersistedStateRegistry` to directly accept a constructed `PersistedValue` / `PersistedTable` instance.
This allows us to avoid having to synchronize the arguments of those methods and the state class constructors.

The usage now looks like this:

```
public class MyFunction implements StatefulFunction {
 
      @Persisted
      PersistedStateRegistry registry = new PersistedStateRegistry();
 
      public MyFunction() {
            // works during function instantiation ...
            registry.registerValue(PersistedValue.of(...));
      }

      @Override
      public void invoke(Context context, Object input) {
          // or during runtime
          registry.registerValue(PersistedValue.of(...));
      }
 }
```

The `register*` methods throw if a duplicate registration occurred for the same state name.

## Validating the change

All existing tests in `PersistedStateRegistryTest` and `PersistedStatesTest` cover this change.