### PR TITLE
 [FLINK-20009][docs] Add documentation link check to travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,8 @@ jobs:
       jdk: "openjdk11"
       script: mvn clean install -Prun-e2e-tests
       name: build - jdk11
+    - if: type = (pull_request, push) 
+      script: ./tools/ci/docs.sh
+      language: ruby
+      rvm: 2.4.0
+      name: Documentation links check

--- a/docs/concepts/distributed_architecture.md
+++ b/docs/concepts/distributed_architecture.md
@@ -74,7 +74,7 @@ Function invocations happen through an HTTP / gRPC protocol and go through a ser
 </p>
 
 
-Refer to the documentation on the [Python SDK]({{ site.baseurl }}/sdk/python.html) and [remote modules]({{ site.baseurl }}/sdk/modules.html#remote-module) for details. 
+Refer to the documentation on the [Python SDK]({{ site.baseurl }}/sdk/python.html) and [remote modules]({{ site.baseurl }}/sdk/index.html#remote-module) for details. 
 
 #### Co-located Functions
 

--- a/docs/sdk/java.md
+++ b/docs/sdk/java.md
@@ -27,7 +27,7 @@ under the License.
 Stateful functions are the building blocks of applications; they are atomic units of isolation, distribution, and persistence.
 As objects, they encapsulate the state of a single entity (e.g., a specific user, device, or session) and encode its behavior.
 Stateful functions can interact with each other, and external systems, through message passing.
-The Java SDK is supported as an [embedded module]({{ site.baseurl }}/sdk/modules.html#embedded-module).
+The Java SDK is supported as an [embedded module]({{ site.baseurl }}/sdk/index.html#embedded-module).
 
 To get started, add the Java SDK as a dependency to your application.
 
@@ -163,7 +163,7 @@ Finally, if a catch-all exists, it will be executed or an ``IllegalStateExceptio
 ## Function Types and Messaging
 
 In Java, function types are defined as logical pointers composed of a namespace and name.
-The type is bound to the implementing class in the [module]({{ site.baseurl }}/sdk/modules.html#embedded-module) definition.
+The type is bound to the implementing class in the [module]({{ site.baseurl }}/sdk/index.html#embedded-module) definition.
 Below is an example function type for the hello world function.
 
 {% highlight java %}

--- a/docs/sdk/python.md
+++ b/docs/sdk/python.md
@@ -27,7 +27,7 @@ under the License.
 Stateful functions are the building blocks of applications; they are atomic units of isolation, distribution, and persistence.
 As objects, they encapsulate the state of a single entity (e.g., a specific user, device, or session) and encode its behavior.
 Stateful functions can interact with each other, and external systems, through message passing.
-The Python SDK is supported as a [remote module]({{ site.baseurl}}/sdk/modules.html#remote-module).
+The Python SDK is supported as a [remote module]({{ site.baseurl}}/sdk/index.html#remote-module).
 
 To get started, add the Python SDK as a dependency to your application.
 
@@ -158,7 +158,7 @@ All stateful functions may contain state by merely storing values within the ``c
 The data is always scoped to a specific function type and identifier.
 State values could be absent, ``None``, or a ``google.protobuf.Any``.
 
-<strong>Attention:</strong> [Remote modules]({{ site.baseurl}}/sdk/modules.html#remote-module) require that all state values are eagerly registered at module.yaml.
+<strong>Attention:</strong> [Remote modules]({{ site.baseurl}}/sdk/index.html#remote-module) require that all state values are eagerly registered at module.yaml.
 It'll also allow configuring other state properties, such as state expiration. Please refer to that page for more details.
     
 Below is a stateful function that greets users based on the number of times they have been seen.

--- a/tools/ci/docs.sh
+++ b/tools/ci/docs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid
+if [ ! -f ${PROJECT_ROOT}/docs/build_docs.sh ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+CACHE_DIR=$HOME/gem_cache ${PROJECT_ROOT}/docs/build_docs.sh -p &
+
+for i in `seq 1 30`;
+do
+	echo "Waiting for server..."
+	curl -Is http://localhost:4000 --fail
+	if [ $? -eq 0 ]; then
+		break
+	fi
+	sleep 10
+done
+
+${PROJECT_ROOT}/docs/check_links.sh


### PR DESCRIPTION
This adds a Travis step to verify the docs build and there are no dead links. 

I copied the `docs.sh` file directly from the main flink repo, this is how we keep the docs stable there as well. 