### PR TITLE
[FLINK-19192] Set HTTP connection pool size to 1024

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
@@ -16,6 +16,7 @@
 
 package org.apache.flink.statefun.flink.core.httpfn;
 
+import java.util.concurrent.TimeUnit;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
@@ -28,9 +29,11 @@ final class OkHttpUtils {
     dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
     dispatcher.setMaxRequests(Integer.MAX_VALUE);
 
+    ConnectionPool connectionPool = new ConnectionPool(1024, 1, TimeUnit.MINUTES);
+
     return new OkHttpClient.Builder()
         .dispatcher(dispatcher)
-        .connectionPool(new ConnectionPool())
+        .connectionPool(connectionPool)
         .followRedirects(true)
         .followSslRedirects(true)
         .retryOnConnectionFailure(true)


### PR DESCRIPTION
This PR increase the max size of the http connection pool to
1024. The connection pool holds connections to the various endpoints
and possibly various endpoint instances. The remote server can decide
that they will not keep the connection alive. An idle connection
would be evicted after 1 minute of inactivity.