### PR TITLE
[FLINK-20636] Validate that unaligned checkpoints is not enabled

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigValidator.java
@@ -46,6 +46,7 @@ public final class StatefulFunctionsConfigValidator {
     validateParentFirstClassloaderPatterns(configuration);
     validateCustomPayloadSerializerClassName(configuration);
     validateNoHeapBackedTimers(configuration);
+    validateUnalignedCheckpointsDisabled(configuration);
   }
 
   private static void validateParentFirstClassloaderPatterns(Configuration configuration) {
@@ -95,12 +96,24 @@ public final class StatefulFunctionsConfigValidator {
           .stringType()
           .defaultValue("rocksdb");
 
+  private static final ConfigOption<Boolean> ENABLE_UNALIGNED_CHECKPOINTS =
+      ConfigOptions.key("execution.checkpointing.unaligned").booleanType().defaultValue(false);
+
   private static void validateNoHeapBackedTimers(Configuration configuration) {
     final String timerFactory = configuration.getString(TIMER_SERVICE_FACTORY);
     if (!timerFactory.equalsIgnoreCase("rocksdb")) {
       throw new StatefulFunctionsInvalidConfigException(
           TIMER_SERVICE_FACTORY,
           "StateFun only supports non-heap timers with a rocksdb state backend.");
+    }
+  }
+
+  private static void validateUnalignedCheckpointsDisabled(Configuration configuration) {
+    final boolean unalignedCheckpoints = configuration.getBoolean(ENABLE_UNALIGNED_CHECKPOINTS);
+    if (unalignedCheckpoints) {
+      throw new StatefulFunctionsInvalidConfigException(
+          ENABLE_UNALIGNED_CHECKPOINTS,
+          "StateFun currently does not support unaligned checkpointing.");
     }
   }
 }


### PR DESCRIPTION
Due to how StateFun has feedback loops, with unaligned checkpoints a function dispatcher operator may receive a feedback checkpoint barrier (from other parallel subtasks that process the checkpoint barrier first) before it receives its own checkpoint barrier. This currently isn't handled.

We need to further investigate how to properly support unaligned checkpointing in StateFun.
For the time being, we should strictly require aligned checkpointing for StateFun apps.