### PR TITLE
[FLINK-19190] Use camelCase for metric names

### DIFF
--- a/docs/deployment-and-operations/metrics.md
+++ b/docs/deployment-and-operations/metrics.md
@@ -55,46 +55,88 @@ Along with the [standard metric scopes](https://ci.apache.org/projects/flink/fli
             <td>Meter</td>
         </tr>
         <tr>
-            <td><h5>out-local</h5></td>
+            <td><h5>outLocal</h5></td>
             <td>Function</td>
             <td>The number of messages sent to a function on the same task slot.</td>
             <td>Counter</td>
         </tr>
         <tr>
-            <td><h5>out-localRate</h5></td>
+            <td><h5>outLocalRate</h5></td>
             <td>Function</td>
             <td>The average number of messages sent to a function on the same task slot per second.</td>
             <td>Meter</td>
         </tr>
         <tr>
-            <td><h5>out-remote</h5></td>
+            <td><h5>outRemote</h5></td>
             <td>Function</td>
             <td>The number of messages sent to a function on a different task slot.</td>
             <td>Counter</td>
         </tr>
         <tr>
-            <td><h5>out-remoteRate</h5></td>
+            <td><h5>outRemoteRate</h5></td>
             <td>Function</td>
             <td>The average number of messages sent to a function on a different task slot per second.</td>
             <td>Meter</td>
         </tr>
         <tr>
-            <td><h5>out-egress</h5></td>
+            <td><h5>outEgress</h5></td>
             <td>Function</td>
             <td>The number of messages sent to an egress.</td>
             <td>Counter</td>
+        </tr>
+       <tr>
+            <td><h5>inflightAsyncOps</h5></td>
+            <td>Function</td>
+            <td>The number of uncompleted asynchronous operations</td>
+            <td>Counter</td>
+        </tr>
+        <tr>
+            <td><h5>numBackLog</h5></td>
+            <td>Remote Function</td>
+            <td>The number of pending messages either in flight or to be sent</td>
+            <td>Counter</td>
+        </tr> 
+        <tr>
+           <td><h5>numBlockedAddress</h5></td>
+           <td>Remote Function</td>
+           <td>The number of addresses that are currently under back pressure</td>
+           <td>Counter</td>
+        </tr>
+        <tr>
+            <td><h5>remoteInvocationFailures</h5></td>
+            <td>Remote Function</td>
+            <td>The number of failed attempts to invoke a function remotely</td>
+            <td>Counter</td>
+         </tr>
+         <tr>
+            <td><h5>remoteInvocationFailuresRate</h5></td>
+            <td>Remote Function</td>
+            <td>The average number of failed attempts to invoke a function remotely</td>
+            <td>Meter</td>
+         </tr>
+         <tr>
+            <td><h5>remoteInvocationLatency</h5></td>
+            <td>Remote Function</td>
+            <td>A distribution of remote function invocation latencies</td>
+            <td>Histogram</td>
         </tr>
         <tr>
             <td><h5>feedback.produced</h5></td>
             <td>Operator</td>
             <td>The number of messages read from the feedback channel.</td>
-            <td>Meter</td>
+            <td>Counter</td>
         </tr>
         <tr>
             <td><h5>feedback.producedRate</h5></td>
             <td>Operator</td>
             <td>The average number of messages read from the feedback channel per second.</td>
             <td>Meter</td>
+        </tr>
+        <tr>
+            <td><h5>inflightAsyncOps</h5></td>
+            <td>Operator</td>
+            <td>The total number of uncompleted asynchronous operations (across all function types)</td>
+            <td>Counter</td>
         </tr>
     </tbody>
 </table>

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetrics.java
@@ -28,7 +28,7 @@ public class FlinkFunctionDispatcherMetrics implements FunctionDispatcherMetrics
   public FlinkFunctionDispatcherMetrics(MetricGroup operatorGroup) {
     Objects.requireNonNull(operatorGroup, "operatorGroup");
 
-    this.inflightAsyncOperations = operatorGroup.counter("inflight-async-ops");
+    this.inflightAsyncOperations = operatorGroup.counter("inflightAsyncOps");
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
@@ -38,14 +38,14 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
 
   FlinkFunctionTypeMetrics(MetricGroup typeGroup) {
     this.incoming = metered(typeGroup, "in");
-    this.outgoingLocalMessage = metered(typeGroup, "out-local");
-    this.outgoingRemoteMessage = metered(typeGroup, "out-remote");
-    this.outgoingEgress = metered(typeGroup, "out-egress");
-    this.blockedAddress = typeGroup.counter("num-blocked-address");
-    this.inflightAsyncOps = typeGroup.counter("inflight-async-ops");
-    this.backlogMessage = typeGroup.counter("num-backlog");
-    this.remoteInvocationFailures = metered(typeGroup, "remote-invocation-failures");
-    this.remoteInvocationLatency = typeGroup.histogram("remote-invocation-latency", histogram());
+    this.outgoingLocalMessage = metered(typeGroup, "outLocal");
+    this.outgoingRemoteMessage = metered(typeGroup, "outRemote");
+    this.outgoingEgress = metered(typeGroup, "outEgress");
+    this.blockedAddress = typeGroup.counter("numBlockedAddress");
+    this.inflightAsyncOps = typeGroup.counter("inflightAsyncOps");
+    this.backlogMessage = typeGroup.counter("numBacklog");
+    this.remoteInvocationFailures = metered(typeGroup, "remoteInvocationFailures");
+    this.remoteInvocationLatency = typeGroup.histogram("remoteInvocationLatency", histogram());
   }
 
   @Override


### PR DESCRIPTION
This PR renames the metric names from a snake case to a camel case.
