### PR TITLE
[FLINK-19827] Provide an explicit configuration to the local execution environment.

### DIFF
--- a/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
+++ b/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfigValidator;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsJob;
@@ -114,6 +115,13 @@ public class Harness {
    */
   public Harness withGlobalConfiguration(String key, String value) {
     globalConfigurations.put(key, value);
+    return this;
+  }
+
+  /** Sets the path to the savepoint location to restore from, when this harness starts. */
+  public Harness withSavepointLocation(String savepointLocation) {
+    Objects.requireNonNull(savepointLocation);
+    flinkConfig.set(SavepointConfigOptions.SAVEPOINT_PATH, savepointLocation);
     return this;
   }
 


### PR DESCRIPTION
This PR provides an explicit configuration to the local execution environment.
This allows controlling the way a MiniCluster is started, and the way a job is being submitted (for example setting a save point restore location)
