### PR TITLE
[FLINK-20265] [core] Extend remote invocation protocol with IncompleteInvocationContext response type

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpRequestReplyClient.java
@@ -73,11 +73,7 @@ final class HttpRequestReplyClient implements RequestReplyClient {
   private static FromFunction parseResponse(Response response) {
     final InputStream httpResponseBody = responseBody(response);
     try {
-      FromFunction fromFunction = parseProtobufOrThrow(FromFunction.parser(), httpResponseBody);
-      if (fromFunction.hasInvocationResult()) {
-        return fromFunction;
-      }
-      return FromFunction.getDefaultInstance();
+      return parseProtobufOrThrow(FromFunction.parser(), httpResponseBody);
     } finally {
       IOUtils.closeQuietly(httpResponseBody);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -38,10 +38,17 @@ public final class PersistedRemoteFunctionValues {
 
   private final Map<String, PersistedValue<byte[]>> managedStates;
 
+  /**
+   * @deprecated {@link PersistedRemoteFunctionValues} should no longer be instantiated with eagerly
+   *     declared state specs. State can now be dynamically registered with {@link
+   *     #registerStates(List)}. This constructor will be removed once old module specification
+   *     formats, which supports eager state declarations, are removed.
+   */
+  @Deprecated
   public PersistedRemoteFunctionValues(List<StateSpec> stateSpecs) {
     Objects.requireNonNull(stateSpecs);
     this.managedStates = new HashMap<>(stateSpecs.size());
-    stateSpecs.forEach(this::createAndRegisterValueState);
+    stateSpecs.forEach(this::createAndRegisterEagerValueState);
   }
 
   void forEach(BiConsumer<String, byte[]> consumer) {
@@ -99,7 +106,7 @@ public final class PersistedRemoteFunctionValues {
     }
   }
 
-  private void createAndRegisterValueState(StateSpec stateSpec) {
+  private void createAndRegisterEagerValueState(StateSpec stateSpec) {
     final String stateName = stateSpec.name();
 
     final PersistedValue<byte[]> stateValue =

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
@@ -29,6 +29,7 @@ import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.IncompleteInvocationContext;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.InvocationResponse;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.Invocation;
@@ -41,6 +42,7 @@ import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.types.Either;
 
 public final class RequestReplyFunction implements StatefulFunction {
 
@@ -124,8 +126,44 @@ public final class RequestReplyFunction implements StatefulFunction {
       sendToFunction(context, batch);
       return;
     }
-    InvocationResponse invocationResult = unpackInvocationOrThrow(context.self(), asyncResult);
-    handleInvocationResponse(context, invocationResult);
+    if (asyncResult.failure()) {
+      throw new IllegalStateException(
+          "Failure forwarding a message to a remote function " + context.self(),
+          asyncResult.throwable());
+    }
+
+    final Either<InvocationResponse, IncompleteInvocationContext> response =
+        unpackResponse(asyncResult.value());
+    if (response.isRight()) {
+      handleIncompleteInvocationContextResponse(context, response.right(), asyncResult.metadata());
+    } else {
+      handleInvocationResultResponse(context, response.left());
+    }
+  }
+
+  private static Either<InvocationResponse, IncompleteInvocationContext> unpackResponse(
+      FromFunction fromFunction) {
+    if (fromFunction.hasIncompleteInvocationContext()) {
+      return Either.Right(fromFunction.getIncompleteInvocationContext());
+    }
+    return Either.Left(fromFunction.getInvocationResult());
+  }
+
+  private void handleIncompleteInvocationContextResponse(
+      InternalContext context,
+      IncompleteInvocationContext incompleteContext,
+      ToFunction originalBatch) {
+    managedStates.registerStates(incompleteContext.getMissingValuesList());
+
+    final InvocationBatchRequest.Builder retryBatch = createRetryBatch(originalBatch);
+    sendToFunction(context, retryBatch);
+  }
+
+  private void handleInvocationResultResponse(InternalContext context, InvocationResponse result) {
+    handleOutgoingMessages(context, result);
+    handleOutgoingDelayedMessages(context, result);
+    handleEgressMessages(context, result);
+    managedStates.updateStateValues(result.getStateMutationsList());
 
     final int numBatched = requestState.getOrDefault(-1);
     if (numBatched < 0) {
@@ -136,7 +174,8 @@ public final class RequestReplyFunction implements StatefulFunction {
       final InvocationBatchRequest.Builder nextBatch = getNextBatch();
       // an async request was just completed, but while it was in flight we have
       // accumulated a batch, we now proceed with:
-      // a) clearing the batch from our own persisted state (the batch moves to the async operation
+      // a) clearing the batch from our own persisted state (the batch moves to the async
+      // operation
       // state)
       // b) sending the accumulated batch to the remote function.
       requestState.set(0);
@@ -146,19 +185,6 @@ public final class RequestReplyFunction implements StatefulFunction {
     }
   }
 
-  private InvocationResponse unpackInvocationOrThrow(
-      Address self, AsyncOperationResult<ToFunction, FromFunction> result) {
-    if (result.failure()) {
-      throw new IllegalStateException(
-          "Failure forwarding a message to a remote function " + self, result.throwable());
-    }
-    FromFunction fromFunction = result.value();
-    if (fromFunction.hasInvocationResult()) {
-      return fromFunction.getInvocationResult();
-    }
-    return InvocationResponse.getDefaultInstance();
-  }
-
   private InvocationBatchRequest.Builder getNextBatch() {
     InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
     Iterable<Invocation> view = batch.view();
@@ -166,11 +192,10 @@ public final class RequestReplyFunction implements StatefulFunction {
     return builder;
   }
 
-  private void handleInvocationResponse(Context context, InvocationResponse invocationResult) {
-    handleOutgoingMessages(context, invocationResult);
-    handleOutgoingDelayedMessages(context, invocationResult);
-    handleEgressMessages(context, invocationResult);
-    managedStates.updateStateValues(invocationResult.getStateMutationsList());
+  private InvocationBatchRequest.Builder createRetryBatch(ToFunction toFunction) {
+    InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    builder.addAllInvocations(toFunction.getInvocation().getInvocationsList());
+    return builder;
   }
 
   private void handleEgressMessages(Context context, InvocationResponse invocationResult) {

--- a/statefun-flink/statefun-flink-core/src/main/protobuf/http-function.proto
+++ b/statefun-flink/statefun-flink-core/src/main/protobuf/http-function.proto
@@ -63,11 +63,11 @@ message ToFunction {
     }
 
     // InvocationBatchRequest represents a request to invoke a remote function. It is always associated with a target
-    // address (the function to invoke), a list of eager state values.
+    // address (the function to invoke), and a list of values for registered state.
     message InvocationBatchRequest {
         // The address of the function to invoke
         Address target = 1;
-        // A list of PersistedValues that were registered as an eager state.
+        // A list of PersistedValues that were registered as a persisted state.
         repeated PersistedValue state = 2;
         // A non empty (at least one) list of invocations
         repeated Invocation invocations = 3;
@@ -137,8 +137,45 @@ message FromFunction {
         repeated EgressMessage outgoing_egresses = 4;
     }
 
+    // ----------------------------------------------------------------------------------------------------------------
+    // IncompleteInvocationContext messages:
+    // IncompleteInvocationContext represents a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest,
+    // which should be used as the response if the InvocationBatchRequest provided incomplete information about the
+    // invocation, e.g. insufficient state values where provided.
+    // ----------------------------------------------------------------------------------------------------------------
+
+    message IncompleteInvocationContext {
+        repeated PersistedValueSpec missing_values = 1;
+    }
+
+    // ExpirationSpec represents TTL (Time-To-Live) configuration for persisted states.
+    message ExpirationSpec {
+        enum ExpireMode {
+            NONE = 0;
+            AFTER_WRITE = 1;
+            AFTER_INVOKE = 2;
+        }
+        ExpireMode mode = 1;
+        int64 expire_after_millis = 2;
+    }
+
+    // PersistedValueSpec represents specifications of a function's persisted value state.
+    message PersistedValueSpec {
+        string state_name = 1;
+        ExpirationSpec expiration_spec = 3;
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Response sent from the function, as a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest.
+    //
+    // Can be one of the following types:
+    //   - org.apache.flink.statefun.flink.core.polyglot.FromFunction.InvocationResponse
+    //   - org.apache.flink.statefun.flink.core.polyglot.FromFunction.IncompleteInvocationContext
+    // ----------------------------------------------------------------------------------------------------------------
+
     oneof response {
         InvocationResponse invocation_result = 100;
+        IncompleteInvocationContext incomplete_invocation_context = 101;
     }
 }
 

--- a/statefun-flink/statefun-flink-core/src/main/protobuf/http-function.proto
+++ b/statefun-flink/statefun-flink-core/src/main/protobuf/http-function.proto
@@ -137,17 +137,6 @@ message FromFunction {
         repeated EgressMessage outgoing_egresses = 4;
     }
 
-    // ----------------------------------------------------------------------------------------------------------------
-    // IncompleteInvocationContext messages:
-    // IncompleteInvocationContext represents a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest,
-    // which should be used as the response if the InvocationBatchRequest provided incomplete information about the
-    // invocation, e.g. insufficient state values where provided.
-    // ----------------------------------------------------------------------------------------------------------------
-
-    message IncompleteInvocationContext {
-        repeated PersistedValueSpec missing_values = 1;
-    }
-
     // ExpirationSpec represents TTL (Time-To-Live) configuration for persisted states.
     message ExpirationSpec {
         enum ExpireMode {
@@ -162,17 +151,20 @@ message FromFunction {
     // PersistedValueSpec represents specifications of a function's persisted value state.
     message PersistedValueSpec {
         string state_name = 1;
-        ExpirationSpec expiration_spec = 3;
+        ExpirationSpec expiration_spec = 2;
     }
 
-    // ----------------------------------------------------------------------------------------------------------------
+    // IncompleteInvocationContext represents a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest,
+    // which should be used as the response if the InvocationBatchRequest provided incomplete information about the
+    // invocation, e.g. insufficient state values were provided.
+    message IncompleteInvocationContext {
+        repeated PersistedValueSpec missing_values = 1;
+    }
+
     // Response sent from the function, as a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest.
-    //
-    // Can be one of the following types:
+    // It can be one of the following types:
     //   - org.apache.flink.statefun.flink.core.polyglot.FromFunction.InvocationResponse
     //   - org.apache.flink.statefun.flink.core.polyglot.FromFunction.IncompleteInvocationContext
-    // ----------------------------------------------------------------------------------------------------------------
-
     oneof response {
         InvocationResponse invocation_result = 100;
         IncompleteInvocationContext incomplete_invocation_context = 101;

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.reqreply;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.protobuf.ByteString;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueMutation;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueSpec;
+import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.InvocationBatchRequest;
+import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.PersistedValue;
+import org.junit.Test;
+
+public class PersistedRemoteFunctionValuesTest {
+
+  @Test
+  public void exampleUsage() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    // --- register persisted states
+    values.registerStates(
+        Arrays.asList(
+            protocolPersistedValueSpec("state-1"), protocolPersistedValueSpec("state-2")));
+
+    // --- update state values
+    values.updateStateValues(
+        Arrays.asList(
+            protocolPersistedValueModifyMutation("state-1", ByteString.copyFromUtf8("data-1")),
+            protocolPersistedValueModifyMutation("state-2", ByteString.copyFromUtf8("data-2"))));
+
+    final InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    values.attachStateValues(builder);
+
+    // --- registered state names and their values should be attached
+    assertThat(builder.getStateList().size(), is(2));
+    assertThat(
+        builder.getStateList(),
+        hasItems(
+            protocolPersistedValue("state-1", ByteString.copyFromUtf8("data-1")),
+            protocolPersistedValue("state-2", ByteString.copyFromUtf8("data-2"))));
+  }
+
+  @Test
+  public void zeroRegisteredStates() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    final InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    values.attachStateValues(builder);
+
+    assertThat(builder.getStateList().size(), is(0));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void updatingNonRegisteredStateShouldThrow() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    values.updateStateValues(
+        Collections.singletonList(
+            protocolPersistedValueModifyMutation(
+                "non-registered-state", ByteString.copyFromUtf8("data"))));
+  }
+
+  @Test
+  public void registeredStateWithEmptyValueShouldBeAttached() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    values.registerStates(Collections.singletonList(protocolPersistedValueSpec("state")));
+
+    final InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    values.attachStateValues(builder);
+
+    assertThat(builder.getStateList().size(), is(1));
+    assertThat(builder.getStateList(), hasItems(protocolPersistedValue("state", null)));
+  }
+
+  @Test
+  public void registeredStateWithDeletedValueShouldBeAttached() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    values.registerStates(Collections.singletonList(protocolPersistedValueSpec("state")));
+
+    // modify and then delete state value
+    values.updateStateValues(
+        Collections.singletonList(
+            protocolPersistedValueModifyMutation("state", ByteString.copyFromUtf8("data"))));
+    values.updateStateValues(
+        Collections.singletonList(protocolPersistedValueDeleteMutation("state")));
+
+    final InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    values.attachStateValues(builder);
+
+    assertThat(builder.getStateList().size(), is(1));
+    assertThat(builder.getStateList(), hasItems(protocolPersistedValue("state", null)));
+  }
+
+  @Test
+  public void duplicateRegistrationsHasNoEffect() {
+    final PersistedRemoteFunctionValues values =
+        new PersistedRemoteFunctionValues(Collections.emptyList());
+
+    values.registerStates(Collections.singletonList(protocolPersistedValueSpec("state")));
+    values.updateStateValues(
+        Collections.singletonList(
+            protocolPersistedValueModifyMutation("state", ByteString.copyFromUtf8("data"))));
+
+    // duplicate registration under the same state name
+    values.registerStates(Collections.singletonList(protocolPersistedValueSpec("state")));
+
+    final InvocationBatchRequest.Builder builder = InvocationBatchRequest.newBuilder();
+    values.attachStateValues(builder);
+
+    assertThat(builder.getStateList().size(), is(1));
+    assertThat(
+        builder.getStateList(),
+        hasItems(protocolPersistedValue("state", ByteString.copyFromUtf8("data"))));
+  }
+
+  private static PersistedValueSpec protocolPersistedValueSpec(String stateName) {
+    return PersistedValueSpec.newBuilder().setStateName(stateName).build();
+  }
+
+  private static PersistedValueMutation protocolPersistedValueModifyMutation(
+      String stateName, ByteString modifyValue) {
+    return PersistedValueMutation.newBuilder()
+        .setStateName(stateName)
+        .setMutationType(PersistedValueMutation.MutationType.MODIFY)
+        .setStateValue(modifyValue)
+        .build();
+  }
+
+  private static PersistedValueMutation protocolPersistedValueDeleteMutation(String stateName) {
+    return PersistedValueMutation.newBuilder()
+        .setStateName(stateName)
+        .setMutationType(PersistedValueMutation.MutationType.DELETE)
+        .build();
+  }
+
+  private static PersistedValue protocolPersistedValue(String stateName, ByteString stateValue) {
+    final PersistedValue.Builder builder = PersistedValue.newBuilder();
+    builder.setStateName(stateName);
+
+    if (stateValue != null) {
+      builder.setStateValue(stateValue);
+    }
+    return builder.build();
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.statefun.flink.core.reqreply;
 
 import static org.apache.flink.statefun.flink.core.TestUtils.FUNCTION_1_ADDR;
 import static org.apache.flink.statefun.flink.core.common.PolyglotUtil.polyglotAddressToSdkAddress;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,8 +34,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.flink.core.backpressure.InternalContext;
 import org.apache.flink.statefun.flink.core.httpfn.StateSpec;
@@ -43,9 +46,12 @@ import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.DelayedInvocation;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.EgressMessage;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.ExpirationSpec;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.IncompleteInvocationContext;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.InvocationResponse;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueMutation;
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueMutation.MutationType;
+import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueSpec;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.Invocation;
 import org.apache.flink.statefun.sdk.Address;
@@ -211,6 +217,37 @@ public class RequestReplyFunctionTest {
   }
 
   @Test
+  public void retryBatchOnIncompleteInvocationContextResponse() {
+    Any any = Any.pack(TestUtils.DUMMY_PAYLOAD);
+    functionUnderTest.invoke(context, any);
+
+    FromFunction response =
+        FromFunction.newBuilder()
+            .setIncompleteInvocationContext(
+                IncompleteInvocationContext.newBuilder()
+                    .addMissingValues(
+                        PersistedValueSpec.newBuilder()
+                            .setStateName("new-state")
+                            .setExpirationSpec(
+                                ExpirationSpec.newBuilder()
+                                    .setMode(ExpirationSpec.ExpireMode.AFTER_INVOKE)
+                                    .setExpireAfterMillis(5000)
+                                    .build())))
+            .build();
+
+    functionUnderTest.invoke(context, successfulAsyncOperation(client.wasSentToFunction, response));
+
+    // re-sent batch should have identical invocation input messages
+    assertTrue(client.wasSentToFunction.hasInvocation());
+    assertThat(client.capturedInvocationBatchSize(), is(1));
+    assertThat(client.capturedInvocation(0).getArgument(), is(any));
+
+    // re-sent batch should have new state as well as originally registered state
+    assertThat(client.capturedStateNames().size(), is(2));
+    assertThat(client.capturedStateNames(), hasItems("session", "new-state"));
+  }
+
+  @Test
   public void backlogMetricsIncreasedOnInvoke() {
     functionUnderTest.invoke(context, Any.getDefaultInstance());
 
@@ -246,6 +283,11 @@ public class RequestReplyFunctionTest {
     return new AsyncOperationResult<>(new Object(), Status.SUCCESS, fromFunction, null);
   }
 
+  private static AsyncOperationResult<ToFunction, FromFunction> successfulAsyncOperation(
+      ToFunction toFunction, FromFunction fromFunction) {
+    return new AsyncOperationResult<>(toFunction, Status.SUCCESS, fromFunction, null);
+  }
+
   private static final class FakeClient implements RequestReplyClient {
     ToFunction wasSentToFunction;
     Supplier<FromFunction> fromFunction = FromFunction::getDefaultInstance;
@@ -272,6 +314,12 @@ public class RequestReplyFunctionTest {
 
     ByteString capturedState(int n) {
       return wasSentToFunction.getInvocation().getState(n).getStateValue();
+    }
+
+    Set<String> capturedStateNames() {
+      return wasSentToFunction.getInvocation().getStateList().stream()
+          .map(ToFunction.PersistedValue::getStateName)
+          .collect(Collectors.toSet());
     }
 
     public int capturedInvocationBatchSize() {


### PR DESCRIPTION
This PR extends the current remote invocation request-reply protocol to allow functions to reply with a `IncompleteInvocationContext` response.

The end goal for this protocol extension is to allow state specifications to be declared in the functions (via the language SDKs), instead of being declared statically in the module YAML definition files.

## Extended protocol with the new `IncompleteInvocationContext` response type

Below is an explanation of how the new protocol works:

1. On startup, the StateFun worker processes will not have any knowledge of remote function states, and therefore do not register / attempt to access any Flink state on their behalf.
2. On the first remote invocation, the invocation request would not carry any state values.
3. Upon receiving the invocation request, the functions may decide to respond with a `IncompleteInvocationContext` or the usual `InvocationResponse` as before. If the functions find that the invocation request has missing state values (after matching the provided state names with the declared states in the functions), then it should respond with the new `IncompleteInvocationContext` response type.
4. When the StateFun workers receive an `IncompleteInvocationContext`, it dynamically registers Flink state for the indicated missing states, and then re-sends the original invocation batch now "patched" with all required states.
5. All following invocation requests will be attached with all the required states.
6. The same state specification discovery process from (3) to (5) applies when a function upgrades itself and declares new state, without restarting the StateFun workers.

## Upgrading existing SDKs

After merging this PR to `master`, existing language SDKs may begin to be upgraded to implement the new extended protocol. 

A separate PR will be provided for updating the Python SDK, as a "reference" for upgrading other language SDKs.

## Backwards compatibility for existing SDKs

For the time being (before the next release), old SDKs yet to be updated would still work as is against `master`, since eagerly declaring state specifications via the module YAML definition files (format versions <= `2.0`) will still be temporarily supported in the snapshot `master` branch.

With the next major release (version `2.3.0`), module YAML format versions <= `2.0` will no longer be supported, and therefore old SDKs that are not updated will cease to work with StateFun 2.3.0.

## Brief change log

- 923914b Changes the Protobuf messages definition file to have the new `IncompleteInvocationContext` response type
- f75d7dd to 86aed63 does a few things surrounding `PersistedRemoteFunctionValues`. Most importantly, a new `registerStates` method is added to the class to support registering new `PersistedValue`s dynamically based on `IncompleteInvocationContext` responses from functions. Secondly, mark the original eager state spec (coming from module YAMLs) constructor as deprecated, as this will no longer be supported starting from the next release. Finally, a UT `PersistedRemoteFunctionValuesTest` is added to cover the user contracts of the class.
- 2db4ad1 Actual implementation of the extended protocol in the `RequestReplyFunction` dispatching logic.

## Testing the change

- User contracts of the adapted `PersistedRemoteFunctionValues` class is covered in the new UT `PersistedRemoteFunctionValuesTest`
- A new UT `retryBatchOnIncompleteInvocationContextResponse` has been added to `RequestReplyFunctionTest` to verify that the `RequestReplyFunction` re-sends the original batch with patched states on `IncompleteInvocationContext` responses.