### PR TITLE
[FLINK-20334] Introduce module YAML format version 3.0 and function endpoint templating

### DIFF
--- a/statefun-e2e-tests/statefun-exactly-once-remote-e2e/src/test/resources/remote-module/module.yaml
+++ b/statefun-e2e-tests/statefun-exactly-once-remote-e2e/src/test/resources/remote-module/module.yaml
@@ -13,26 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "1.0"
+version: "3.0"
 
 module:
   meta:
     type: remote
   spec:
-    functions:
-      - function:
+    endpoints:
+      - endpoint:
           meta:
             kind: http
-            type: org.apache.flink.statefun.e2e.remote/counter
           spec:
-            endpoint: http://remote-function:8000/service
-            maxNumBatchRequests: 10000
-      - function:
-          meta:
-            kind: http
-            type: org.apache.flink.statefun.e2e.remote/forward-function
-          spec:
-            endpoint: http://remote-function:8000/service
+            typename:
+              namespace: org.apache.flink.statefun.e2e.remote
+            urlPathTemplate: http://remote-function:8000/service
             maxNumBatchRequests: 10000
     ingresses:
       - ingress:

--- a/statefun-examples/statefun-async-python-example/statefun/module.yaml
+++ b/statefun-examples/statefun-async-python-example/statefun/module.yaml
@@ -12,20 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: "1.0"
+version: "3.0"
 module:
   meta:
     type: remote
   spec:
-    functions:
-      - function:
+    endpoints:
+      - endpoint:
           meta:
             kind: http
-            type: example/greeter
           spec:
-            endpoint: http://python-worker:8000/statefun
+            typename:
+              namespace: example
+              type: greeter
+            urlPathTemplate: http://python-worker:8000/statefun
             maxNumBatchRequests: 500
-            timeout: 2min
+            timeouts:
+              call: 2min
     ingresses:
       - ingress:
           meta:

--- a/statefun-examples/statefun-python-greeter-example/module.yaml
+++ b/statefun-examples/statefun-python-greeter-example/module.yaml
@@ -12,20 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: "1.0"
+version: "3.0"
 module:
   meta:
     type: remote
   spec:
-    functions:
-      - function:
+    endpoints:
+      - endpoint:
           meta:
             kind: http
-            type: example/greeter
           spec:
-            endpoint: http://python-worker:8000/statefun
+            typename:
+              namespace: example
+              type: greeter
+            urlPathTemplate: http://python-worker:8000/statefun
             maxNumBatchRequests: 500
-            timeout: 2min
+            timeouts:
+              call: 2min
     ingresses:
       - ingress:
           meta:

--- a/statefun-examples/statefun-python-k8s-example/module.yaml
+++ b/statefun-examples/statefun-python-k8s-example/module.yaml
@@ -12,20 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: "1.0"
+version: "3.0"
 module:
   meta:
     type: remote
   spec:
-    functions:
-      - function:
+    endpoints:
+      - endpoint:
           meta:
             kind: http
-            type: k8s-demo/greeter
           spec:
+            typename:
+              namespace: k8s-demo
+              type: greeter
             endpoint: http://statefun-python:8000/statefun
             maxNumBatchRequests: 500
