### PR TITLE
[FLINK-19279] Remove StatefulFunctionUnvierse cache

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/FlinkConfigExtractor.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/FlinkConfigExtractor.java
@@ -27,8 +27,8 @@ final class FlinkConfigExtractor {
 
   /**
    * Reflectively extracts Flink {@link Configuration} from a {@link StreamExecutionEnvironment}.
-   * The Flink configuration contains Stateful Functions specific configurations.
-   * This is currently a private method in the {@code StreamExecutionEnvironment} class.
+   * The Flink configuration contains Stateful Functions specific configurations. This is currently
+   * a private method in the {@code StreamExecutionEnvironment} class.
    */
   static Configuration reflectivelyExtractFromEnv(StreamExecutionEnvironment env) {
     try {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverses.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverses.java
@@ -17,33 +17,19 @@
  */
 package org.apache.flink.statefun.flink.core;
 
-import static java.util.Collections.synchronizedMap;
-
-import java.util.Map;
-import java.util.WeakHashMap;
 import org.apache.flink.statefun.flink.core.spi.Modules;
 import org.apache.flink.util.Preconditions;
 
 public final class StatefulFunctionsUniverses {
-
-  private static final Map<ClassLoader, StatefulFunctionsUniverse> universes =
-      synchronizedMap(new WeakHashMap<>());
 
   public static StatefulFunctionsUniverse get(
       ClassLoader classLoader, StatefulFunctionsConfig configuration) {
     Preconditions.checkState(classLoader != null, "The class loader was not set.");
     Preconditions.checkState(configuration != null, "The configuration was not set.");
 
-    return universes.computeIfAbsent(
-        classLoader, cl -> initializeFromConfiguration(cl, configuration));
-  }
+    StatefulFunctionsUniverseProvider provider = configuration.getProvider(classLoader);
 
-  private static StatefulFunctionsUniverse initializeFromConfiguration(
-      ClassLoader cl, StatefulFunctionsConfig configuration) {
-
-    StatefulFunctionsUniverseProvider provider = configuration.getProvider(cl);
-
-    return provider.get(cl, configuration);
+    return provider.get(classLoader, configuration);
   }
 
   static final class ClassPathUniverseProvider implements StatefulFunctionsUniverseProvider {


### PR DESCRIPTION
### This PR removes the per JVM `StatefulFunctionUniverse` cache

Currently we cache the provided universe, per JVM. The cache exists to avoid scanning the class path, whenever accessing the universe across different operators executing at the same JVM, however:
1. Each operator accesses the universe during its open phase (once)
2. Having such a cache result in a shared universe across attempts, and this is undesirable. For example accessing previously released resources.

The changes in this PR were tested by executing the e2e tests, and deployed to k8s (while triggering failures)