### PR TITLE
Fix for FLINK-19515 by moving creation of the InvocationContext out o…

### DIFF
--- a/statefun-python-sdk/statefun/request_reply.py
+++ b/statefun-python-sdk/statefun/request_reply.py
@@ -118,10 +118,10 @@ class InvocationContext:
 
 class RequestReplyHandler:
     def __init__(self, functions):
-        self.invocation_context = InvocationContext(functions)
+        self.functions = functions
 
     def __call__(self, request_bytes):
-        ic = self.invocation_context
+        ic = InvocationContext(self.functions)
         ic.setup(request_bytes)
         self.handle_invocation(ic)
         return ic.complete()
@@ -143,10 +143,10 @@ class RequestReplyHandler:
 
 class AsyncRequestReplyHandler:
     def __init__(self, functions):
-        self.invocation_context = InvocationContext(functions)
+        self.functions = functions
 
     async def __call__(self, request_bytes):
-        ic = self.invocation_context
+        ic = InvocationContext(self.functions)
         ic.setup(request_bytes)
         await self.handle_invocation(ic)
         return ic.complete()


### PR DESCRIPTION
…f __init__ and into __call__.  The ic is destroyed per __call__ so needs to be instantiated per __call__ also.