### PR TITLE
[FLINK-19017] Add logging and metrics for remote function invocations

### DIFF
--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -88,6 +88,21 @@ under the License.
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-metrics-dropwizard</artifactId>
+                <version>${flink.version}</version>
+                <exclusions>
+                    <!--
+                    This artifact transitively depends on different versions of slf4j-api. 
+                    To see the complete list, comment this exclusion run mvn enforcer:enforce.
+                    -->
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!-- Statefun -->
             <dependency>

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -58,6 +58,11 @@ under the License.
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-metrics-dropwizard</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
 
         <!-- 3rd party -->
         <dependency>

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -31,7 +31,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
 import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
@@ -52,7 +51,9 @@ final class HttpRequestReplyClient implements RequestReplyClient {
 
   @Override
   public CompletableFuture<FromFunction> call(
-          ToFunctionRequestSummary requestSummary, RemoteInvocationMetrics metrics, ToFunction toFunction) {
+      ToFunctionRequestSummary requestSummary,
+      RemoteInvocationMetrics metrics,
+      ToFunction toFunction) {
     Request request =
         new Request.Builder()
             .url(url)

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -58,7 +58,7 @@ final class HttpRequestReplyClient implements RequestReplyClient {
             .build();
 
     Call newCall = client.newCall(request);
-    RetryingCallback callback = new RetryingCallback(newCall.timeout());
+    RetryingCallback callback = new RetryingCallback(requestSummary, newCall.timeout());
     newCall.enqueue(callback);
     return callback.future().thenApply(HttpRequestReplyClient::parseResponse);
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -60,8 +60,8 @@ final class HttpRequestReplyClient implements RequestReplyClient {
             .build();
 
     Call newCall = client.newCall(request);
-    RetryingCallback callback = new RetryingCallback(requestSummary, newCall.timeout());
-    newCall.enqueue(callback);
+    RetryingCallback callback = new RetryingCallback(requestSummary, metrics, newCall.timeout());
+    callback.attachToCall(newCall);
     return callback.future().thenApply(HttpRequestReplyClient::parseResponse);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -34,6 +34,7 @@ import okhttp3.Response;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.ToFunctionRequestSummary;
 import org.apache.flink.util.IOUtils;
 
 final class HttpRequestReplyClient implements RequestReplyClient {
@@ -48,7 +49,8 @@ final class HttpRequestReplyClient implements RequestReplyClient {
   }
 
   @Override
-  public CompletableFuture<FromFunction> call(ToFunction toFunction) {
+  public CompletableFuture<FromFunction> call(
+      ToFunctionRequestSummary requestSummary, ToFunction toFunction) {
     Request request =
         new Request.Builder()
             .url(url)

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -51,7 +51,7 @@ final class HttpRequestReplyClient implements RequestReplyClient {
   @Override
   public CompletableFuture<FromFunction> call(
       ToFunctionRequestSummary requestSummary, ToFunction toFunction) {
-    Request request =
+  Request request =
         new Request.Builder()
             .url(url)
             .post(RequestBody.create(MEDIA_TYPE_BINARY, toFunction.toByteArray()))

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -31,6 +31,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
@@ -50,8 +52,8 @@ final class HttpRequestReplyClient implements RequestReplyClient {
 
   @Override
   public CompletableFuture<FromFunction> call(
-      ToFunctionRequestSummary requestSummary, ToFunction toFunction) {
-  Request request =
+          ToFunctionRequestSummary requestSummary, RemoteInvocationMetrics metrics, ToFunction toFunction) {
+    Request request =
         new Request.Builder()
             .url(url)
             .post(RequestBody.create(MEDIA_TYPE_BINARY, toFunction.toByteArray()))

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -29,6 +29,7 @@ import okhttp3.Callback;
 import okhttp3.Response;
 import okio.Timeout;
 import org.apache.flink.statefun.flink.core.backpressure.BoundedExponentialBackoff;
+import org.apache.flink.statefun.flink.core.reqreply.ToFunctionRequestSummary;
 import org.apache.flink.util.function.RunnableWithException;
 
 @SuppressWarnings("NullableProblems")
@@ -40,10 +41,12 @@ final class RetryingCallback implements Callback {
 
   private final CompletableFuture<Response> resultFuture;
   private final BoundedExponentialBackoff backoff;
+  private final ToFunctionRequestSummary requestSummary;
 
-  RetryingCallback(Timeout timeout) {
+  RetryingCallback(ToFunctionRequestSummary requestSummary, Timeout timeout) {
     this.resultFuture = new CompletableFuture<>();
     this.backoff = new BoundedExponentialBackoff(INITIAL_BACKOFF_DURATION, duration(timeout));
+    this.requestSummary = requestSummary;
   }
 
   CompletableFuture<Response> future() {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -31,6 +31,8 @@ import okio.Timeout;
 import org.apache.flink.statefun.flink.core.backpressure.BoundedExponentialBackoff;
 import org.apache.flink.statefun.flink.core.reqreply.ToFunctionRequestSummary;
 import org.apache.flink.util.function.RunnableWithException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("NullableProblems")
 final class RetryingCallback implements Callback {
@@ -38,6 +40,8 @@ final class RetryingCallback implements Callback {
 
   private static final Set<Integer> RETRYABLE_HTTP_CODES =
       new HashSet<>(Arrays.asList(409, 420, 408, 429, 499, 500));
+
+  private static final Logger LOG = LoggerFactory.getLogger(RetryingCallback.class);
 
   private final CompletableFuture<Response> resultFuture;
   private final BoundedExponentialBackoff backoff;
@@ -64,6 +68,8 @@ final class RetryingCallback implements Callback {
   }
 
   private void onFailureUnsafe(Call call, IOException cause) {
+    LOG.warn(
+        "Retriable exception caught while trying to deliver a message: " + requestSummary, cause);
     if (!retryAfterApplyingBackoff(call)) {
       throw new IllegalStateException(
           "Maximal request time has elapsed. Last cause is attached", cause);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FunctionTypeMetrics.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.metrics;
 
-public interface FunctionTypeMetrics {
+public interface FunctionTypeMetrics extends RemoteInvocationMetrics {
 
   void incomingMessage();
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/RemoteInvocationMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/RemoteInvocationMetrics.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.metrics;
+
+public interface RemoteInvocationMetrics {
+
+  void remoteInvocationFailures();
+
+  void remoteInvocationLatency(long elapsed);
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
@@ -24,5 +24,6 @@ import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 
 public interface RequestReplyClient {
 
-  CompletableFuture<FromFunction> call(ToFunction toFunction);
+  CompletableFuture<FromFunction> call(
+      ToFunctionRequestSummary requestSummary, ToFunction toFunction);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
@@ -19,11 +19,14 @@
 package org.apache.flink.statefun.flink.core.reqreply;
 
 import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 
 public interface RequestReplyClient {
 
   CompletableFuture<FromFunction> call(
-      ToFunctionRequestSummary requestSummary, ToFunction toFunction);
+      ToFunctionRequestSummary requestSummary,
+      RemoteInvocationMetrics metrics,
+      ToFunction toFunction);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.InvocationResponse;
@@ -278,7 +279,9 @@ public final class RequestReplyFunction implements StatefulFunction {
             toFunction.getSerializedSize(),
             toFunction.getInvocation().getStateCount(),
             toFunction.getInvocation().getInvocationsCount());
-    CompletableFuture<FromFunction> responseFuture = client.call(requestSummary, toFunction);
+    RemoteInvocationMetrics metrics = ((InternalContext) context).functionTypeMetrics();
+    CompletableFuture<FromFunction> responseFuture =
+        client.call(requestSummary, metrics, toFunction);
     context.registerAsyncOperation(toFunction, responseFuture);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
@@ -272,8 +272,13 @@ public final class RequestReplyFunction implements StatefulFunction {
   }
 
   private void sendToFunction(Context context, ToFunction toFunction) {
-
-    CompletableFuture<FromFunction> responseFuture = client.call(toFunction);
+    ToFunctionRequestSummary requestSummary =
+        new ToFunctionRequestSummary(
+            context.self(),
+            toFunction.getSerializedSize(),
+            toFunction.getInvocation().getStateCount(),
+            toFunction.getInvocation().getInvocationsCount());
+    CompletableFuture<FromFunction> responseFuture = client.call(requestSummary, toFunction);
     context.registerAsyncOperation(toFunction, responseFuture);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ToFunctionRequestSummary.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ToFunctionRequestSummary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.reqreply;
+
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.Address;
+
+/**
+ * ToFunctionRequestSummary - represents a summary of that request, it is indented to be used as an
+ * additional context for logging.
+ */
+public final class ToFunctionRequestSummary {
+  private final Address address;
+  private final int batchSize;
+  private final int totalSizeInBytes;
+  private final int numberOfStates;
+
+  public ToFunctionRequestSummary(
+      Address address, int totalSizeInBytes, int numberOfStates, int batchSize) {
+    this.address = Objects.requireNonNull(address);
+    this.totalSizeInBytes = totalSizeInBytes;
+    this.numberOfStates = numberOfStates;
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public String toString() {
+    return "ToFunctionRequestSummary("
+        + "address="
+        + address
+        + ", batchSize="
+        + batchSize
+        + ", totalSizeInBytes="
+        + totalSizeInBytes
+        + ", numberOfStates="
+        + numberOfStates
+        + ')';
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -251,7 +251,8 @@ public class RequestReplyFunctionTest {
 
     @Override
     public CompletableFuture<FromFunction> call(
-        ToFunctionRequestSummary requestSummary, ToFunction toFunction) {
+        ToFunctionRequestSummary requestSummary,
+        ToFunction toFunction) {
       this.wasSentToFunction = toFunction;
       try {
         return CompletableFuture.completedFuture(this.fromFunction.get());
@@ -341,6 +342,12 @@ public class RequestReplyFunctionTest {
     public void consumeBacklogMessages(int count) {
       numBacklog -= count;
     }
+
+    @Override
+    public void remoteInvocationFailures() {}
+
+    @Override
+    public void remoteInvocationLatency(long elapsed) {}
 
     @Override
     public void asyncOperationRegistered() {}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetrics;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.DelayedInvocation;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
@@ -252,6 +253,7 @@ public class RequestReplyFunctionTest {
     @Override
     public CompletableFuture<FromFunction> call(
         ToFunctionRequestSummary requestSummary,
+        RemoteInvocationMetrics metrics,
         ToFunction toFunction) {
       this.wasSentToFunction = toFunction;
       try {

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -250,7 +250,8 @@ public class RequestReplyFunctionTest {
     Supplier<FromFunction> fromFunction = FromFunction::getDefaultInstance;
 
     @Override
-    public CompletableFuture<FromFunction> call(ToFunction toFunction) {
+    public CompletableFuture<FromFunction> call(
+        ToFunctionRequestSummary requestSummary, ToFunction toFunction) {
       this.wasSentToFunction = toFunction;
       try {
         return CompletableFuture.completedFuture(this.fromFunction.get());

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -74,6 +74,13 @@ under the License.
             <artifactId>statefun-flink-launcher</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <!-- flink runtime metrics -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-metrics-dropwizard</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
 
         <!-- flink runtime is always provided -->
         <dependency>


### PR DESCRIPTION
### This PR adds logging and metrics for remote function invocations

After applying this PR we would have the following additional metrics (per function type)

- `remote-invocation-failures` count of any exception happened during the request.
- `remote-invocation-failures` rate of exceptions thrown 
- `remote-invocation-latency` an histogram of request duration (the time takes either to a failure or a successful result)

<img width="868" alt="image" src="https://user-images.githubusercontent.com/546103/92615041-fc5dca80-f2bc-11ea-8837-6506ef681d0a.png">

<img width="875" alt="image" src="https://user-images.githubusercontent.com/546103/92615129-126b8b00-f2bd-11ea-8945-50c172c254af.png">

<img width="870" alt="image" src="https://user-images.githubusercontent.com/546103/92615211-2911e200-f2bd-11ea-9f14-2973a061ca93.png">

<img width="869" alt="image" src="https://user-images.githubusercontent.com/546103/92615270-39c25800-f2bd-11ea-93e1-89237dfea03c.png">


In addition, a log message would be written with the detailed exception during retires.

```
worker_1           | 2020-09-09 14:58:00,028 WARN  org.apache.flink.statefun.flink.core.httpfn.RetryingCallback [] - Retriable exception caught while trying to deliver a message: ToFunctionRequestSummary(address=Address(example, greeter, George), batchSize=1, totalSizeInBytes=142, numberOfStates=1)
worker_1           | java.net.UnknownHostException: python-worker
worker_1           | 	at java.net.InetAddress.getAllByName0(InetAddress.java:1281) ~[?:1.8.0_265]
worker_1           | 	at java.net.InetAddress.getAllByName(InetAddress.java:1193) ~[?:1.8.0_265]
worker_1           | 	at java.net.InetAddress.getAllByName(InetAddress.java:1127) ~[?:1.8.0_265]
worker_1           | 	at okhttp3.Dns.lambda$static$0(Dns.java:39) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.RouteSelector.resetNextInetSocketAddress(RouteSelector.java:171) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.RouteSelector.nextProxy(RouteSelector.java:135) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.RouteSelector.next(RouteSelector.java:84) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:187) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:172) [statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32) [statefun-flink-distribution.jar:2.2-SNAPSHOT]
worker_1           | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_265]
worker_1           | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_265]
worker_1           | 	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_265]
```
 
