### PR TITLE
[FLINK-19296][http] Do not retry HTTP calls on shutdown

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -39,6 +39,8 @@ public class HttpFunctionProvider implements StatefulFunctionProvider, ManagingR
   /** lazily initialized by {code buildHttpClient} */
   @Nullable private OkHttpClient sharedClient;
 
+  private volatile boolean shutdown;
+
   public HttpFunctionProvider(Map<FunctionType, HttpFunctionSpec> supportedTypes) {
     this.supportedTypes = supportedTypes;
   }
@@ -84,11 +86,12 @@ public class HttpFunctionProvider implements StatefulFunctionProvider, ManagingR
     } else {
       url = HttpUrl.get(spec.endpoint());
     }
-    return new HttpRequestReplyClient(url, clientBuilder.build());
+    return new HttpRequestReplyClient(url, clientBuilder.build(), () -> shutdown);
   }
 
   @Override
   public void shutdown() {
+    shutdown = true;
     OkHttpUtils.closeSilently(sharedClient);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -22,9 +22,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
@@ -49,15 +51,20 @@ final class RetryingCallback implements Callback {
   private final BoundedExponentialBackoff backoff;
   private final ToFunctionRequestSummary requestSummary;
   private final RemoteInvocationMetrics metrics;
+  private final BooleanSupplier isShutdown;
 
   private long requestStarted;
 
   RetryingCallback(
-      ToFunctionRequestSummary requestSummary, RemoteInvocationMetrics metrics, Timeout timeout) {
+      ToFunctionRequestSummary requestSummary,
+      RemoteInvocationMetrics metrics,
+      Timeout timeout,
+      BooleanSupplier isShutdown) {
     this.resultFuture = new CompletableFuture<>();
     this.backoff = new BoundedExponentialBackoff(INITIAL_BACKOFF_DURATION, duration(timeout));
     this.requestSummary = requestSummary;
     this.metrics = metrics;
+    this.isShutdown = Objects.requireNonNull(isShutdown);
   }
 
   CompletableFuture<Response> future() {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -87,6 +87,9 @@ final class RetryingCallback implements Callback {
   }
 
   private void onFailureUnsafe(Call call, IOException cause) {
+    if (isShutdown.getAsBoolean()) {
+      throw new IllegalStateException("An exception caught during shutdown.", cause);
+    }
     LOG.warn(
         "Retriable exception caught while trying to deliver a message: " + requestSummary, cause);
     metrics.remoteInvocationFailures();


### PR DESCRIPTION
Currently an HTTP request to a remote function would be retrying until the maximum timeout elapses, however during a task cancelation there is no need in retrying and we can short circuit immediately.
This PR addressed that issue by propagating a shutdown flag to a `RetryingCallback`