### PR TITLE
[FLINK-19106] [core] Add more timeout configs for remote functions

### DIFF
--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -71,7 +71,17 @@ A ``function`` is described via a number of properties:
     * Default: 1000
 * ``function.spec.timeout``
     * The maximum amount of time for the runtime to wait for the remote function to return before failing.
+      This spans the complete call, including connecting to the function endpoint, writing the request, function processing, and reading the response.
     * Default: 1 min
+* ``function.spec.connectTimeout``
+    * The maximum amount of time for the runtime to wait for connecting to the remote function endpoint.
+    * Default: 10 sec
+* ``function.spec.readTimeout``
+    * The maximum amount of time for the runtime to wait for individual read IO operations, such as reading the invocation response.
+    * Default: 10 sec
+* ``function.spec.writeTimeout``
+    * The maximum amount of time for the runtime to wait for individual write IO operations, such as writing the invocation request.
+    * Default: 10 sec
 
 ### Full Example
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -64,6 +64,9 @@ public class HttpFunctionProvider implements StatefulFunctionProvider {
     }
     OkHttpClient.Builder clientBuilder = sharedClient.newBuilder();
     clientBuilder.callTimeout(spec.maxRequestDuration());
+    clientBuilder.connectTimeout(spec.connectTimeout());
+    clientBuilder.readTimeout(spec.readTimeout());
+    clientBuilder.writeTimeout(spec.writeTimeout());
 
     final HttpUrl url;
     if (spec.isUnixDomainSocket()) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
@@ -31,12 +31,18 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
   private static final long serialVersionUID = 1;
 
   private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
+  private static final Duration DEFAULT_HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_HTTP_READ_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_HTTP_WRITE_TIMEOUT = Duration.ofSeconds(10);
   private static final Integer DEFAULT_MAX_NUM_BATCH_REQUESTS = 1000;
 
   private final FunctionType functionType;
   private final URI endpoint;
   private final List<StateSpec> states;
   private final Duration maxRequestDuration;
+  private final Duration connectTimeout;
+  private final Duration readTimeout;
+  private final Duration writeTimeout;
   private final int maxNumBatchRequests;
 
   private HttpFunctionSpec(
@@ -44,11 +50,17 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
       URI endpoint,
       List<StateSpec> states,
       Duration maxRequestDuration,
+      Duration connectTimeout,
+      Duration readTimeout,
+      Duration writeTimeout,
       int maxNumBatchRequests) {
     this.functionType = Objects.requireNonNull(functionType);
     this.endpoint = Objects.requireNonNull(endpoint);
     this.states = Objects.requireNonNull(states);
     this.maxRequestDuration = Objects.requireNonNull(maxRequestDuration);
+    this.connectTimeout = Objects.requireNonNull(connectTimeout);
+    this.readTimeout = Objects.requireNonNull(readTimeout);
+    this.writeTimeout = Objects.requireNonNull(writeTimeout);
     this.maxNumBatchRequests = maxNumBatchRequests;
   }
 
@@ -83,6 +95,18 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
     return maxRequestDuration;
   }
 
+  public Duration connectTimeout() {
+    return connectTimeout;
+  }
+
+  public Duration readTimeout() {
+    return readTimeout;
+  }
+
+  public Duration writeTimeout() {
+    return writeTimeout;
+  }
+
   public int maxNumBatchRequests() {
     return maxNumBatchRequests;
   }
@@ -94,6 +118,9 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
 
     private final List<StateSpec> states = new ArrayList<>();
     private Duration maxRequestDuration = DEFAULT_HTTP_TIMEOUT;
+    private Duration connectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT;
+    private Duration readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
+    private Duration writeTimeout = DEFAULT_HTTP_WRITE_TIMEOUT;
     private int maxNumBatchRequests = DEFAULT_MAX_NUM_BATCH_REQUESTS;
 
     private Builder(FunctionType functionType, URI endpoint) {
@@ -111,6 +138,21 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
       return this;
     }
 
+    public Builder withConnectTimeoutDuration(Duration duration) {
+      this.connectTimeout = Objects.requireNonNull(duration);
+      return this;
+    }
+
+    public Builder withReadTimeoutDuration(Duration duration) {
+      this.readTimeout = Objects.requireNonNull(duration);
+      return this;
+    }
+
+    public Builder withWriteTimeoutDuration(Duration duration) {
+      this.writeTimeout = Objects.requireNonNull(duration);
+      return this;
+    }
+
     public Builder withMaxNumBatchRequests(int maxNumBatchRequests) {
       this.maxNumBatchRequests = maxNumBatchRequests;
       return this;
@@ -118,7 +160,14 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
 
     public HttpFunctionSpec build() {
       return new HttpFunctionSpec(
-          functionType, endpoint, states, maxRequestDuration, maxNumBatchRequests);
+          functionType,
+          endpoint,
+          states,
+          maxRequestDuration,
+          connectTimeout,
+          readTimeout,
+          writeTimeout,
+          maxNumBatchRequests);
     }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
