### PR TITLE
[FLINK-20699] Set FeedbackKey invocation_id explicitly

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackKey.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackKey.java
@@ -34,7 +34,7 @@ public final class FeedbackKey<V> implements Serializable {
   }
 
   public SubtaskFeedbackKey<V> withSubTaskIndex(int subTaskIndex, int attemptId) {
-    return new SubtaskFeedbackKey<>(pipelineName, invocationId, attemptId, subTaskIndex);
+    return new SubtaskFeedbackKey<>(pipelineName, invocationId, subTaskIndex, attemptId);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/FlinkUniverse.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/FlinkUniverse.java
@@ -28,14 +28,17 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public final class FlinkUniverse {
-  private static final FeedbackKey<Message> FEEDBACK_KEY =
-      new FeedbackKey<>("statefun-pipeline", 1);
 
   private final StatefulFunctionsUniverse universe;
 
   private final StatefulFunctionsConfig configuration;
+  private final FeedbackKey<Message> feedbackKey;
 
-  public FlinkUniverse(StatefulFunctionsUniverse universe, StatefulFunctionsConfig configuration) {
+  public FlinkUniverse(
+      FeedbackKey<Message> feedbackKey,
+      StatefulFunctionsConfig configuration,
+      StatefulFunctionsUniverse universe) {
+    this.feedbackKey = Objects.requireNonNull(feedbackKey);
     this.universe = Objects.requireNonNull(universe);
     this.configuration = Objects.requireNonNull(configuration);
   }
@@ -45,7 +48,7 @@ public final class FlinkUniverse {
     Sinks sinks = Sinks.create(universe);
 
     StatefulFunctionTranslator translator =
-        new StatefulFunctionTranslator(FEEDBACK_KEY, configuration);
+        new StatefulFunctionTranslator(feedbackKey, configuration);
 
     Map<EgressIdentifier<?>, DataStream<?>> sideOutputs = translator.translate(sources, sinks);
 


### PR DESCRIPTION
###  This PR sets the invocation id part of a `FeedbackKey` explicitly, both in the data stream integration API and the embedded API.

Currently the operators that obtain a `FeedbackChannel` via a `FeedbackKey` are also closing it, on their `dispose` and `close` methods. Setting an invocation_id explicitly every time a `FeedbackKey` is created, reduces the risk of accidentally sharing the same `FeedbackChannel` across invocations.

### Verifying the change
* run e2e test
* run  `org.apache.flink.statefun.e2e.smoke.Harness` in a loop.