### PR TITLE
[FLINK-19199] [core] Add execution attempt ID to feedback channel keys

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackKey.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackKey.java
@@ -33,8 +33,8 @@ public final class FeedbackKey<V> implements Serializable {
     this.invocationId = invocationId;
   }
 
-  public SubtaskFeedbackKey<V> withSubTaskIndex(int subTaskIndex) {
-    return new SubtaskFeedbackKey<>(pipelineName, invocationId, subTaskIndex);
+  public SubtaskFeedbackKey<V> withSubTaskIndex(int subTaskIndex, int attemptId) {
+    return new SubtaskFeedbackKey<>(pipelineName, invocationId, attemptId, subTaskIndex);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackSinkOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackSinkOperator.java
@@ -67,7 +67,8 @@ public final class FeedbackSinkOperator<V> extends AbstractStreamOperator<Void>
   public void open() throws Exception {
     super.open();
     final int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
-    final SubtaskFeedbackKey<V> key = this.key.withSubTaskIndex(indexOfThisSubtask);
+    final int attemptNum = getRuntimeContext().getAttemptNumber();
+    final SubtaskFeedbackKey<V> key = this.key.withSubTaskIndex(indexOfThisSubtask, attemptNum);
 
     FeedbackChannelBroker broker = FeedbackChannelBroker.get();
     this.channel = broker.getChannel(key);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackUnionOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackUnionOperator.java
@@ -168,8 +168,9 @@ public final class FeedbackUnionOperator<T> extends AbstractStreamOperator<T>
   }
 
   private void registerFeedbackConsumer(Executor mailboxExecutor) {
-    final SubtaskFeedbackKey<T> key =
-        feedbackKey.withSubTaskIndex(getRuntimeContext().getIndexOfThisSubtask());
+    final int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+    final int attemptNum = getRuntimeContext().getAttemptNumber();
+    final SubtaskFeedbackKey<T> key = feedbackKey.withSubTaskIndex(indexOfThisSubtask, attemptNum);
     FeedbackChannelBroker broker = FeedbackChannelBroker.get();
     FeedbackChannel<T> channel = broker.getChannel(key);
     channel.registerConsumer(this, mailboxExecutor);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/SubtaskFeedbackKey.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/SubtaskFeedbackKey.java
@@ -29,11 +29,13 @@ public final class SubtaskFeedbackKey<V> implements Serializable {
   private final String pipelineName;
   private final int subtaskIndex;
   private final long invocationId;
+  private final int attemptId;
 
-  SubtaskFeedbackKey(String pipeline, long invocationId, int subtaskIndex) {
+  SubtaskFeedbackKey(String pipeline, long invocationId, int subtaskIndex, int attemptId) {
     this.pipelineName = Objects.requireNonNull(pipeline);
     this.invocationId = invocationId;
     this.subtaskIndex = subtaskIndex;
+    this.attemptId = attemptId;
   }
 
   @Override
@@ -47,11 +49,12 @@ public final class SubtaskFeedbackKey<V> implements Serializable {
     SubtaskFeedbackKey<?> that = (SubtaskFeedbackKey<?>) o;
     return subtaskIndex == that.subtaskIndex
         && invocationId == that.invocationId
+        && attemptId == that.attemptId
         && Objects.equals(pipelineName, that.pipelineName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pipelineName, subtaskIndex, invocationId);
+    return Objects.hash(pipelineName, subtaskIndex, invocationId, attemptId);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/FeedbackChannelTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/FeedbackChannelTest.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 })
 public class FeedbackChannelTest {
   private static final SubtaskFeedbackKey<String> KEY =
-      new FeedbackKey<String>("foo", 1).withSubTaskIndex(0);
+      new FeedbackKey<String>("foo", 1).withSubTaskIndex(0, 1);
 
   @Test
   public void exampleUsage() {


### PR DESCRIPTION
The feedback brokers identify a single pair of producer / consumer with a `SubtaskFeedbackKey`, which is uniquely identified within a job by only the subtask index.

This can potentially become an issue in job restart scenarios, since the feedback brokers are static fields, and are durable across non-TM failure job restarts.
Currently it is not a problem because we do clear broker channels on close, but adding an extra execution attempt ID into the `SubtaskFeedbackKey` can make things safer.

---

## Verifying this change

There are existing unit tests in `FeedbackChannelTest`.
Moreover, it is assumed that the failure recover / exactly-once E2E tests have sufficient coverage for this change.