### PR TITLE
[FLINK-19692] Write all assigned key groups into the keyed raw stream with a Header.

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/CheckpointedStreamOperations.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/CheckpointedStreamOperations.java
@@ -25,6 +25,8 @@ public interface CheckpointedStreamOperations {
 
   void requireKeyedStateCheckpointed(OutputStream keyedStateCheckpointOutputStream);
 
+  Iterable<Integer> keyGroupList(OutputStream stream);
+
   void startNewKeyGroup(OutputStream stream, int keyGroup) throws IOException;
 
   Closeable acquireLease(OutputStream keyedStateCheckpointOutputStream);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/KeyGroupStream.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/KeyGroupStream.java
@@ -94,4 +94,8 @@ final class KeyGroupStream<T> {
       memoryPool.release(segment);
     }
   }
+
+  public static void writeEmptyTo(DataOutputView target) throws IOException {
+    target.writeInt(0);
+  }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/Loggers.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/Loggers.java
@@ -87,6 +87,11 @@ public final class Loggers {
     }
 
     @Override
+    public Iterable<Integer> keyGroupList(OutputStream stream) {
+      return cast(stream).getKeyGroupList();
+    }
+
+    @Override
     public void startNewKeyGroup(OutputStream stream, int keyGroup) throws IOException {
       cast(stream).startNewKeyGroup(keyGroup);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
@@ -19,10 +19,13 @@ package org.apache.flink.statefun.flink.core.logger;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
+import java.io.BufferedInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PushbackInputStream;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -30,8 +33,11 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackConsumer;
@@ -104,6 +110,7 @@ public final class UnboundedFeedbackLogger<T> implements FeedbackLogger<T> {
     // to this operator must be written to the underlying stream.
     for (Integer keyGroupId : assignedKeyGroupIds) {
       checkpointedStreamOperations.startNewKeyGroup(keyedStateOutputStream, keyGroupId);
+      Header.writeHeader(target);
 
       @Nullable KeyGroupStream<T> stream = keyGroupStreams.get(keyGroupId);
       if (stream == null) {
@@ -116,8 +123,8 @@ public final class UnboundedFeedbackLogger<T> implements FeedbackLogger<T> {
 
   public void replyLoggedEnvelops(InputStream rawKeyedStateInputs, FeedbackConsumer<T> consumer)
       throws Exception {
-
-    DataInputViewStreamWrapper in = new DataInputViewStreamWrapper(rawKeyedStateInputs);
+    DataInputView in =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(rawKeyedStateInputs));
     KeyGroupStream.readFrom(in, serializer, consumer);
   }
 
@@ -137,5 +144,38 @@ public final class UnboundedFeedbackLogger<T> implements FeedbackLogger<T> {
     snapshotLease = null;
     keyedStateOutputStream = null;
     keyGroupStreams.clear();
+  }
+
+  @VisibleForTesting
+  static final class Header {
+    private static final int STATEFUN_VERSION = 0;
+    private static final int STATEFUN_MAGIC = 710818519;
+    private static final byte[] HEADER_BYTES = headerBytes();
+
+    public static void writeHeader(DataOutputView target) throws IOException {
+      target.write(HEADER_BYTES);
+    }
+
+    public static InputStream skipHeaderSilently(InputStream rawKeyedInput) throws IOException {
+      byte[] header = new byte[HEADER_BYTES.length];
+      PushbackInputStream input =
+          new PushbackInputStream(new BufferedInputStream(rawKeyedInput), header.length);
+      int bytesRead = input.read(header);
+      if (bytesRead > 0 && !Arrays.equals(header, HEADER_BYTES)) {
+        input.unread(header, 0, bytesRead);
+      }
+      return input;
+    }
+
+    private static byte[] headerBytes() {
+      DataOutputSerializer out = new DataOutputSerializer(8);
+      try {
+        out.writeInt(STATEFUN_VERSION);
+        out.writeInt(STATEFUN_MAGIC);
+      } catch (IOException e) {
+        throw new IllegalStateException("Unable to compute the header bytes");
+      }
+      return out.getCopyOfBuffer();
+    }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
+import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -57,7 +58,7 @@ public class UnboundedFeedbackLoggerTest {
     logger.startLogging(output);
     logger.commit();
 
-    assertThat(output.size(), is(0));
+    assertThat(output.size(), Matchers.greaterThan(0));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
+import org.apache.flink.statefun.flink.core.logger.UnboundedFeedbackLogger.Header;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -75,6 +76,11 @@ public class UnboundedFeedbackLoggerTest {
     roundTrip(100, 1024);
   }
 
+  @Test
+  public void roundTripWithoutElements() throws Exception {
+    roundTrip(0, 1024);
+  }
+
   @Ignore
   @Test
   public void roundTripWithSpill() throws Exception {
@@ -82,18 +88,48 @@ public class UnboundedFeedbackLoggerTest {
   }
 
   @Test
-  public void testHeader() throws IOException {
+  public void roundTripWithHeader() throws IOException {
     DataOutputSerializer out = new DataOutputSerializer(32);
-
-    UnboundedFeedbackLogger.Header.writeHeader(out);
+    Header.writeHeader(out);
     out.writeInt(123);
+    out.writeInt(456);
+    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
 
-    InputStream stream =
-        UnboundedFeedbackLogger.Header.skipHeaderSilently(
-            new ByteArrayInputStream(out.getCopyOfBuffer()));
+    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
 
-    DataInputViewStreamWrapper in = new DataInputViewStreamWrapper(stream);
-    assertThat(in.readInt(), is(123));
+    assertThat(view.readInt(), is(123));
+    assertThat(view.readInt(), is(456));
+  }
+
+  @Test
+  public void roundTripWithoutHeader() throws IOException {
+    DataOutputSerializer out = new DataOutputSerializer(32);
+    out.writeInt(123);
+    out.writeInt(456);
+    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
+
+    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
+
+    assertThat(view.readInt(), is(123));
+    assertThat(view.readInt(), is(456));
+  }
+
+  @Test
+  public void emptyKeyGroupWithHeader() throws IOException {
+    DataOutputSerializer out = new DataOutputSerializer(32);
+    Header.writeHeader(out);
+    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
+
+    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
+
+    assertThat(view.read(), is(-1));
+  }
+
+  @Test
+  public void emptyKeyGroupWithoutHeader() throws IOException {
+    InputStream in = new ByteArrayInputStream(new byte[0]);
+    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
+    assertThat(view.read(), is(-1));
   }
 
   private void roundTrip(int numElements, int maxMemoryInBytes) throws Exception {


### PR DESCRIPTION
This PR allows creating and restoring from savepoints that contain elements in the feedback log, taken as of this PR and moving forward. 
Restoring from savepoints taken prior to this PR (with elements in the feedback log) requires a followup work.

This PR changes the on the wire checkpoint format for the feedback log.
For each key group written to the raw keyed stream (empty or not), we now write the following header:  `<statefun version: int><statefun magic header: int>`

We start with the version 0 and a magic header that is a constant random number. Writing the version and the magic header are made for safety and format evolution.

The version number `0` is carefully chosen as a workaround to FLINK-19692. This is because the InternalTimerManager reads that first 0 (that we wrote as a version) and it will not try to read anything else from the stream.