### PR TITLE
[FLINK-19191] Set the default maxInflightAsyncOperations to 1024

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -90,7 +90,7 @@ public class StatefulFunctionsConfig implements Serializable {
   public static final ConfigOption<Integer> ASYNC_MAX_OPERATIONS_PER_TASK =
       ConfigOptions.key("statefun.async.max-per-task")
           .intType()
-          .defaultValue(10_000_000)
+          .defaultValue(1024)
           .withDescription(
               "The max number of async operations per task before backpressure is applied.");
 


### PR DESCRIPTION
The default upper limit for async operations per task slot is currently set to 10 million,
and it is unrealistically high, this PR sets it to a more realistic value.
A closer example would be the recommend value in Flink's AsyncWait operator.
This parameter can be overridden by users.