### PR TITLE
[FLINK-19220] Clean any dangling resources in HttpFunctionProvider

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/common/ManagingResources.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/common/ManagingResources.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.common;
+
+import org.apache.flink.annotation.Internal;
+
+@Internal
+public interface ManagingResources {
+  /**
+   * This method would be called by the runtime on shutdown, and indicates that this is the time to
+   * free up any resources managed by this class.
+   */
+  void shutdown();
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.apache.flink.statefun.flink.core.common.ManagingResources;
 import org.apache.flink.statefun.flink.core.reqreply.PersistedRemoteFunctionValues;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyFunction;
@@ -32,7 +33,7 @@ import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 
 @NotThreadSafe
-public class HttpFunctionProvider implements StatefulFunctionProvider {
+public class HttpFunctionProvider implements StatefulFunctionProvider, ManagingResources {
   private final Map<FunctionType, HttpFunctionSpec> supportedTypes;
 
   /** lazily initialized by {code buildHttpClient} */
@@ -84,5 +85,10 @@ public class HttpFunctionProvider implements StatefulFunctionProvider {
       url = HttpUrl.get(spec.endpoint());
     }
     return new HttpRequestReplyClient(url, clientBuilder.build());
+  }
+
+  @Override
+  public void shutdown() {
+    OkHttpUtils.closeSilently(sharedClient);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtils.java
@@ -17,11 +17,16 @@
 package org.apache.flink.statefun.flink.core.httpfn;
 
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class OkHttpUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(OkHttpUtils.class);
+
   private OkHttpUtils() {}
 
   static OkHttpClient newClient() {
@@ -38,5 +43,26 @@ final class OkHttpUtils {
         .followSslRedirects(true)
         .retryOnConnectionFailure(true)
         .build();
+  }
+
+  static void closeSilently(@Nullable OkHttpClient client) {
+    if (client == null) {
+      return;
+    }
+    final Dispatcher dispatcher = client.dispatcher();
+    try {
+      dispatcher.executorService().shutdownNow();
+    } catch (Throwable ignored) {
+    }
+    try {
+      dispatcher.cancelAll();
+    } catch (Throwable throwable) {
+      LOG.warn("Exception caught while trying to close the HTTP client", throwable);
+    }
+    try {
+      client.connectionPool().evictAll();
+    } catch (Throwable throwable) {
+      LOG.warn("Exception caught while trying to close the HTTP connection pool", throwable);
+    }
   }
 }


### PR DESCRIPTION
Currently the internal Http stateful function, obtains transitively few resources like a thread pool and a connection pool via an http client. But it is unaware of a task cancellation and redeploying, creating the potential for these resources to leak.