### PR TITLE
[FLINK-19130] [core] Expose metrics for backpressure

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/BackPressureValve.java
@@ -53,4 +53,12 @@ public interface BackPressureValve {
    * @param address the address
    */
   void blockAddress(Address address);
+
+  /**
+   * Checks whether a given address was previously blocked with {@link #blockAddress(Address)}.
+   *
+   * @param address the address to check
+   * @return boolean indicating whether or not the address was blocked.
+   */
+  boolean isAddressBlocked(Address address);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/InternalContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/InternalContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.statefun.flink.core.backpressure;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
 import org.apache.flink.statefun.sdk.Context;
 
 @Internal
@@ -37,4 +38,11 @@ public interface InternalContext extends Context {
    * every async operation registered per each address.
    */
   void awaitAsyncOperationComplete();
+
+  /**
+   * Returns the metrics handle for the current invoked function's type.
+   *
+   * @return the metrics handle for the current invoked function's type.
+   */
+  FunctionTypeMetrics functionTypeMetrics();
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/InternalContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/InternalContext.java
@@ -19,9 +19,10 @@
 package org.apache.flink.statefun.flink.core.backpressure;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.sdk.Context;
 
 @Internal
-public interface AsyncWaiter {
+public interface InternalContext extends Context {
 
   /**
    * Signals the runtime to stop invoking the currently executing function with new input until at

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
@@ -43,7 +43,7 @@ public final class ThresholdBackPressureValve implements BackPressureValve {
 
   /**
    * a set of address that had explicitly requested to stop processing any new inputs (via {@link
-   * AsyncWaiter#awaitAsyncOperationComplete()}. Note that this is a set implemented on top of a
+   * InternalContext#awaitAsyncOperationComplete()}. Note that this is a set implemented on top of a
    * map, and the value (Boolean) has no meaning.
    */
   private final ObjectOpenHashMap<Address, Boolean> blockedAddressSet =

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValve.java
@@ -88,6 +88,12 @@ public final class ThresholdBackPressureValve implements BackPressureValve {
     blockedAddressSet.remove(owningAddress);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean isAddressBlocked(Address address) {
+    return blockedAddressSet.containsKey(address);
+  }
+
   private boolean totalPendingAsyncOperationsAtCapacity() {
     return maximumPendingAsynchronousOperations > 0
         && pendingAsynchronousOperationsCount >= maximumPendingAsynchronousOperations;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/di/ObjectContainer.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/di/ObjectContainer.java
@@ -51,6 +51,14 @@ public class ObjectContainer {
     factories.put(new Key(type, label), () -> createReflectively(actual));
   }
 
+  public <T, ET> void addAlias(
+      String newLabel,
+      Class<? super T> newType,
+      String existingLabel,
+      Class<? super ET> existingType) {
+    factories.put(new Key(newType, newLabel), () -> get(existingType, existingLabel));
+  }
+
   public <T> void add(String label, Lazy<T> lazyValue) {
     factories.put(new Key(Lazy.class, label), () -> lazyValue.withContainer(this));
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -32,7 +32,10 @@ import org.apache.flink.statefun.flink.core.di.Lazy;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
+import org.apache.flink.statefun.flink.core.metrics.FlinkFunctionDispatcherMetrics;
 import org.apache.flink.statefun.flink.core.metrics.FlinkMetricsFactory;
+import org.apache.flink.statefun.flink.core.metrics.FunctionDispatcherMetrics;
+import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetricsRepository;
 import org.apache.flink.statefun.flink.core.metrics.MetricsFactory;
 import org.apache.flink.statefun.flink.core.state.FlinkState;
 import org.apache.flink.statefun.flink.core.state.State;
@@ -71,6 +74,11 @@ final class Reductions {
     container.add("function-providers", Map.class, statefulFunctionsUniverse.functions());
     container.add(
         "function-repository", FunctionRepository.class, StatefulFunctionRepository.class);
+    container.addAlias(
+        "function-metrics-repository",
+        FunctionTypeMetricsRepository.class,
+        "function-repository",
+        FunctionRepository.class);
 
     // for FlinkState
     container.add("runtime-context", RuntimeContext.class, context);
@@ -96,6 +104,10 @@ final class Reductions {
     container.add(Reductions.class);
     container.add(LocalFunctionGroup.class);
     container.add("metrics-factory", MetricsFactory.class, new FlinkMetricsFactory(metricGroup));
+    container.add(
+        "function-dispatcher-metrics",
+        FunctionDispatcherMetrics.class,
+        new FlinkFunctionDispatcherMetrics(metricGroup));
 
     // for delayed messages
     container.add(

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -32,11 +32,11 @@ import org.apache.flink.statefun.flink.core.di.Lazy;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
+import org.apache.flink.statefun.flink.core.metrics.FlinkFuncionTypeMetricsFactory;
 import org.apache.flink.statefun.flink.core.metrics.FlinkFunctionDispatcherMetrics;
-import org.apache.flink.statefun.flink.core.metrics.FlinkMetricsFactory;
+import org.apache.flink.statefun.flink.core.metrics.FuncionTypeMetricsFactory;
 import org.apache.flink.statefun.flink.core.metrics.FunctionDispatcherMetrics;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetricsRepository;
-import org.apache.flink.statefun.flink.core.metrics.MetricsFactory;
 import org.apache.flink.statefun.flink.core.state.FlinkState;
 import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
@@ -103,7 +103,10 @@ final class Reductions {
     container.add("function-loader", FunctionLoader.class, PredefinedFunctionLoader.class);
     container.add(Reductions.class);
     container.add(LocalFunctionGroup.class);
-    container.add("metrics-factory", MetricsFactory.class, new FlinkMetricsFactory(metricGroup));
+    container.add(
+        "function-metrics-factory",
+        FuncionTypeMetricsFactory.class,
+        new FlinkFuncionTypeMetricsFactory(metricGroup));
     container.add(
         "function-dispatcher-metrics",
         FunctionDispatcherMetrics.class,

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
@@ -113,7 +113,7 @@ final class ReusableContext implements ApplyingContext, AsyncWaiter {
     Objects.requireNonNull(future);
 
     Message message = messageFactory.from(self(), self(), metadata);
-    asyncSink.accept(message, future);
+    asyncSink.accept(self(), message, future);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
@@ -25,6 +25,7 @@ import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
+import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
 import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
@@ -119,6 +120,11 @@ final class ReusableContext implements ApplyingContext, InternalContext {
   @Override
   public void awaitAsyncOperationComplete() {
     asyncSink.blockAddress(self());
+  }
+
+  @Override
+  public FunctionTypeMetrics functionTypeMetrics() {
+    return function.metrics();
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
@@ -20,7 +20,7 @@ package org.apache.flink.statefun.flink.core.functions;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import org.apache.flink.statefun.flink.core.backpressure.AsyncWaiter;
+import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.flink.core.message.Message;
@@ -29,7 +29,7 @@ import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 
-final class ReusableContext implements ApplyingContext, AsyncWaiter {
+final class ReusableContext implements ApplyingContext, InternalContext {
   private final Partition thisPartition;
   private final LocalSink localSink;
   private final RemoteSink remoteSink;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
@@ -24,13 +24,15 @@ import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
+import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetricsRepository;
 import org.apache.flink.statefun.flink.core.metrics.MetricsFactory;
 import org.apache.flink.statefun.flink.core.state.FlinkStateBinder;
 import org.apache.flink.statefun.flink.core.state.PersistedStates;
 import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.sdk.FunctionType;
 
-final class StatefulFunctionRepository implements FunctionRepository {
+final class StatefulFunctionRepository
+    implements FunctionRepository, FunctionTypeMetricsRepository {
   private final ObjectOpenHashMap<FunctionType, StatefulFunction> instances;
   private final State flinkState;
   private final FunctionLoader functionLoader;
@@ -57,6 +59,11 @@ final class StatefulFunctionRepository implements FunctionRepository {
       instances.put(type, function = load(type));
     }
     return function;
+  }
+
+  @Override
+  public FunctionTypeMetrics getMetrics(FunctionType functionType) {
+    return get(functionType).metrics();
   }
 
   private StatefulFunction load(FunctionType functionType) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/StatefulFunctionRepository.java
@@ -23,9 +23,9 @@ import org.apache.flink.statefun.flink.common.SetContextClassLoader;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
+import org.apache.flink.statefun.flink.core.metrics.FuncionTypeMetricsFactory;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetricsRepository;
-import org.apache.flink.statefun.flink.core.metrics.MetricsFactory;
 import org.apache.flink.statefun.flink.core.state.FlinkStateBinder;
 import org.apache.flink.statefun.flink.core.state.PersistedStates;
 import org.apache.flink.statefun.flink.core.state.State;
@@ -36,18 +36,18 @@ final class StatefulFunctionRepository
   private final ObjectOpenHashMap<FunctionType, StatefulFunction> instances;
   private final State flinkState;
   private final FunctionLoader functionLoader;
-  private final MetricsFactory metricsFactory;
+  private final FuncionTypeMetricsFactory metricsFactory;
   private final MessageFactory messageFactory;
 
   @Inject
   StatefulFunctionRepository(
       @Label("function-loader") FunctionLoader functionLoader,
-      @Label("metrics-factory") MetricsFactory metricsFactory,
+      @Label("function-metrics-factory") FuncionTypeMetricsFactory functionMetricsFactory,
       @Label("state") State state,
       MessageFactory messageFactory) {
     this.instances = new ObjectOpenHashMap<>();
     this.functionLoader = Objects.requireNonNull(functionLoader);
-    this.metricsFactory = Objects.requireNonNull(metricsFactory);
+    this.metricsFactory = Objects.requireNonNull(functionMetricsFactory);
     this.flinkState = Objects.requireNonNull(state);
     this.messageFactory = Objects.requireNonNull(messageFactory);
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
@@ -21,11 +21,11 @@ import java.util.Objects;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.statefun.sdk.FunctionType;
 
-public class FlinkMetricsFactory implements MetricsFactory {
+public class FlinkFuncionTypeMetricsFactory implements FuncionTypeMetricsFactory {
 
   private final MetricGroup metricGroup;
 
-  public FlinkMetricsFactory(MetricGroup metricGroup) {
+  public FlinkFuncionTypeMetricsFactory(MetricGroup metricGroup) {
     this.metricGroup = Objects.requireNonNull(metricGroup);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetrics.java
@@ -15,23 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.statefun.flink.core.metrics;
 
-public interface FunctionTypeMetrics {
+import java.util.Objects;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
 
-  void incomingMessage();
+public class FlinkFunctionDispatcherMetrics implements FunctionDispatcherMetrics {
+  private final Counter inflightAsyncOperations;
 
-  void outgoingLocalMessage();
+  public FlinkFunctionDispatcherMetrics(MetricGroup operatorGroup) {
+    Objects.requireNonNull(operatorGroup, "operatorGroup");
 
-  void outgoingRemoteMessage();
+    this.inflightAsyncOperations = operatorGroup.counter("inflight-async-ops");
+  }
 
-  void outgoingEgressMessage();
+  @Override
+  public void asyncOperationRegistered() {
+    inflightAsyncOperations.inc();
+  }
 
-  void blockedAddress();
-
-  void unblockedAddress();
-
-  void asyncOperationRegistered();
-
-  void asyncOperationCompleted();
+  @Override
+  public void asyncOperationCompleted() {
+    inflightAsyncOperations.dec();
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
@@ -29,6 +29,7 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
   private final Counter outgoingEgress;
   private final Counter blockedAddress;
   private final Counter inflightAsyncOps;
+  private final Counter backlogMessage;
 
   FlinkFunctionTypeMetrics(MetricGroup typeGroup) {
     this.incoming = metered(typeGroup, "in");
@@ -37,6 +38,7 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
     this.outgoingEgress = metered(typeGroup, "out-egress");
     this.blockedAddress = typeGroup.counter("num-blocked-address");
     this.inflightAsyncOps = typeGroup.counter("inflight-async-ops");
+    this.backlogMessage = typeGroup.counter("num-backlog");
   }
 
   @Override
@@ -77,6 +79,16 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
   @Override
   public void asyncOperationCompleted() {
     this.inflightAsyncOps.dec();
+  }
+
+  @Override
+  public void appendBacklogMessages(int count) {
+    backlogMessage.inc(count);
+  }
+
+  @Override
+  public void consumeBacklogMessages(int count) {
+    backlogMessage.dec(count);
   }
 
   private static SimpleCounter metered(MetricGroup metrics, String name) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
@@ -27,12 +27,16 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
   private final Counter outgoingLocalMessage;
   private final Counter outgoingRemoteMessage;
   private final Counter outgoingEgress;
+  private final Counter blockedAddress;
+  private final Counter inflightAsyncOps;
 
   FlinkFunctionTypeMetrics(MetricGroup typeGroup) {
     this.incoming = metered(typeGroup, "in");
     this.outgoingLocalMessage = metered(typeGroup, "out-local");
     this.outgoingRemoteMessage = metered(typeGroup, "out-remote");
     this.outgoingEgress = metered(typeGroup, "out-egress");
+    this.blockedAddress = typeGroup.counter("num-blocked-address");
+    this.inflightAsyncOps = typeGroup.counter("inflight-async-ops");
   }
 
   @Override
@@ -53,6 +57,26 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
   @Override
   public void outgoingEgressMessage() {
     this.outgoingEgress.inc();
+  }
+
+  @Override
+  public void blockedAddress() {
+    this.blockedAddress.inc();
+  }
+
+  @Override
+  public void unblockedAddress() {
+    this.blockedAddress.dec();
+  }
+
+  @Override
+  public void asyncOperationRegistered() {
+    this.inflightAsyncOps.inc();
+  }
+
+  @Override
+  public void asyncOperationCompleted() {
+    this.inflightAsyncOps.dec();
   }
 
   private static SimpleCounter metered(MetricGroup metrics, String name) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FuncionTypeMetricsFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FuncionTypeMetricsFactory.java
@@ -19,7 +19,7 @@ package org.apache.flink.statefun.flink.core.metrics;
 
 import org.apache.flink.statefun.sdk.FunctionType;
 
-public interface MetricsFactory {
+public interface FuncionTypeMetricsFactory {
 
   FunctionTypeMetrics forType(FunctionType functionType);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionDispatcherMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionDispatcherMetrics.java
@@ -15,21 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.statefun.flink.core.metrics;
 
-public interface FunctionTypeMetrics {
-
-  void incomingMessage();
-
-  void outgoingLocalMessage();
-
-  void outgoingRemoteMessage();
-
-  void outgoingEgressMessage();
-
-  void blockedAddress();
-
-  void unblockedAddress();
+public interface FunctionDispatcherMetrics {
 
   void asyncOperationRegistered();
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetrics.java
@@ -34,4 +34,8 @@ public interface FunctionTypeMetrics {
   void asyncOperationRegistered();
 
   void asyncOperationCompleted();
+
+  void appendBacklogMessages(int count);
+
+  void consumeBacklogMessages(int count);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetricsRepository.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetricsRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.metrics;
+
+import org.apache.flink.statefun.sdk.FunctionType;
+
+public interface FunctionTypeMetricsRepository {
+  FunctionTypeMetrics getMetrics(FunctionType functionType);
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
@@ -26,7 +26,7 @@ import com.google.protobuf.ByteString;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import org.apache.flink.statefun.flink.core.backpressure.AsyncWaiter;
+import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.InvocationResponse;
@@ -111,7 +111,7 @@ public final class RequestReplyFunction implements StatefulFunction {
       // we need to signal to the runtime that we are unable to process any new input
       // and we must wait for our in flight asynchronous operation to complete before
       // we are able to process more input.
-      ((AsyncWaiter) context).awaitAsyncOperationComplete();
+      ((InternalContext) context).awaitAsyncOperationComplete();
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/di/ObjectContainerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/di/ObjectContainerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.di;
+
+import static org.hamcrest.CoreMatchers.theInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class ObjectContainerTest {
+
+  @Test
+  public void addAliasTest() {
+    final ObjectContainer container = new ObjectContainer();
+
+    container.add("label-1", InterfaceA.class, TestClass.class);
+    container.addAlias("label-2", InterfaceB.class, "label-1", InterfaceA.class);
+
+    assertThat(
+        container.get(InterfaceB.class, "label-2"),
+        theInstance(container.get(InterfaceA.class, "label-1")));
+  }
+
+  private interface InterfaceA {}
+
+  private interface InterfaceB {}
+
+  private static class TestClass implements InterfaceA, InterfaceB {}
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -578,7 +579,7 @@ public class ReductionsTest {
 
     @Override
     public Counter counter(String s) {
-      throw new UnsupportedOperationException();
+      return new SimpleCounter();
     }
 
     @Override

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -322,5 +322,11 @@ public class RequestReplyFunctionTest {
 
     @Override
     public void unblockedAddress() {}
+
+    @Override
+    public void appendBacklogMessages(int count) {}
+
+    @Override
+    public void consumeBacklogMessages(int count) {}
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -38,6 +38,7 @@ import java.util.function.Supplier;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
+import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.DelayedInvocation;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
@@ -250,6 +251,8 @@ public class RequestReplyFunctionTest {
 
   private static final class FakeContext implements InternalContext {
 
+    private final FunctionTypeMetrics fakeMetrics = new FakeMetrics();
+
     Address caller;
     boolean needsWaiting;
 
@@ -260,6 +263,11 @@ public class RequestReplyFunctionTest {
     @Override
     public void awaitAsyncOperationComplete() {
       needsWaiting = true;
+    }
+
+    @Override
+    public FunctionTypeMetrics functionTypeMetrics() {
+      return fakeMetrics;
     }
 
     @Override
@@ -287,5 +295,32 @@ public class RequestReplyFunctionTest {
 
     @Override
     public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
+  }
+
+  private static final class FakeMetrics implements FunctionTypeMetrics {
+
+    @Override
+    public void asyncOperationRegistered() {}
+
+    @Override
+    public void asyncOperationCompleted() {}
+
+    @Override
+    public void incomingMessage() {}
+
+    @Override
+    public void outgoingRemoteMessage() {}
+
+    @Override
+    public void outgoingEgressMessage() {}
+
+    @Override
+    public void outgoingLocalMessage() {}
+
+    @Override
+    public void blockedAddress() {}
+
+    @Override
+    public void unblockedAddress() {}
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apache.flink.statefun.flink.core.TestUtils;
-import org.apache.flink.statefun.flink.core.backpressure.AsyncWaiter;
+import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.DelayedInvocation;
@@ -49,7 +49,6 @@ import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.Invoca
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.AsyncOperationResult;
 import org.apache.flink.statefun.sdk.AsyncOperationResult.Status;
-import org.apache.flink.statefun.sdk.Context;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.junit.Test;
@@ -249,7 +248,7 @@ public class RequestReplyFunctionTest {
     }
   }
 
-  private static final class FakeContext implements Context, AsyncWaiter {
+  private static final class FakeContext implements InternalContext {
 
     Address caller;
     boolean needsWaiting;


### PR DESCRIPTION
This PR adds in total 2 new metrics related to backpressure:
- Number of blocked addresses (per function type)
- Number of inflight async operations (per function type + per operator)

We also rejected to add the following metric, since after some discussion it doesn't seem to add much value:
- Number of accumulated records pre-flight in batch per function type.
This was not added, with the assumption that users would really only want to care about that some address has reached the maximum request batch size and was being blocked.

---

## Verification

I verified this by running the Python Greeter example, with the following modifications to let backpressure happen more easily:
- Maximum batch size = 1
- No delay between each generated message to have maximum input rate

You can see the following metric charts in the Flink Web UI:

![image](https://user-images.githubusercontent.com/5284370/92202926-a0f19e00-eeb2-11ea-946d-cbae5bb82260.png)
 
---

## Brief changelog

- 78cbc19 Extends the `FunctionTypeMetrics` interface to include the new metrics, and adds a new `FunctionDispatcherMetrics` interface for per-operator metrics.
- 6408866 Introduce a scoped-down interface `FunctionTypeMetricsRepository` and let `StatefulFunctionsRepository` extend it. Components that need to access function metrics will be passed this interface.
- 0fbb17a preliminary extension to `ObjectContainer` DI utility so that we can share same instance across different object labels.
- 6c77ca4 Wire-in the new metrics in `AsyncSink` to expose backpressure metrics.