### PR TITLE
[FLINK-19102] [core, sdk] Make StateBinder a per-FunctionType entity

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -35,7 +35,6 @@ import org.apache.flink.statefun.flink.core.message.MessageFactory;
 import org.apache.flink.statefun.flink.core.metrics.FlinkMetricsFactory;
 import org.apache.flink.statefun.flink.core.metrics.MetricsFactory;
 import org.apache.flink.statefun.flink.core.state.FlinkState;
-import org.apache.flink.statefun.flink.core.state.FlinkStateBinder;
 import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
@@ -94,7 +93,6 @@ final class Reductions {
     container.add("applying-context", ApplyingContext.class, ReusableContext.class);
     container.add(LocalSink.class);
     container.add("function-loader", FunctionLoader.class, PredefinedFunctionLoader.class);
-    container.add(FlinkStateBinder.class);
     container.add(Reductions.class);
     container.add(LocalFunctionGroup.class);
     container.add("metrics-factory", MetricsFactory.class, new FlinkMetricsFactory(metricGroup));

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
@@ -64,7 +64,7 @@ final class StatefulFunctionRepository implements FunctionRepository {
         functionLoader.load(functionType);
     try (SetContextClassLoader ignored = new SetContextClassLoader(statefulFunction)) {
       FlinkStateBinder stateBinderForType = new FlinkStateBinder(flinkState, functionType);
-      PersistedStates.findAndBind(statefulFunction, stateBinderForType);
+      PersistedStates.findReflectivelyAndBind(statefulFunction, stateBinderForType);
       FunctionTypeMetrics metrics = metricsFactory.forType(functionType);
       return new StatefulFunction(statefulFunction, metrics, messageFactory);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
@@ -19,7 +19,6 @@ package org.apache.flink.statefun.flink.core.state;
 
 import java.util.Objects;
 import org.apache.flink.statefun.flink.core.di.Inject;
-import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.state.Accessor;
 import org.apache.flink.statefun.sdk.state.ApiExtension;
@@ -30,30 +29,35 @@ import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.StateBinder;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 
+/**
+ * A {@link StateBinder} that binds persisted state objects to Flink state for a specific {@link
+ * FunctionType}.
+ */
 public final class FlinkStateBinder extends StateBinder {
   private final State state;
+  private final FunctionType functionType;
 
   @Inject
-  public FlinkStateBinder(@Label("state") State state) {
+  public FlinkStateBinder(State state, FunctionType functionType) {
     this.state = Objects.requireNonNull(state);
+    this.functionType = Objects.requireNonNull(functionType);
   }
 
   @Override
-  public void bindValue(PersistedValue<?> persistedValue, FunctionType functionType) {
+  public void bindValue(PersistedValue<?> persistedValue) {
     Accessor<?> accessor = state.createFlinkStateAccessor(functionType, persistedValue);
     setAccessorRaw(persistedValue, accessor);
   }
 
   @Override
-  public void bindTable(PersistedTable<?, ?> persistedTable, FunctionType functionType) {
+  public void bindTable(PersistedTable<?, ?> persistedTable) {
     TableAccessor<?, ?> accessor =
         state.createFlinkStateTableAccessor(functionType, persistedTable);
     setAccessorRaw(persistedTable, accessor);
   }
 
   @Override
-  public void bindAppendingBuffer(
-      PersistedAppendingBuffer<?> persistedAppendingBuffer, FunctionType functionType) {
+  public void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer) {
     AppendingBufferAccessor<?> accessor =
         state.createFlinkStateAppendingBufferAccessor(functionType, persistedAppendingBuffer);
     setAccessorRaw(persistedAppendingBuffer, accessor);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -35,7 +35,7 @@ import org.apache.flink.statefun.sdk.state.PersistedValue;
 
 public final class PersistedStates {
 
-  public static void findAndBind(@Nullable Object instance, FlinkStateBinder stateBinder) {
+  public static void findReflectivelyAndBind(@Nullable Object instance, FlinkStateBinder stateBinder) {
     List<?> states = findReflectively(instance);
     for (Object persisted : states) {
       if (persisted instanceof PersistedStateRegistry) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.state.ApiExtension;
 import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
@@ -36,15 +35,14 @@ import org.apache.flink.statefun.sdk.state.PersistedValue;
 
 public final class PersistedStates {
 
-  public static void findAndBind(
-      FunctionType functionType, @Nullable Object instance, FlinkStateBinder stateBinder) {
+  public static void findAndBind(@Nullable Object instance, FlinkStateBinder stateBinder) {
     List<?> states = findReflectively(instance);
     for (Object persisted : states) {
       if (persisted instanceof PersistedStateRegistry) {
         PersistedStateRegistry stateRegistry = (PersistedStateRegistry) persisted;
-        ApiExtension.bindPersistedStateRegistry(stateRegistry, stateBinder, functionType);
+        ApiExtension.bindPersistedStateRegistry(stateRegistry, stateBinder);
       } else {
-        stateBinder.bind(persisted, functionType);
+        stateBinder.bind(persisted);
       }
     }
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
@@ -17,8 +17,6 @@
  */
 package org.apache.flink.statefun.sdk.state;
 
-import org.apache.flink.statefun.sdk.FunctionType;
-
 public class ApiExtension {
   public static <T> void setPersistedValueAccessor(
       PersistedValue<T> persistedValue, Accessor<T> accessor) {
@@ -36,9 +34,7 @@ public class ApiExtension {
   }
 
   public static void bindPersistedStateRegistry(
-      PersistedStateRegistry persistedStateRegistry,
-      StateBinder stateBinder,
-      FunctionType functionType) {
-    persistedStateRegistry.bind(stateBinder, functionType);
+      PersistedStateRegistry persistedStateRegistry, StateBinder stateBinder) {
+    persistedStateRegistry.bind(stateBinder);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -47,52 +47,50 @@ public class PersistedStatesTest {
   private final FakeState state = new FakeState();
 
   // object under test
-  private final FlinkStateBinder binderUnderTest = new FlinkStateBinder(state);
+  private final FlinkStateBinder binderUnderTest =
+      new FlinkStateBinder(state, TestUtils.FUNCTION_TYPE);
 
   @Test
   public void exampleUsage() {
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, new SanityClass(), binderUnderTest);
+    PersistedStates.findAndBind(new SanityClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("name", "last"));
   }
 
   @Test(expected = IllegalStateException.class)
   public void nullValueField() {
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, new NullValueClass(), binderUnderTest);
+    PersistedStates.findAndBind(new NullValueClass(), binderUnderTest);
   }
 
   @Test
   public void nonAnnotatedClass() {
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, new IgnoreNonAnnotated(), binderUnderTest);
+    PersistedStates.findAndBind(new IgnoreNonAnnotated(), binderUnderTest);
 
     assertTrue(state.boundNames.isEmpty());
   }
 
   @Test
   public void extendedClass() {
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, new ChildClass(), binderUnderTest);
+    PersistedStates.findAndBind(new ChildClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("parent", "child"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void staticPersistedFieldsAreNotAllowed() {
-    PersistedStates.findAndBind(
-        TestUtils.FUNCTION_TYPE, new StaticPersistedValue(), binderUnderTest);
+    PersistedStates.findAndBind(new StaticPersistedValue(), binderUnderTest);
   }
 
   @Test
   public void bindPersistedTable() {
-    PersistedStates.findAndBind(
-        TestUtils.FUNCTION_TYPE, new PersistedTableValue(), binderUnderTest);
+    PersistedStates.findAndBind(new PersistedTableValue(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("table"));
   }
 
   @Test
   public void bindPersistedAppendingBuffer() {
-    PersistedStates.findAndBind(
-        TestUtils.FUNCTION_TYPE, new PersistedAppendingBufferState(), binderUnderTest);
+    PersistedStates.findAndBind(new PersistedAppendingBufferState(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("buffer"));
   }
@@ -100,7 +98,7 @@ public class PersistedStatesTest {
   @Test
   public void bindDynamicState() {
     DynamicState dynamicState = new DynamicState();
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, dynamicState, binderUnderTest);
+    PersistedStates.findAndBind(dynamicState, binderUnderTest);
 
     dynamicState.process();
 
@@ -117,7 +115,7 @@ public class PersistedStatesTest {
 
   @Test
   public void bindComposedState() {
-    PersistedStates.findAndBind(TestUtils.FUNCTION_TYPE, new OuterClass(), binderUnderTest);
+    PersistedStates.findAndBind(new OuterClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("inner"));
   }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -180,15 +180,19 @@ public class PersistedStatesTest {
     @Persisted PersistedStateRegistry provider = new PersistedStateRegistry();
 
     DynamicState() {
-      provider.registerValue("in-constructor-value", String.class);
-      provider.registerTable("in-constructor-table", String.class, Integer.class);
-      provider.registerAppendingBuffer("in-constructor-buffer", String.class);
+      provider.registerValue(PersistedValue.of("in-constructor-value", String.class));
+      provider.registerTable(
+          PersistedTable.of("in-constructor-table", String.class, Integer.class));
+      provider.registerAppendingBuffer(
+          PersistedAppendingBuffer.of("in-constructor-buffer", String.class));
     }
 
     void process() {
-      provider.registerValue("post-constructor-value", String.class);
-      provider.registerTable("post-constructor-table", String.class, Integer.class);
-      provider.registerAppendingBuffer("post-constructor-buffer", String.class);
+      provider.registerValue(PersistedValue.of("post-constructor-value", String.class));
+      provider.registerTable(
+          PersistedTable.of("post-constructor-table", String.class, Integer.class));
+      provider.registerAppendingBuffer(
+          PersistedAppendingBuffer.of("post-constructor-buffer", String.class));
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -52,45 +52,45 @@ public class PersistedStatesTest {
 
   @Test
   public void exampleUsage() {
-    PersistedStates.findAndBind(new SanityClass(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new SanityClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("name", "last"));
   }
 
   @Test(expected = IllegalStateException.class)
   public void nullValueField() {
-    PersistedStates.findAndBind(new NullValueClass(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new NullValueClass(), binderUnderTest);
   }
 
   @Test
   public void nonAnnotatedClass() {
-    PersistedStates.findAndBind(new IgnoreNonAnnotated(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new IgnoreNonAnnotated(), binderUnderTest);
 
     assertTrue(state.boundNames.isEmpty());
   }
 
   @Test
   public void extendedClass() {
-    PersistedStates.findAndBind(new ChildClass(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new ChildClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("parent", "child"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void staticPersistedFieldsAreNotAllowed() {
-    PersistedStates.findAndBind(new StaticPersistedValue(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new StaticPersistedValue(), binderUnderTest);
   }
 
   @Test
   public void bindPersistedTable() {
-    PersistedStates.findAndBind(new PersistedTableValue(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new PersistedTableValue(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("table"));
   }
 
   @Test
   public void bindPersistedAppendingBuffer() {
-    PersistedStates.findAndBind(new PersistedAppendingBufferState(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new PersistedAppendingBufferState(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("buffer"));
   }
@@ -98,7 +98,7 @@ public class PersistedStatesTest {
   @Test
   public void bindDynamicState() {
     DynamicState dynamicState = new DynamicState();
-    PersistedStates.findAndBind(dynamicState, binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(dynamicState, binderUnderTest);
 
     dynamicState.process();
 
@@ -115,7 +115,7 @@ public class PersistedStatesTest {
 
   @Test
   public void bindComposedState() {
-    PersistedStates.findAndBind(new OuterClass(), binderUnderTest);
+    PersistedStates.findReflectivelyAndBind(new OuterClass(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("inner"));
   }

--- a/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistry.java
+++ b/statefun-flink/statefun-flink-state-processor/src/main/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistry.java
@@ -117,7 +117,7 @@ public final class StateBootstrapFunctionRegistry implements Serializable {
   private static StateBootstrapFunction bindState(
       StateBootstrapFunction bootstrapFunction, FlinkStateBinder stateBinder) {
     try (SetContextClassLoader ignored = new SetContextClassLoader(bootstrapFunction)) {
-      PersistedStates.findAndBind(bootstrapFunction, stateBinder);
+      PersistedStates.findReflectivelyAndBind(bootstrapFunction, stateBinder);
       return bootstrapFunction;
     }
   }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/Expiration.java
@@ -82,4 +82,9 @@ public final class Expiration {
   public Duration duration() {
     return duration;
   }
+
+  @Override
+  public String toString() {
+    return String.format("Expiration{mode=%s, duration=%s}", mode, duration);
+  }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBuffer.java
@@ -160,6 +160,13 @@ public final class PersistedAppendingBuffer<E> {
     accessor.clear();
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedAppendingBuffer{name=%s, elementType=%s, expiration=%s}",
+        name, elementType.getName(), expiration);
+  }
+
   @ForRuntime
   void setAccessor(AppendingBufferAccessor<E> newAccessor) {
     this.accessor = Objects.requireNonNull(newAccessor);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
@@ -121,9 +121,7 @@ public final class PersistedStateRegistry {
       throw new IllegalStateException(
           String.format(
               "State name '%s' was registered twice; previous registered state object with the same name was a %s, attempting to register a new %s under the same name.",
-              stateName,
-              previousRegistration.getClass().getName(),
-              newStateObject.getClass().getName()));
+              stateName, previousRegistration, newStateObject));
     }
 
     registeredStates.put(stateName, newStateObject);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedTable.java
@@ -182,6 +182,13 @@ public final class PersistedTable<K, V> {
     accessor.clear();
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedTable{name=%s, keyType=%s, valueType=%s, expiration=%s}",
+        name, keyType.getName(), valueType.getName(), expiration);
+  }
+
   @ForRuntime
   void setAccessor(TableAccessor<K, V> newAccessor) {
     Objects.requireNonNull(newAccessor);

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedValue.java
@@ -165,6 +165,12 @@ public final class PersistedValue<T> {
     this.accessor = newAccessor;
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "PersistedValue{name=%s, type=%s, expiration=%s}", name, type.getName(), expiration);
+  }
+
   private static final class NonFaultTolerantAccessor<E> implements Accessor<E> {
     private E element;
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/StateBinder.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/StateBinder.java
@@ -18,23 +18,20 @@
 
 package org.apache.flink.statefun.sdk.state;
 
-import org.apache.flink.statefun.sdk.FunctionType;
-
 public abstract class StateBinder {
-  public abstract void bindValue(PersistedValue<?> persistedValue, FunctionType functionType);
+  public abstract void bindValue(PersistedValue<?> persistedValue);
 
-  public abstract void bindTable(PersistedTable<?, ?> persistedTable, FunctionType functionType);
+  public abstract void bindTable(PersistedTable<?, ?> persistedTable);
 
-  public abstract void bindAppendingBuffer(
-      PersistedAppendingBuffer<?> persistedAppendingBuffer, FunctionType functionType);
+  public abstract void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer);
 
-  public final void bind(Object stateObject, FunctionType functionType) {
+  public final void bind(Object stateObject) {
     if (stateObject instanceof PersistedValue) {
-      bindValue((PersistedValue<?>) stateObject, functionType);
+      bindValue((PersistedValue<?>) stateObject);
     } else if (stateObject instanceof PersistedTable) {
-      bindTable((PersistedTable<?, ?>) stateObject, functionType);
+      bindTable((PersistedTable<?, ?>) stateObject);
     } else if (stateObject instanceof PersistedAppendingBuffer) {
-      bindAppendingBuffer((PersistedAppendingBuffer<?>) stateObject, functionType);
+      bindAppendingBuffer((PersistedAppendingBuffer<?>) stateObject);
     } else {
       throw new IllegalArgumentException("Unknown persisted state object " + stateObject);
     }

--- a/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
+++ b/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
@@ -26,16 +26,16 @@ public class PersistedStateRegistryTest {
   public void exampleUsage() {
     final PersistedStateRegistry registry = new PersistedStateRegistry();
 
-    registry.registerValue("value", String.class);
-    registry.registerTable("table", String.class, Integer.class);
-    registry.registerAppendingBuffer("buffer", String.class);
+    registry.registerValue(PersistedValue.of("value", String.class));
+    registry.registerTable(PersistedTable.of("table", String.class, Integer.class));
+    registry.registerAppendingBuffer(PersistedAppendingBuffer.of("buffer", String.class));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void reaccessAsWrongStatePrimitiveType() {
+  public void duplicateRegistration() {
     final PersistedStateRegistry registry = new PersistedStateRegistry();
 
-    registry.registerValue("my-state", String.class);
-    registry.registerAppendingBuffer("my-state", String.class);
+    registry.registerValue(PersistedValue.of("my-state", String.class));
+    registry.registerTable(PersistedTable.of("my-state", String.class, Integer.class));
   }
 }


### PR DESCRIPTION
This PR is based on top of #136 because it touches a few overlapping classes.
Only last 2 commits are relevant.

---

Prior to this PR, a single `StateBinder` instance handles binding state objects to Flink state for multiple `FunctionType`s.

With these changes, this is changed so that each `FunctionType` has its own `StateBinder` (specifically, a `FlinkStateBinder`).
This allows a cleaner separation of concerns in the `PersistedStateRegistry`, so that the information about which function type the registry is bounded is not leaked into the SDK classes, but instead encapsulated within the `StateBinder` being used at runtime.

---

## Verifying this change

The existing tests in `PersistedStatesTest` cover the changes introduced by this refactoring.