### PR TITLE
[FLINK-19203] Use Scala 2.12 Flink variants

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,9 +37,9 @@ flink_version: "1.11.1"
 github_branch: "master"
 
 # Plain Scala version is needed for e.g. the Gradle quickstart.
-scala_version: "2.11"
+scala_version: "2.12"
 # This suffix is appended to the Scala-dependent Maven artifact names
-scala_version_suffix: "_2.11"
+scala_version_suffix: "_2.12"
 
 # Plain flink-shaded version is needed for e.g. the hive connector.
 # Please update the shaded_version once new flink-shaded is released.

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ under the License.
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
         <flink.version>1.11.1</flink.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <root.dir>${rootDir}</root.dir>
     </properties>
 

--- a/statefun-examples/statefun-state-processor-example/pom.xml
+++ b/statefun-examples/statefun-state-processor-example/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <artifactId>statefun-state-processor-example</artifactId>
 
     <properties>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.binary.version>2.12</scala.binary.version>
     </properties>
 
     <dependencies>

--- a/statefun-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/statefun-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <statefun.version>@project.version@</statefun.version>
         <java.version>1.8</java.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:1.11.1-scala_2.11-java8
+FROM flink:1.11.1-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
This PR uses Scala 2.12 variants of the various Flink artifacts.
It was tested by running the e2e tests, executing few of the examples, and running StateFun on Kubernetes.