@@ -16,7 +16,6 @@
 
 package org.apache.flink.statefun.flink.core.httpfn;
 
-import java.time.Duration;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
@@ -24,15 +23,12 @@ import okhttp3.OkHttpClient;
 final class OkHttpUtils {
   private OkHttpUtils() {}
 
-  private static final Duration DEFAULT_CALL_TIMEOUT = Duration.ofMinutes(2);
-
   static OkHttpClient newClient() {
     Dispatcher dispatcher = new Dispatcher();
     dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
     dispatcher.setMaxRequests(Integer.MAX_VALUE);
 
     return new OkHttpClient.Builder()
-        .callTimeout(DEFAULT_CALL_TIMEOUT)
         .dispatcher(dispatcher)
         .connectionPool(new ConnectionPool())
         .followRedirects(true)

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionJsonEntity.java
@@ -67,7 +67,15 @@ final class FunctionJsonEntity implements JsonEntity {
     private static final JsonPointer ENDPOINT = JsonPointer.compile("/function/spec/endpoint");
     private static final JsonPointer PORT = JsonPointer.compile("/function/spec/port");
     private static final JsonPointer STATES = JsonPointer.compile("/function/spec/states");
+
     private static final JsonPointer TIMEOUT = JsonPointer.compile("/function/spec/timeout");
+    private static final JsonPointer CONNECT_TIMEOUT =
+        JsonPointer.compile("/function/spec/connectTimeout");
+    private static final JsonPointer READ_TIMEOUT =
+        JsonPointer.compile("/function/spec/readTimeout");
+    private static final JsonPointer WRITE_TIMEOUT =
+        JsonPointer.compile("/function/spec/writeTimeout");
+
     private static final JsonPointer MAX_NUM_BATCH_REQUESTS =
         JsonPointer.compile("/function/spec/maxNumBatchRequests");
   }
@@ -120,7 +128,14 @@ final class FunctionJsonEntity implements JsonEntity {
           specBuilder.withState(state);
         }
         optionalMaxNumBatchRequests(functionNode).ifPresent(specBuilder::withMaxNumBatchRequests);
-        optionalMaxRequestDuration(functionNode).ifPresent(specBuilder::withMaxRequestDuration);
+        optionalTimeoutDuration(functionNode, SpecPointers.TIMEOUT)
+            .ifPresent(specBuilder::withMaxRequestDuration);
+        optionalTimeoutDuration(functionNode, SpecPointers.CONNECT_TIMEOUT)
+            .ifPresent(specBuilder::withConnectTimeoutDuration);
+        optionalTimeoutDuration(functionNode, SpecPointers.READ_TIMEOUT)
+            .ifPresent(specBuilder::withReadTimeoutDuration);
+        optionalTimeoutDuration(functionNode, SpecPointers.WRITE_TIMEOUT)
+            .ifPresent(specBuilder::withWriteTimeoutDuration);
 
         return specBuilder.build();
       case GRPC:
@@ -165,9 +180,9 @@ final class FunctionJsonEntity implements JsonEntity {
     return Selectors.optionalIntegerAt(functionNode, SpecPointers.MAX_NUM_BATCH_REQUESTS);
   }
 
-  private static Optional<Duration> optionalMaxRequestDuration(JsonNode functionNode) {
-    return Selectors.optionalTextAt(functionNode, SpecPointers.TIMEOUT)
-        .map(TimeUtils::parseDuration);
+  private static Optional<Duration> optionalTimeoutDuration(
+      JsonNode functionNode, JsonPointer timeoutPointer) {
+    return Selectors.optionalTextAt(functionNode, timeoutPointer).map(TimeUtils::parseDuration);
   }
 
   private static Expiration stateTtlExpiration(JsonNode stateSpecNode) {

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v2_0/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v2_0/module.yaml
@@ -37,6 +37,10 @@ module:
               - name: seen_count
                 expireAfter: 60000millisecond
                 expireMode: after-invoke
+            timeout: 2minutes
+            connectTimeout: 20seconds
+            readTimeout: 1second
+            writeTimeout: 10seconds
             maxNumBatchRequests: 10000
       - function:
           meta:


### PR DESCRIPTION
Prior to this PR, we only support setting the call timeout for remote functions, which spans a complete call including connection, writing request, server-side processing, and reading response.

To allow more fine-grained control of this, this PR introduces configuration keys for `connectTimeout` / `readTimeout` / `writeTimeout` to remote function specs.
By default, these values should be 10  seconds to be coherent with the current behaviour

Usage:
```
function:
      meta:
            kind: http
            type: com.foo/world
      spec:
            endpoint: http://localhost:5959/statefun
            states:
                ...
            timeout: 2minutes
            connectTimeout: 20seconds
            readTimeout: 1second
            writeTimeout: 10seconds
```