### PR TITLE
[FLINK-19329] FunctionGroupOperator#dispose() might throw NPE during an unclean shutdown.

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -186,6 +186,12 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
   }
 
   private void closeOrDispose() {
+    final List<ManagingResources> managingResources = this.managingResources;
+    if (managingResources == null) {
+      // dispose can be called before state initialization was completed (for example a failure
+      // during initialization).
+      return;
+    }
     for (ManagingResources withResources : managingResources) {
       try {
         withResources.shutdown();


### PR DESCRIPTION
The `dispose` method of an operator can be called without a successful call to `initalizeState`.
(for example a failure to load the checkpoint data, or any user exception during initializeState) 

This doesn't cause a real issue , since it happens within dispose() and in a `try {} finally { super.dispose()}` block,  but still might be confusing for users to see an NPE.

 
