### PR TITLE
[FLINK-20189] [core] Fix Header.skipHeaderSilently to fully fill the header bytes read buffer before comparing

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtils.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+final class InputStreamUtils {
+
+  private InputStreamUtils() {}
+
+  /**
+   * Attempt to fill the provided read buffer with bytes from the given {@link InputStream}, and
+   * returns the total number of bytes read into the read buffer.
+   *
+   * <p>This method repeatedly reads the {@link InputStream} until either:
+   *
+   * <ul>
+   *   <li>the read buffer is filled, or
+   *   <li>EOF of the input stream is reached.
+   * </ul>
+   *
+   * <p>TODO we can remove this once we upgrade to Flink 1.12.x, since {@link
+   * org.apache.flink.util.IOUtils} would have a new utility for exactly this.
+   *
+   * @param in the input stream to read from
+   * @param readBuffer the read buffer to fill
+   * @return the total number of bytes read into the read buffer
+   */
+  static int tryReadFully(final InputStream in, final byte[] readBuffer) throws IOException {
+    int totalRead = 0;
+    while (totalRead != readBuffer.length) {
+      int read = in.read(readBuffer, totalRead, readBuffer.length - totalRead);
+      if (read == -1) {
+        break;
+      }
+      totalRead += read;
+    }
+    return totalRead;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
@@ -19,7 +19,6 @@ package org.apache.flink.statefun.flink.core.logger;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
-import java.io.BufferedInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -158,9 +157,8 @@ public final class UnboundedFeedbackLogger<T> implements FeedbackLogger<T> {
 
     public static InputStream skipHeaderSilently(InputStream rawKeyedInput) throws IOException {
       byte[] header = new byte[HEADER_BYTES.length];
-      PushbackInputStream input =
-          new PushbackInputStream(new BufferedInputStream(rawKeyedInput), header.length);
-      int bytesRead = input.read(header);
+      PushbackInputStream input = new PushbackInputStream(rawKeyedInput, header.length);
+      int bytesRead = InputStreamUtils.tryReadFully(input, header);
       if (bytesRead > 0 && !Arrays.equals(header, HEADER_BYTES)) {
         input.unread(header, 0, bytesRead);
       }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtilsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtilsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.logger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import org.apache.flink.util.function.ThrowingRunnable;
+import org.junit.Test;
+
+public final class InputStreamUtilsTest {
+
+  private static final int NUM_REPEAT_TESTS = 10000;
+
+  @Test
+  public void tryReadFullyExampleUsage() throws Exception {
+    final byte[] testBytes = "test-data".getBytes();
+    final byte[] readBuffer = new byte[testBytes.length];
+
+    try (InputStream in = testInputStream(testBytes)) {
+      final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
+
+      assertThat(numReadBytes, is(testBytes.length));
+      assertThat(readBuffer, is(testBytes));
+      assertThat(in.read(), is(-1));
+    }
+  }
+
+  @Test
+  public void tryReadFullyEmptyInputStream() throws Exception {
+    repeatTest(
+        NUM_REPEAT_TESTS,
+        () -> {
+          final byte[] testBytes = new byte[0];
+          final byte[] readBuffer = new byte[10];
+
+          try (InputStream in = testInputStream(testBytes)) {
+            final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
+
+            assertThat(numReadBytes, is(0));
+            assertThat(readBuffer, is(new byte[10]));
+            assertThat(in.read(), is(-1));
+          }
+        });
+  }
+
+  @Test
+  public void tryReadFullyReadBufferSizeLargerThanInputStream() throws Exception {
+    repeatTest(
+        NUM_REPEAT_TESTS,
+        () -> {
+          final byte[] testBytes = new byte[] {-91, 11, 8};
+          // read buffer has larger size than the test data
+          final byte[] readBuffer = new byte[testBytes.length + 20];
+
+          try (InputStream in = testInputStream(testBytes)) {
+            final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
+
+            assertThat(numReadBytes, is(testBytes.length));
+            assertThat(readBuffer, is(Arrays.copyOf(testBytes, readBuffer.length)));
+            assertThat(in.read(), is(-1));
+          }
+        });
+  }
+
+  @Test
+  public void tryReadFullyReadBufferSizeSmallerThanInputStream() throws Exception {
+    repeatTest(
+        NUM_REPEAT_TESTS,
+        () -> {
+          final byte[] testBytes = new byte[] {-91, 11, 8, 53, 100, 5, -100, 102, 56, 95};
+          // read buffer has smaller size than the test data
+          final byte[] readBuffer = new byte[testBytes.length - 2];
+
+          try (InputStream in = testInputStream(testBytes)) {
+            final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
+
+            assertThat(numReadBytes, is(readBuffer.length));
+            assertThat(readBuffer, is(Arrays.copyOfRange(testBytes, 0, readBuffer.length)));
+
+            // assert that the input stream is not overly-read
+            assertThat(in.read(), is(56));
+            assertThat(in.read(), is(95));
+            assertThat(in.read(), is(-1));
+          }
+        });
+  }
+
+  @Test
+  public void tryReadFullyEmptyReadBuffer() throws Exception {
+    repeatTest(
+        NUM_REPEAT_TESTS,
+        () -> {
+          final byte[] testBytes = "test-data".getBytes();
+          final byte[] readBuffer = new byte[0];
+
+          try (InputStream in = testInputStream(testBytes)) {
+            final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
+
+            assertThat(numReadBytes, is(0));
+            assertThat(readBuffer, is(new byte[0]));
+          }
+        });
+  }
+
+  private static InputStream testInputStream(byte[] streamBytes) {
+    return new RandomReadLengthByteArrayInputStream(Arrays.copyOf(streamBytes, streamBytes.length));
+  }
+
+  private static void repeatTest(int numRepeats, ThrowingRunnable<Exception> test)
+      throws Exception {
+    for (int i = 0; i < numRepeats; i++) {
+      test.run();
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/RandomReadLengthByteArrayInputStream.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/RandomReadLengthByteArrayInputStream.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Random;
+
+/**
+ * A {@link ByteArrayInputStream} that reads a random number of bytes per read (at least 1) up to
+ * the requested amount, and always returns 0 on {@link InputStream#available()}.
+ *
+ * <p>We use this input stream in our tests to mimic behaviour of "real-life" input streams, while
+ * still adhering to the contracts of the {@link InputStream} methods:
+ *
+ * <ul>
+ *   <li>For {@link InputStream#read(byte[])} and {@link InputStream#read()}: read methods always
+ *       blocks until at least 1 byte is available from the stream; it always at least reads 1 byte.
+ *   <li>For {@link InputStream#available()}: always return 0, to imply that there are no bytes
+ *       immediately available from the stream, and the next read will block.
+ * </ul>
+ */
+final class RandomReadLengthByteArrayInputStream extends ByteArrayInputStream {
+
+  private static final Random RANDOM = new Random();
+
+  RandomReadLengthByteArrayInputStream(byte[] byteBuffer) {
+    super(byteBuffer);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) {
+    final int randomNumBytesToRead = RANDOM.nextInt(len) + 1;
+    return super.read(b, off, randomNumBytesToRead);
+  }
+
+  @Override
+  public synchronized int available() {
+    return 0;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
@@ -93,7 +93,7 @@ public class UnboundedFeedbackLoggerTest {
     Header.writeHeader(out);
     out.writeInt(123);
     out.writeInt(456);
-    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
+    InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
     DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
 
@@ -106,7 +106,7 @@ public class UnboundedFeedbackLoggerTest {
     DataOutputSerializer out = new DataOutputSerializer(32);
     out.writeInt(123);
     out.writeInt(456);
-    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
+    InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
     DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
 
@@ -118,7 +118,7 @@ public class UnboundedFeedbackLoggerTest {
   public void emptyKeyGroupWithHeader() throws IOException {
     DataOutputSerializer out = new DataOutputSerializer(32);
     Header.writeHeader(out);
-    InputStream in = new ByteArrayInputStream(out.getCopyOfBuffer());
+    InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
     DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
 
@@ -127,7 +127,7 @@ public class UnboundedFeedbackLoggerTest {
 
   @Test
   public void emptyKeyGroupWithoutHeader() throws IOException {
-    InputStream in = new ByteArrayInputStream(new byte[0]);
+    InputStream in = new RandomReadLengthByteArrayInputStream(new byte[0]);
     DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
     assertThat(view.read(), is(-1));
   }


### PR DESCRIPTION
This PR fixes the per key-group `Header.skipHeaderSilently` operation to properly fully fill the header bytes read buffer, before comparing it with the expected header bytes.

Since {{InputStream.read(byte[])}} by contract only guarantees reading at least 1 byte and could read less bytes than desired (i.e. the read buffer length), prior to this PR, it was possible that the read buffer wasn't fully filled. This would result in an invalid header bytes comparison, and incorrectly pushing back header bytes back into the remaining stream.

Ultimately, what this means is that in this case, `Header.skipHeaderSilently` doesn't actually skip the header bytes, and the following reads on the per key-group streams (to restore the feedback events) would be attempting to read a corrupt stream.

The fix is to do a `readFully` operation instead of a simple read when filling the header bytes read buffer.

## Change log

- b6256df Backports the `tryReadFully` utility in Flink. This backport can be reverted once we upgrade to Flink 1.12.0 / 1.11.3. Note that in our backport, we introduced a new `RandomReadLengthByteArrayInputStream` utility to attempt to mimic the behaviour of "real-life" input streams in our tests, where each read can return less than the desired number of bytes.

- e246c1c Use `tryReadFully` in `Header.skipHeaderSilently`.

- 099015c Extend the existing tests in `UnboundedFeedbackLoggerTest` to use the new `RandomReadLengthByteArrayInputStream`. This new version of the test would fail without applying the fix.