### PR TITLE
[FLINK-19327][k8s] Bump JobManager heap size to 1 GB

### DIFF
--- a/tools/k8s/templates/master-deployment.yaml
+++ b/tools/k8s/templates/master-deployment.yaml
@@ -37,6 +37,9 @@ spec:
               value: master
             - name: MASTER_HOST
               value: {{ .Values.master.name }}
+          resources:
+            requests:
+              memory: "{{ .Values.master.container_mem }}"
           ports:
             - containerPort: 6123
               name: rpc

--- a/tools/k8s/values.yaml
+++ b/tools/k8s/values.yaml
@@ -22,7 +22,8 @@ checkpoint:
 master:
   name: statefun-master
   image: statefun-application # replace with your image
-  jvm_mem: 500m
+  jvm_mem: 1g
+  container_mem: 1.5Gi
 
 worker:
   name: statefun-worker


### PR DESCRIPTION
Currently our Helm chart specify the value of 
`jobmanager.memory.process.size` to be 500mb which causes the JobManager to crush on start with:

```
INFO  [] - Loading configuration property: jobmanager.memory.process.size, 500m
INFO  [] - Loading configuration property: taskmanager.memory.process.size, 4g
INFO  [] - Loading configuration property: parallelism.default, 3
INFO  [] - The derived from fraction jvm overhead memory (50.000mb (52428800 bytes)) is less than its min value 192.000mb (201326592 bytes), min value will be used instead
Exception in thread "main" org.apache.flink.configuration.IllegalConfigurationException: The configured Total Flink Memory (52.000mb (54525952 bytes)) is less than the configured Off-heap Memory (128.000mb (134217728 bytes)).
	at org.apache.flink.runtime.util.config.memory.jobmanager.JobManagerFlinkMemoryUtils.deriveFromTotalFlinkMemory(JobManagerFlinkMemoryUtils.java:107)
	at org.apache.flink.runtime.util.config.memory.jobmanager.JobManagerFlinkMemoryUtils.deriveFromTotalFlinkMemory(JobManagerFlinkMemoryUtils.java:36)
	at org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils.deriveProcessSpecWithTotalProcessMemory(ProcessMemoryUtils.java:105)
	at org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils.memoryProcessSpecFromConfig(ProcessMemoryUtils.java:79)
	at org.apache.flink.runtime.jobmanager.JobManagerProcessUtils.processSpecFromConfig(JobManagerProcessUtils.java:76)
	at org.apache.flink.runtime.jobmanager.JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(JobManagerProcessUtils.java:71)
	at org.apache.flink.runtime.util.bash.BashJavaUtils.getJmResourceParams(BashJavaUtils.java:102)
	at org.apache.flink.runtime.util.bash.BashJavaUtils.runCommand(BashJavaUtils.java:73)
	at org.apache.flink.runtime.util.bash.BashJavaUtils.main(BashJavaUtils.java:61)
```

This PR bumps the default value for the job manager jvm process to 1GB.
