### PR TITLE
[FLINK-19107] Add checkpointing and recovery options to template flink-conf.yaml

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
@@ -14,12 +14,32 @@
 # limitations under the License.
 # This file is the base for the Apache Flink configuration
 
+#==============================================================================
+# Configurations strictly required by Stateful Functions. Do not change.
+#==============================================================================
+
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+
+#==============================================================================
+# Fault tolerance, checkpointing and recovery.
+# For more related configuration options, please see: https://ci.apache.org/projects/flink/flink-docs-master/ops/config.html#fault-tolerance
+#==============================================================================
+
+execution.checkpointing.mode: EXACTLY_ONCE
+execution.checkpointing.interval: 5sec
+
+restart-strategy: fixed-delay
+restart-strategy.fixed-delay.attempts: 2147483647
+restart-strategy.fixed-delay.delay: 1sec
+
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+#==============================================================================
+# Recommended memory configurations. Users may change according to their needs.
+#==============================================================================
+
 jobmanager.memory.process.size: 1g
 taskmanager.memory.process.size: 4g
-execution.checkpointing.interval: 5sec
-execution.checkpointing.mode: EXACTLY_ONCE

--- a/tools/docker/flink-distribution-template/conf/flink-conf.yaml
+++ b/tools/docker/flink-distribution-template/conf/flink-conf.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 # This file is the base for the Apache Flink configuration
 
+statefun.flink-job-name: Statefun Application
+
 #==============================================================================
 # Configurations strictly required by Stateful Functions. Do not change.
 #==============================================================================
@@ -21,14 +23,26 @@
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
 
 #==============================================================================
-# Recommended configurations. Users may change according to their needs.
+# Fault tolerance, checkpointing and recovery.
+# For more related configuration options, please see: https://ci.apache.org/projects/flink/flink-docs-master/ops/config.html#fault-tolerance
 #==============================================================================
+
+# Uncomment the below to enable checkpointing for your application
+#execution.checkpointing.mode: EXACTLY_ONCE
+#execution.checkpointing.interval: 5sec
+
+restart-strategy: fixed-delay
+restart-strategy.fixed-delay.attempts: 2147483647
+restart-strategy.fixed-delay.delay: 1sec
 
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+#==============================================================================
+# Recommended memory configurations. Users may change according to their needs.
+#==============================================================================
+
 jobmanager.memory.process.size: 1g
 taskmanager.memory.process.size: 4g
-
-statefun.flink-job-name: Statefun Application


### PR DESCRIPTION
A corresponding change for the template flink-conf.yaml used in distributed Docker images can be found at https://github.com/apache/flink-statefun-docker/pull/6.

This also changes the flink-conf.yaml used in e2e tests to verify that the template does indeed work out-of-box for users.