-            timeout: 2min
+            timeouts:
+              call: 2min
     ingresses:
       - ingress:
           meta:

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidator.java
@@ -30,7 +30,8 @@ final class StatefulFunctionsUniverseValidator {
     if (statefulFunctionsUniverse.routers().isEmpty()) {
       throw new IllegalStateException("There are no routers defined.");
     }
-    if (statefulFunctionsUniverse.functions().isEmpty()) {
+    if (statefulFunctionsUniverse.functions().isEmpty()
+        && statefulFunctionsUniverse.namespaceFunctions().isEmpty()) {
       throw new IllegalStateException("There are no function providers defined.");
     }
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoader.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoader.java
@@ -29,26 +29,39 @@ import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 /** An {@link FunctionLoader} that has a predefined set of {@link StatefulFunctionProvider}s. */
 final class PredefinedFunctionLoader implements FunctionLoader {
   private final Map<FunctionType, StatefulFunctionProvider> functionProviders;
+  private final Map<String, StatefulFunctionProvider> namespaceFunctionProviders;
 
   @Inject
   PredefinedFunctionLoader(
-      @Label("function-providers") Map<FunctionType, StatefulFunctionProvider> functionProviders) {
+      @Label("function-providers") Map<FunctionType, StatefulFunctionProvider> functionProviders,
+      @Label("namespace-function-providers")
+          Map<String, StatefulFunctionProvider> namespaceFunctionProviders) {
     this.functionProviders = Objects.requireNonNull(functionProviders);
+    this.namespaceFunctionProviders = Objects.requireNonNull(namespaceFunctionProviders);
   }
 
   @Override
   public StatefulFunction load(FunctionType functionType) {
     Objects.requireNonNull(functionType);
-    StatefulFunctionProvider provider = functionProviders.get(functionType);
-    if (provider == null) {
-      throw new IllegalArgumentException("Unknown provider for type " + functionType);
-    }
-    StatefulFunction statefulFunction = load(provider, functionType);
+    final StatefulFunctionProvider provider = getFunctionProviderOrThrow(functionType);
+    final StatefulFunction statefulFunction = load(provider, functionType);
     if (statefulFunction == null) {
       throw new IllegalStateException(
           "A provider for a type " + functionType + " has produced a NULL function");
     }
     return statefulFunction;
+  }
+
+  private StatefulFunctionProvider getFunctionProviderOrThrow(FunctionType functionType) {
+    StatefulFunctionProvider provider = functionProviders.get(functionType);
+    if (provider != null) {
+      return provider;
+    }
+    provider = namespaceFunctionProviders.get(functionType.namespace());
+    if (provider != null) {
+      return provider;
+    }
+    throw new IllegalArgumentException("Cannot find a provider for type " + functionType);
   }
 
   private static StatefulFunction load(

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -73,6 +73,8 @@ final class Reductions {
 
     container.add("function-providers", Map.class, statefulFunctionsUniverse.functions());
     container.add(
+        "namespace-function-providers", Map.class, statefulFunctionsUniverse.namespaceFunctions());
+    container.add(
         "function-repository", FunctionRepository.class, StatefulFunctionRepository.class);
     container.addAlias(
         "function-metrics-repository",

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+import org.apache.flink.types.Either;
+
+public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec {
+
+  private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
+  private static final Duration DEFAULT_HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_HTTP_READ_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_HTTP_WRITE_TIMEOUT = Duration.ofSeconds(10);
+  private static final Integer DEFAULT_MAX_NUM_BATCH_REQUESTS = 1000;
+
+  private final Either<FunctionType, FunctionTypeNamespaceMatcher> target;
+  private final UrlPathTemplate urlPathTemplate;
+
+  private final Duration maxRequestDuration;
+  private final Duration connectTimeout;
+  private final Duration readTimeout;
+  private final Duration writeTimeout;
+  private final int maxNumBatchRequests;
+
+  public static Builder builder(
+      Either<FunctionType, FunctionTypeNamespaceMatcher> target, UrlPathTemplate urlPathTemplate) {
+    return new Builder(target, urlPathTemplate);
+  }
+
+  private HttpFunctionEndpointSpec(
+      Either<FunctionType, FunctionTypeNamespaceMatcher> target,
+      UrlPathTemplate urlPathTemplate,
+      Duration maxRequestDuration,
+      Duration connectTimeout,
+      Duration readTimeout,
+      Duration writeTimeout,
+      int maxNumBatchRequests) {
+    this.target = target;
+    this.urlPathTemplate = urlPathTemplate;
+    this.maxRequestDuration = maxRequestDuration;
+    this.connectTimeout = connectTimeout;
+    this.readTimeout = readTimeout;
+    this.writeTimeout = writeTimeout;
+    this.maxNumBatchRequests = maxNumBatchRequests;
+  }
+
+  @Override
+  public Either<FunctionType, FunctionTypeNamespaceMatcher> target() {
+    return target;
+  }
+
+  @Override
+  public Kind kind() {
+    return Kind.HTTP;
+  }
+
+  @Override
+  public UrlPathTemplate urlPathTemplate() {
+    return urlPathTemplate;
+  }
+
+  public Duration maxRequestDuration() {
+    return maxRequestDuration;
+  }
+
+  public Duration connectTimeout() {
+    return connectTimeout;
+  }
+
+  public Duration readTimeout() {
+    return readTimeout;
+  }
+
+  public Duration writeTimeout() {
+    return writeTimeout;
+  }
+
+  public int maxNumBatchRequests() {
+    return maxNumBatchRequests;
+  }
+
+  public static final class Builder {
+
+    private final Either<FunctionType, FunctionTypeNamespaceMatcher> target;
+    private final UrlPathTemplate urlPathTemplate;
+
+    private Duration maxRequestDuration = DEFAULT_HTTP_TIMEOUT;
+    private Duration connectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT;
+    private Duration readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
+    private Duration writeTimeout = DEFAULT_HTTP_WRITE_TIMEOUT;
+    private int maxNumBatchRequests = DEFAULT_MAX_NUM_BATCH_REQUESTS;
+
+    private Builder(
+        Either<FunctionType, FunctionTypeNamespaceMatcher> target,
+        UrlPathTemplate urlPathTemplate) {
+      this.target = Objects.requireNonNull(target);
+      this.urlPathTemplate = Objects.requireNonNull(urlPathTemplate);
+    }
+
+    public Builder withMaxRequestDuration(Duration duration) {
+      this.maxRequestDuration = requireNonZeroDuration(duration);
+      return this;
+    }
+
+    public Builder withConnectTimeoutDuration(Duration duration) {
+      this.connectTimeout = requireNonZeroDuration(duration);
+      return this;
+    }
+
+    public Builder withReadTimeoutDuration(Duration duration) {
+      this.readTimeout = requireNonZeroDuration(duration);
+      return this;
+    }
+
+    public Builder withWriteTimeoutDuration(Duration duration) {
+      this.writeTimeout = requireNonZeroDuration(duration);
+      return this;
+    }
+
+    public Builder withMaxNumBatchRequests(int maxNumBatchRequests) {
+      this.maxNumBatchRequests = maxNumBatchRequests;
+      return this;
+    }
+
+    public HttpFunctionEndpointSpec build() {
+      validateTimeouts();
+
+      return new HttpFunctionEndpointSpec(
+          target,
+          urlPathTemplate,
+          maxRequestDuration,
+          connectTimeout,
+          readTimeout,
+          writeTimeout,
+          maxNumBatchRequests);
+    }
+
+    private Duration requireNonZeroDuration(Duration duration) {
+      Objects.requireNonNull(duration);
+      if (duration.equals(Duration.ZERO)) {
+        throw new IllegalArgumentException("Timeout durations must be larger than 0.");
+      }
+
+      return duration;
+    }
+
+    private void validateTimeouts() {
+      if (connectTimeout.compareTo(maxRequestDuration) > 0) {
+        throw new IllegalArgumentException(
+            "Connect timeout cannot be larger than request timeout.");
+      }
+
+      if (readTimeout.compareTo(maxRequestDuration) > 0) {
+        throw new IllegalArgumentException("Read timeout cannot be larger than request timeout.");
+      }
+
+      if (writeTimeout.compareTo(maxRequestDuration) > 0) {
+        throw new IllegalArgumentException("Write timeout cannot be larger than request timeout.");
+      }
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -72,7 +72,7 @@ public class HttpFunctionProvider implements StatefulFunctionProvider, ManagingR
     clientBuilder.writeTimeout(spec.writeTimeout());
 
     final HttpUrl url;
-    if (spec.isUnixDomainSocket()) {
+    if (UnixDomainHttpEndpoint.validate(spec.endpoint())) {
       UnixDomainHttpEndpoint endpoint = UnixDomainHttpEndpoint.parseFrom(spec.endpoint());
 
       url =

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionSpec.java
@@ -82,11 +82,6 @@ public final class HttpFunctionSpec implements FunctionSpec, Serializable {
     return endpoint;
   }
 
-  public boolean isUnixDomainSocket() {
-    String scheme = endpoint.getScheme();
-    return "http+unix".equalsIgnoreCase(scheme) || "https+unix".equalsIgnoreCase(scheme);
-  }
-
   public List<StateSpec> states() {
     return states;
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TemplatedHttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TemplatedHttpFunctionProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.apache.flink.statefun.flink.core.httpfn.OkHttpUnixSocketBridge.configureUnixDomainSocket;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.apache.flink.statefun.flink.core.common.ManagingResources;
+import org.apache.flink.statefun.flink.core.reqreply.PersistedRemoteFunctionValues;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyFunction;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+
+@NotThreadSafe
+public final class TemplatedHttpFunctionProvider
+    implements StatefulFunctionProvider, ManagingResources {
+
+  private final Map<FunctionType, HttpFunctionEndpointSpec> specificTypeEndpointSpecs;
+  private final Map<String, HttpFunctionEndpointSpec> perNamespaceEndpointSpecs;
+
+  /** lazily initialized by {code buildHttpClient} */
+  @Nullable private OkHttpClient sharedClient;
+
+  private volatile boolean shutdown;
+
+  public TemplatedHttpFunctionProvider(
+      Map<FunctionType, HttpFunctionEndpointSpec> specificTypeEndpointSpecs,
+      Map<String, HttpFunctionEndpointSpec> perNamespaceEndpointSpecs) {
+    this.specificTypeEndpointSpecs = Objects.requireNonNull(specificTypeEndpointSpecs);
+    this.perNamespaceEndpointSpecs = Objects.requireNonNull(perNamespaceEndpointSpecs);
+  }
+
+  @Override
+  public StatefulFunction functionOfType(FunctionType functionType) {
+    final HttpFunctionEndpointSpec endpointsSpec = getEndpointsSpecOrThrow(functionType);
+    return new RequestReplyFunction(
+        new PersistedRemoteFunctionValues(Collections.emptyList()),
+        endpointsSpec.maxNumBatchRequests(),
+        buildHttpClient(endpointsSpec, functionType));
+  }
+
+  private HttpFunctionEndpointSpec getEndpointsSpecOrThrow(FunctionType functionType) {
+    HttpFunctionEndpointSpec endpointSpec = specificTypeEndpointSpecs.get(functionType);
+    if (endpointSpec != null) {
+      return endpointSpec;
+    }
+    endpointSpec = perNamespaceEndpointSpecs.get(functionType.namespace());
+    if (endpointSpec != null) {
+      return endpointSpec;
+    }
+
+    throw new IllegalStateException("Unknown type: " + functionType);
+  }
+
+  private RequestReplyClient buildHttpClient(
+      HttpFunctionEndpointSpec spec, FunctionType functionType) {
+    if (sharedClient == null) {
+      sharedClient = OkHttpUtils.newClient();
+    }
+    OkHttpClient.Builder clientBuilder = sharedClient.newBuilder();
+    clientBuilder.callTimeout(spec.maxRequestDuration());
+    clientBuilder.connectTimeout(spec.connectTimeout());
+    clientBuilder.readTimeout(spec.readTimeout());
+    clientBuilder.writeTimeout(spec.writeTimeout());
+
+    URI endpointUrl = spec.urlPathTemplate().apply(functionType);
+
+    final HttpUrl url;
+    if (UnixDomainHttpEndpoint.validate(endpointUrl)) {
+      UnixDomainHttpEndpoint endpoint = UnixDomainHttpEndpoint.parseFrom(endpointUrl);
+
+      url =
+          new HttpUrl.Builder()
+              .scheme("http")
+              .host("unused")
+              .addPathSegment(endpoint.pathSegment)
+              .build();
+
+      configureUnixDomainSocket(clientBuilder, endpoint.unixDomainFile);
+    } else {
+      url = HttpUrl.get(endpointUrl);
+    }
+    return new HttpRequestReplyClient(url, clientBuilder.build(), () -> shutdown);
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown = true;
+    OkHttpUtils.closeSilently(sharedClient);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpoint.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpoint.java
@@ -23,12 +23,20 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import org.apache.flink.util.Preconditions;
 
 /** Represents a Unix domain file path and an http endpoint */
 final class UnixDomainHttpEndpoint {
 
+  /** Checks whether or not an endpoint is using UNIX domain sockets. */
+  static boolean validate(URI endpoint) {
+    String scheme = endpoint.getScheme();
+    return "http+unix".equalsIgnoreCase(scheme) || "https+unix".equalsIgnoreCase(scheme);
+  }
+
   /** Parses a URI of the form {@code http+unix://<file system path>.sock/<http endpoint>}. */
   static UnixDomainHttpEndpoint parseFrom(URI endpoint) {
+    Preconditions.checkArgument(validate(endpoint));
     final Path path = Paths.get(endpoint.getPath());
     final int sockPathIndex = indexOfSockFile(path);
     final String filePath = "/" + path.subpath(0, sockPathIndex + 1).toString();

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
@@ -20,7 +20,8 @@ package org.apache.flink.statefun.flink.core.jsonmodule;
 
 enum FormatVersion {
   v1_0("1.0"),
-  v2_0("2.0");
+  v2_0("2.0"),
+  v3_0("3.0");
 
   private String versionStr;
 
@@ -39,6 +40,8 @@ enum FormatVersion {
         return v1_0;
       case "2.0":
         return v2_0;
+      case "3.0":
+        return v3_0;
       default:
         throw new IllegalArgumentException("Unrecognized format version: " + versionStr);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.StreamSupport;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.flink.common.json.Selectors;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
+import org.apache.flink.statefun.flink.core.httpfn.TemplatedHttpFunctionProvider;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.TimeUtils;
+
+public final class FunctionEndpointJsonEntity implements JsonEntity {
+
+  private static final JsonPointer FUNCTION_ENDPOINTS_POINTER = JsonPointer.compile("/endpoints");
+
+  private static final class MetaPointers {
+    private static final JsonPointer KIND = JsonPointer.compile("/endpoint/meta/kind");
+  }
+
+  private static final class SpecPointers {
+    private static final JsonPointer TYPENAME = JsonPointer.compile("/endpoint/spec/typename");
+    private static final JsonPointer URL_PATH_TEMPLATE =
+        JsonPointer.compile("/endpoint/spec/urlPathTemplate");
+    private static final JsonPointer TIMEOUTS = JsonPointer.compile("/endpoint/spec/timeouts");
+    private static final JsonPointer MAX_NUM_BATCH_REQUESTS =
+        JsonPointer.compile("/endpoint/spec/maxNumBatchRequests");
+  }
+
+  private static final class TypenamePointers {
+    private static final JsonPointer NAMESPACE = JsonPointer.compile("/namespace");
+    private static final JsonPointer FUNCTION_NAME = JsonPointer.compile("/type");
+  }
+
+  private static final class TimeoutPointers {
+    private static final JsonPointer CALL = JsonPointer.compile("/call");
+    private static final JsonPointer CONNECT = JsonPointer.compile("/connect");
+    private static final JsonPointer READ = JsonPointer.compile("/read");
+    private static final JsonPointer WRITE = JsonPointer.compile("/write");
+  }
+
+  @Override
+  public void bind(
+      StatefulFunctionModule.Binder binder, JsonNode moduleSpecNode, FormatVersion formatVersion) {
+    if (formatVersion != FormatVersion.v3_0) {
+      throw new IllegalArgumentException("endpoints is only supported with format version 3.0.");
+    }
+
+    final Iterable<? extends JsonNode> functionEndpointsSpecNodes =
+        functionEndpointSpecNodes(moduleSpecNode);
+
+    for (Map.Entry<FunctionEndpointSpec.Kind, List<FunctionEndpointSpec>> entry :
+        parseFunctionEndpointSpecs(functionEndpointsSpecNodes).entrySet()) {
+      final Map<FunctionType, FunctionEndpointSpec> specificTypeEndpointSpecs = new HashMap<>();
+      final Map<String, FunctionEndpointSpec> perNamespaceEndpointSpecs = new HashMap<>();
+
+      entry
+          .getValue()
+          .forEach(
+              spec -> {
+                Either<FunctionType, FunctionTypeNamespaceMatcher> target = spec.target();
+                if (target.isLeft()) {
+                  specificTypeEndpointSpecs.put(target.left(), spec);
+                } else {
+                  perNamespaceEndpointSpecs.put(target.right().targetNamespace(), spec);
+                }
+              });
+
+      StatefulFunctionProvider provider =
+          functionProvider(entry.getKey(), specificTypeEndpointSpecs, perNamespaceEndpointSpecs);
+      specificTypeEndpointSpecs
+          .keySet()
+          .forEach(specificType -> binder.bindFunctionProvider(specificType, provider));
+      perNamespaceEndpointSpecs
+          .keySet()
+          .forEach(
+              namespace ->
+                  binder.bindFunctionProvider(
+                      FunctionTypeNamespaceMatcher.targetNamespace(namespace), provider));
+    }
+  }
+
+  private static Iterable<? extends JsonNode> functionEndpointSpecNodes(
+      JsonNode moduleSpecRootNode) {
+    return Selectors.listAt(moduleSpecRootNode, FUNCTION_ENDPOINTS_POINTER);
+  }
+
+  private static Map<FunctionEndpointSpec.Kind, List<FunctionEndpointSpec>>
+      parseFunctionEndpointSpecs(Iterable<? extends JsonNode> functionEndpointsSpecNodes) {
+    return StreamSupport.stream(functionEndpointsSpecNodes.spliterator(), false)
+        .map(FunctionEndpointJsonEntity::parseFunctionEndpointsSpec)
+        .collect(groupingBy(FunctionEndpointSpec::kind, toList()));
+  }
+
+  private static FunctionEndpointSpec parseFunctionEndpointsSpec(
+      JsonNode functionEndpointSpecNode) {
+    FunctionEndpointSpec.Kind kind = endpointKind(functionEndpointSpecNode);
+
+    switch (kind) {
+      case HTTP:
+        final HttpFunctionEndpointSpec.Builder specBuilder =
+            HttpFunctionEndpointSpec.builder(
+                target(functionEndpointSpecNode), urlPathTemplate(functionEndpointSpecNode));
+
+        JsonNode timeoutsNode = functionEndpointSpecNode.at(SpecPointers.TIMEOUTS);
+        optionalMaxNumBatchRequests(functionEndpointSpecNode)
+            .ifPresent(specBuilder::withMaxNumBatchRequests);
+        optionalTimeoutDuration(timeoutsNode, TimeoutPointers.CALL)
+            .ifPresent(specBuilder::withMaxRequestDuration);
+        optionalTimeoutDuration(timeoutsNode, TimeoutPointers.CONNECT)
+            .ifPresent(specBuilder::withConnectTimeoutDuration);
+        optionalTimeoutDuration(timeoutsNode, TimeoutPointers.READ)
+            .ifPresent(specBuilder::withReadTimeoutDuration);
+        optionalTimeoutDuration(timeoutsNode, TimeoutPointers.WRITE)
+            .ifPresent(specBuilder::withWriteTimeoutDuration);
+
+        return specBuilder.build();
+      case GRPC:
+        throw new UnsupportedOperationException("GRPC endpoints are not supported yet.");
+      default:
+        throw new IllegalArgumentException("Unrecognized function endpoint kind " + kind);
+    }
+  }
+
+  private static FunctionEndpointSpec.Kind endpointKind(JsonNode functionEndpointSpecNode) {
+    String endpointKind = Selectors.textAt(functionEndpointSpecNode, MetaPointers.KIND);
+    return FunctionEndpointSpec.Kind.valueOf(endpointKind.toUpperCase(Locale.getDefault()));
+  }
+
+  private static Either<FunctionType, FunctionTypeNamespaceMatcher> target(
+      JsonNode functionEndpointSpecNode) {
+    JsonNode targetNode = functionEndpointSpecNode.at(SpecPointers.TYPENAME);
+    String namespace = Selectors.textAt(targetNode, TypenamePointers.NAMESPACE);
+    Optional<String> functionName =
+        Selectors.optionalTextAt(targetNode, TypenamePointers.FUNCTION_NAME);
+    return (functionName.isPresent())
+        ? Either.Left(new FunctionType(namespace, functionName.get()))
+        : Either.Right(FunctionTypeNamespaceMatcher.targetNamespace(namespace));
+  }
+
+  private static FunctionEndpointSpec.UrlPathTemplate urlPathTemplate(
+      JsonNode functionEndpointSpecNode) {
+    String template = Selectors.textAt(functionEndpointSpecNode, SpecPointers.URL_PATH_TEMPLATE);
+    return new FunctionEndpointSpec.UrlPathTemplate(template);
+  }
+
+  private static OptionalInt optionalMaxNumBatchRequests(JsonNode functionNode) {
+    return Selectors.optionalIntegerAt(functionNode, SpecPointers.MAX_NUM_BATCH_REQUESTS);
+  }
+
+  private static Optional<Duration> optionalTimeoutDuration(
+      JsonNode node, JsonPointer timeoutPointer) {
+    return Selectors.optionalTextAt(node, timeoutPointer).map(TimeUtils::parseDuration);
+  }
+
+  private static StatefulFunctionProvider functionProvider(
+      FunctionEndpointSpec.Kind kind,
+      Map<FunctionType, FunctionEndpointSpec> specificTypeEndpointSpecs,
+      Map<String, FunctionEndpointSpec> perNamespaceEndpointSpecs) {
+    switch (kind) {
+      case HTTP:
+        return new TemplatedHttpFunctionProvider(
+            castValues(specificTypeEndpointSpecs), castValues(perNamespaceEndpointSpecs));
+      case GRPC:
+        throw new UnsupportedOperationException("GRPC endpoints are not supported yet.");
+      default:
+        throw new IllegalStateException("Unexpected kind: " + kind);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <K, NV extends FunctionEndpointSpec> Map<K, NV> castValues(
+      Map<K, FunctionEndpointSpec> toCast) {
+    return new HashMap(toCast);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointSpec.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import java.net.URI;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+import org.apache.flink.types.Either;
+
+public interface FunctionEndpointSpec {
+
+  Either<FunctionType, FunctionTypeNamespaceMatcher> target();
+
+  Kind kind();
+
+  UrlPathTemplate urlPathTemplate();
+
+  enum Kind {
+    HTTP,
+    GRPC
+  }
+
+  class UrlPathTemplate {
+    private static final String FUNCTION_NAME_HOLDER = "{typename.function}";
+
+    private final String template;
+
+    public UrlPathTemplate(String template) {
+      this.template = Objects.requireNonNull(template);
+    }
+
+    public URI apply(FunctionType functionType) {
+      return URI.create(template.replace(FUNCTION_NAME_HOLDER, functionType.name()));
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -37,6 +37,13 @@ final class JsonModule implements StatefulFunctionModule {
           new RouterJsonEntity(),
           new EgressJsonEntity());
 
+  private static final List<JsonEntity> V3_ENTITIES =
+      Arrays.asList(
+          new FunctionEndpointJsonEntity(),
+          new IngressJsonEntity(),
+          new RouterJsonEntity(),
+          new EgressJsonEntity());
+
   private final JsonNode moduleSpecNode;
   private final FormatVersion formatVersion;
   private final URL moduleUrl;
@@ -49,7 +56,11 @@ final class JsonModule implements StatefulFunctionModule {
 
   public void configure(Map<String, String> conf, Binder binder) {
     try {
-      ENTITIES.forEach(jsonEntity -> jsonEntity.bind(binder, moduleSpecNode, formatVersion));
+      if (formatVersion == FormatVersion.v3_0) {
+        V3_ENTITIES.forEach(jsonEntity -> jsonEntity.bind(binder, moduleSpecNode, formatVersion));
+      } else {
+        ENTITIES.forEach(jsonEntity -> jsonEntity.bind(binder, moduleSpecNode, formatVersion));
+      }
     } catch (Throwable t) {
       throw new ModuleConfigurationException(
           format("Error while parsing module at %s", moduleUrl), t);

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoaderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoaderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.functions;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.statefun.sdk.*;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.junit.Test;
+
+public class PredefinedFunctionLoaderTest {
+
+  private static final FunctionType TEST_TYPE = new FunctionType("namespace", "name");
+
+  @Test
+  public void exampleUsage() {
+    PredefinedFunctionLoader loader =
+        new PredefinedFunctionLoader(specificFunctionProviders(), Collections.emptyMap());
+
+    StatefulFunction function = loader.load(TEST_TYPE);
+
+    assertThat(function, notNullValue());
+  }
+
+  @Test
+  public void withOnlyPerNamespaceFunctionProviders() {
+    PredefinedFunctionLoader loader =
+        new PredefinedFunctionLoader(Collections.emptyMap(), perNamespaceFunctionProviders());
+
+    StatefulFunction function = loader.load(TEST_TYPE);
+
+    assertThat(function, notNullValue());
+  }
+
+  @Test
+  public void specificFunctionProvidersHigherPrecedence() {
+    PredefinedFunctionLoader loader =
+        new PredefinedFunctionLoader(specificFunctionProviders(), perNamespaceFunctionProviders());
+
+    StatefulFunction function = loader.load(TEST_TYPE);
+
+    assertThat(function, instanceOf(StatefulFunctionA.class));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullLoadedFunctions() {
+    PredefinedFunctionLoader loader =
+        new PredefinedFunctionLoader(specificFunctionProviders(), Collections.emptyMap());
+
+    loader.load(new FunctionType("doesn't", "exist"));
+  }
+
+  private static Map<FunctionType, StatefulFunctionProvider> specificFunctionProviders() {
+    final Map<FunctionType, StatefulFunctionProvider> providers = new HashMap<>();
+    providers.put(
+        new FunctionType(TEST_TYPE.namespace(), TEST_TYPE.name()), new SpecificFunctionProvider());
+    return providers;
+  }
+
+  private static Map<String, StatefulFunctionProvider> perNamespaceFunctionProviders() {
+    final Map<String, StatefulFunctionProvider> providers = new HashMap<>();
+    providers.put(TEST_TYPE.namespace(), new PerNamespaceFunctionProvider());
+    return providers;
+  }
+
+  private static class SpecificFunctionProvider implements StatefulFunctionProvider {
+    @Override
+    public org.apache.flink.statefun.sdk.StatefulFunction functionOfType(FunctionType type) {
+      if (type.equals(TEST_TYPE)) {
+        return new StatefulFunctionA();
+      } else {
+        return null;
+      }
+    }
+  }
+
+  private static class PerNamespaceFunctionProvider implements StatefulFunctionProvider {
+    @Override
+    public org.apache.flink.statefun.sdk.StatefulFunction functionOfType(FunctionType type) {
+      if (type.equals(TEST_TYPE)) {
+        return new StatefulFunctionB();
+      } else {
+        return null;
+      }
+    }
+  }
+
+  private static class StatefulFunctionA implements StatefulFunction {
+    @Override
+    public void invoke(Context context, Object input) {}
+  }
+
+  private static class StatefulFunctionB implements StatefulFunction {
+    @Override
+    public void invoke(Context context, Object input) {}
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpointTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpointTest.java
@@ -1,6 +1,7 @@
 package org.apache.flink.statefun.flink.core.httpfn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.net.URI;
 import org.junit.Test;
@@ -28,5 +29,15 @@ public class UnixDomainHttpEndpointTest {
   @Test(expected = IllegalStateException.class)
   public void missingSockFile() {
     UnixDomainHttpEndpoint.parseFrom(URI.create("http+unix:///some/path/hello"));
+  }
+
+  @Test
+  public void validateUdsEndpoint() {
+    assertFalse(UnixDomainHttpEndpoint.validate(URI.create("http:///bar.foo.com/some/path")));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseNonUdsEndpoint() {
+    UnixDomainHttpEndpoint.parseFrom(URI.create("http:///bar.foo.com/some/path"));
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleV3Test.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleV3Test.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+import java.net.URL;
+import java.util.Collections;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+import org.junit.Test;
+
+public class JsonModuleV3Test {
+
+  private static final String modulePath = "module-v3_0/module.yaml";
+
+  @Test
+  public void exampleUsage() {
+    StatefulFunctionModule module = fromPath(modulePath);
+
+    assertThat(module, notNullValue());
+  }
+
+  @Test
+  public void testFunctions() {
+    StatefulFunctionModule module = fromPath(modulePath);
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.functions(),
+        allOf(
+            hasKey(new FunctionType("com.foo.bar", "specific_function")),
+            hasKey(new FunctionType("com.other.namespace", "hello"))));
+
+    assertThat(universe.namespaceFunctions(), hasKey("com.foo.bar"));
+  }
+
+  @Test
+  public void testRouters() {
+    StatefulFunctionModule module = fromPath(modulePath);
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.routers(),
+        hasKey(new IngressIdentifier<>(Message.class, "com.mycomp.igal", "names")));
+  }
+
+  @Test
+  public void testIngresses() {
+    StatefulFunctionModule module = fromPath(modulePath);
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.ingress(),
+        hasKey(new IngressIdentifier<>(Message.class, "com.mycomp.igal", "names")));
+  }
+
+  @Test
+  public void testEgresses() {
+    StatefulFunctionModule module = fromPath(modulePath);
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.egress(), hasKey(new EgressIdentifier<>("com.mycomp.foo", "bar", Any.class)));
+  }
+
+  private static StatefulFunctionModule fromPath(String path) {
+    URL moduleUrl = JsonModuleTest.class.getClassLoader().getResource(path);
+    assertThat(moduleUrl, not(nullValue()));
+    ObjectMapper mapper = JsonServiceLoader.mapper();
+    return JsonServiceLoader.fromUrl(mapper, moduleUrl);
+  }
+
+  private static StatefulFunctionsUniverse emptyUniverse() {
+    return new StatefulFunctionsUniverse(
+        MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v3_0/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v3_0/module.yaml
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.0"
+
+module:
+  meta:
+    type: remote
+  spec:
+    endpoints:
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            typename:
+              namespace: com.foo.bar
+            urlPathTemplate: http://bar.foo.com:8080/functions/{typename.function}
+            timeouts:
+              call: 1minutes
+              connect: 10seconds
+              read: 10second
+              write: 10seconds
+            maxNumBatchRequests: 10000
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            typename:
+              namespace: com.foo.bar
+              type: specific_function
+            urlPathTemplate: http://bar.foo.com:8080/functions/abc
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            typename:
+              namespace: com.other.namespace
+              type: hello
+            urlPathTemplate: http://namespace.other.com:8080/hello
+    routers:
+      - router:
+          meta:
+            type: org.apache.flink.statefun.sdk/protobuf-router
+          spec:
+            ingress: com.mycomp.igal/names
+            target: "com.example/hello/{{$.name}}"
+            messageType: org.apache.flink.test.SimpleMessage
+            descriptorSet: classpath:test.desc
+    ingresses:
+      - ingress:
+          meta:
+            type: statefun.kafka.io/protobuf-ingress
+            id: com.mycomp.igal/names
+          spec:
+            address: kafka-broker:9092
+            topics:
+              - names
+            properties:
+              - consumer.group: greeter
+            messageType: org.apache.flink.test.SimpleMessage
+            descriptorSet: classpath:test.desc
+    egresses:
+      - egress:
+          meta:
+            type: statefun.kafka.io/generic-egress
+            id: com.mycomp.foo/bar
+          spec:
+            address: kafka-broker:9092
+            deliverySemantic:
+              type: exactly-once
+              transactionTimeoutMillis: 100000
+            properties:
+              - foo.config: bar

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/FunctionTypeNamespaceMatcher.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/FunctionTypeNamespaceMatcher.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk;
+
+import java.util.Objects;
+
+public final class FunctionTypeNamespaceMatcher {
+
+  private final String targetNamespace;
+
+  public static FunctionTypeNamespaceMatcher targetNamespace(String namespace) {
+    return new FunctionTypeNamespaceMatcher(namespace);
+  }
+
+  private FunctionTypeNamespaceMatcher(String targetNamespace) {
+    this.targetNamespace = Objects.requireNonNull(targetNamespace);
+  }
+
+  public String targetNamespace() {
+    return targetNamespace;
+  }
+
+  public boolean matches(FunctionType functionType) {
+    return targetNamespace.equals(functionType.namespace());
+  }
+
+  @Override
+  public int hashCode() {
+    return targetNamespace.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    FunctionTypeNamespaceMatcher other = (FunctionTypeNamespaceMatcher) obj;
+    return targetNamespace.equals(other.targetNamespace);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("FunctionTypeNamespaceMatcher(%s)", targetNamespace);
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/spi/StatefulFunctionModule.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/spi/StatefulFunctionModule.java
@@ -19,6 +19,7 @@ package org.apache.flink.statefun.sdk.spi;
 
 import java.util.Map;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
 import org.apache.flink.statefun.sdk.StatefulFunction;
 import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 import org.apache.flink.statefun.sdk.io.EgressSpec;
@@ -94,12 +95,26 @@ public interface StatefulFunctionModule {
     <T> void bindEgress(EgressSpec<T> spec);
 
     /**
-     * Binds a {@link StatefulFunctionProvider} to the Stateful Functions application.
+     * Binds a {@link StatefulFunctionProvider} to the Stateful Functions application for a specific
+     * {@link FunctionType}.
      *
      * @param functionType the type of functions that the {@link StatefulFunctionProvider} provides.
      * @param provider the provider to bind.
      */
     void bindFunctionProvider(FunctionType functionType, StatefulFunctionProvider provider);
+
+    /**
+     * Binds a {@link StatefulFunctionProvider} to the Stateful Functions application for all
+     * functions under the specified namespace. If a provider was bound for a specific function type
+     * using {@link #bindFunctionProvider(FunctionType, StatefulFunctionProvider)}, that provider
+     * would be used instead.
+     *
+     * @param namespaceMatcher matcher for the target namespace of functions that the {@link
+     *     StatefulFunctionProvider} provides.
+     * @param provider the provider to bind.
+     */
+    void bindFunctionProvider(
+        FunctionTypeNamespaceMatcher namespaceMatcher, StatefulFunctionProvider provider);
 
     /**
      * Binds a {@link Router} for a given ingress to the Stateful Functions application.


### PR DESCRIPTION
This PR adds a module YAML format version, 3.0, which supports function endpoint templating.

With 3.0, users define function endpoints like so:
```
endpoints:
   
  ## An endpoint url template for all function types under namespace "com.foo.bar"
  - endpoint:
      meta:
          kind: http
      spec:
          typename:
              namespace: com.foo.bar
          urlPathTemplate: http://bar.foo.com/{typename.function}
          maxNumBatchRequests: 1000
          timeouts:
              call: 5mins
              read: 10seconds

  ## An endpoint url specifically for the function type "(com.foo.bar, hello-world)"
  - endpoint:
      meta:
         kind: http
      spec:
         typename:
           namespace: com.foo.bar
           function: hello-world
         urlPathTemplate: http://bar.foo.com/some/specific/path
```

Endpoint URL templates that have been defined for specific types (fully specifying both namespace and function name) will have precedence other ones that have been widely defined for a namespace.

## Implementation notes

The main changes required to enable function templating (besides implementing the JSON parser for the new format) was the following:

- fd361ca In the Java SDK, allow binding `StatefulFunctionProvider` per namespace. Providers bound for specific function types have higher precedence.

- 42cdb52 Logic of resolving the `StatefulFunctionProvider` to use has been updated in the `PredefinedFunctionLoader`.

- 326b56a to 6c2ae2f covers the main work around introducing the new YAML format. Function endpoint specifications are represented by `FunctionEndpointSpec`, with an HTTP implementation `HttpFunctionEndpointSpec`. A new type of function provider `TemplatedHttpFunctionProvider` is used for instantiating `RequestReplyFunction`s based on the parsed `HttpFunctionEndpointSpec`.

- 45f9efb to 1d83341 updates all examples and E2E tests to use module YAML format version 3.0.

## Testing this change

The E2E `ExactlyOnceWithRemoteFnE2E` has been updated to use function endpoint templating, so a CI pass would verify the feature end-to-end.