### PR TITLE
[FLINK-20689] Upgrade to Flink 1.11.3

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,7 @@ version: "2.3-SNAPSHOT"
 # release this should be the same as the regular version
 version_title: "2.3-SNAPSHOT"
 # The Flink version supported by this version of Stateful Functions
-flink_version: "1.11.1"
+flink_version: "1.11.3"
 # Branch on Github for this version
 github_branch: "master"
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ under the License.
         <protobuf.version>3.7.1</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.11.1</flink.version>
+        <flink.version>1.11.3</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <root.dir>${rootDir}</root.dir>
     </properties>

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -151,6 +151,11 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
   }
 
   @Override
+  protected boolean isUsingCustomRawKeyedState() {
+    return true;
+  }
+
+  @Override
   public void close() throws Exception {
     try {
       closeOrDispose();

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:1.11.1-scala_2.12-java8
+FROM flink:1.11.3-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
This PR upgrades Flink version to 1.11.3.

Moreover, the `isUsingCustomRawKeyedState` flag is being set on the `FunctionGroupOperator`. Setting this flag will now (finally) enable us to safely restore from savepoints from versions earlier than 2.2.1, and containing feedback elements.