### PR TITLE
Add Haskell SDK to 3rd party SDKs

### DIFF
--- a/docs/sdk/external.md
+++ b/docs/sdk/external.md
@@ -42,3 +42,10 @@ None of these SDKs are managed by the Flink PMC and the normal rules of open sou
 - Maintainer: [Aljoscha Krettek](https://github.com/aljoscha)
 - Artifact: [crates.io](https://crates.io/crates/statefun)
 - License: [MIT License](https://github.com/aljoscha/statefun-rust/blob/main/LICENSE)
+
+## Haskell
+
+- Repository: [https://github.com/tdbgamer/flink-statefulfun-hs](https://github.com/tdbgamer/flink-statefulfun-hs)
+- Maintainer: [Timothy Bess](https://github.com/tdbgamer)
+- Artifact: [Hackage](https://hackage.haskell.org/package/flink-statefulfun-0.1.0.1)
+- License: [MPL-2.0](https://github.com/tdbgamer/flink-statefulfun-hs/blob/master/LICENSE)


### PR DESCRIPTION
I finished putting together a simple example in the repository, documented it, and have it pushed out to Hackage. Feel free to review and let me know if there are any issues.