### PR TITLE
[FLINK-19826][docker] Use wildcards instead of a specific Flink version

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -36,13 +36,13 @@ RUN mkdir -p $STATEFUN_MODULES && \
 
 # add filesystem plugins
 RUN mkdir -p $FLINK_HOME/plugins/s3-fs-presto && \
-    mv $FLINK_HOME/opt/flink-s3-fs-presto-1.11.1.jar $FLINK_HOME/plugins/s3-fs-presto
+    mv $FLINK_HOME/opt/flink-s3-fs-presto-*.jar $FLINK_HOME/plugins/s3-fs-presto
 RUN mkdir -p $FLINK_HOME/plugins/swift-fs-hadoop && \
-    mv $FLINK_HOME/opt/flink-swift-fs-hadoop-1.11.1.jar $FLINK_HOME/plugins/swift-fs-hadoop
+    mv $FLINK_HOME/opt/flink-swift-fs-hadoop-*.jar $FLINK_HOME/plugins/swift-fs-hadoop
 RUN mkdir -p $FLINK_HOME/plugins/oss-fs-hadoop && \
-    mv $FLINK_HOME/opt/flink-oss-fs-hadoop-1.11.1.jar $FLINK_HOME/plugins/oss-fs-hadoop
+    mv $FLINK_HOME/opt/flink-oss-fs-hadoop-*.jar $FLINK_HOME/plugins/oss-fs-hadoop
 RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \
-    mv $FLINK_HOME/opt/flink-azure-fs-hadoop-1.11.1.jar $FLINK_HOME/plugins/azure-fs-hadoop
+    mv $FLINK_HOME/opt/flink-azure-fs-hadoop-*.jar $FLINK_HOME/plugins/azure-fs-hadoop
 
 # entry point 
 ADD docker-entry-point.sh /docker-entry-point.sh


### PR DESCRIPTION
This PR replaces the usage of specific Flink version, when specifying artifacts with wildcards.
The change was verified by building the docker image and:
```
docker : master ✘ :✹ ᐅ  docker run --entrypoint /bin/sh -it flink-statefun:2.3-SNAPSHOT --
# find plugins
plugins
plugins/metrics-graphite
plugins/metrics-graphite/flink-metrics-graphite-1.11.1.jar
plugins/README.txt
plugins/metrics-datadog
plugins/metrics-datadog/flink-metrics-datadog-1.11.1.jar
plugins/metrics-statsd
plugins/metrics-statsd/flink-metrics-statsd-1.11.1.jar
plugins/metrics-prometheus
plugins/metrics-prometheus/flink-metrics-prometheus-1.11.1.jar
plugins/metrics-slf4j
plugins/metrics-slf4j/flink-metrics-slf4j-1.11.1.jar
plugins/metrics-jmx
plugins/metrics-jmx/flink-metrics-jmx-1.11.1.jar
plugins/metrics-influx
plugins/metrics-influx/flink-metrics-influxdb-1.11.1.jar
plugins/external-resource-gpu
plugins/external-resource-gpu/nvidia-gpu-discovery.sh
plugins/external-resource-gpu/gpu-discovery-common.sh
plugins/external-resource-gpu/flink-external-resource-gpu-1.11.1.jar
plugins/azure-fs-hadoop
plugins/azure-fs-hadoop/flink-azure-fs-hadoop-1.11.1.jar
plugins/oss-fs-hadoop
plugins/oss-fs-hadoop/flink-oss-fs-hadoop-1.11.1.jar
plugins/swift-fs-hadoop
plugins/swift-fs-hadoop/flink-swift-fs-hadoop-1.11.1.jar
plugins/s3-fs-presto
plugins/s3-fs-presto/flink-s3-fs-presto-1.11.1.jar
#
```