### PR TITLE
[FLINK-20742] Skip deployment of Maven artifacts for examples

### DIFF
--- a/statefun-examples/pom.xml
+++ b/statefun-examples/pom.xml
@@ -40,5 +40,16 @@ under the License.
         <module>statefun-flink-datastream-example</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 

--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
@@ -119,87 +119,17 @@ under the License.
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>repackage</goal>
                         </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/spring.handlers</resource>
-                                </transformer>
-                                <transformer implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
-                                    <resource>META-INF/spring.factories</resource>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/spring.schemas</resource>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.apache.flink.statefun.examples.ridesharing.simulator.Main</mainClass>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                                    <projectName>Apache Flink Stateful Functions (flink-statefun)</projectName>
-                                    <encoding>UTF-8</encoding>
-                                </transformer>
-                                <!-- remove all duplicate licenses -->
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
-                                </transformer>
-                                <!-- explicitly include our LICENSE file, located at project root dir -->
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/LICENSE</resource>
-                                    <file>${basedir}/../../../LICENSE</file>
-                                </transformer>
-                            </transformers>
-                        </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <version>2.1.6.RELEASE</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>org.apache.kafka:*</artifact>
-                            <excludes>
-                                <exclude>kafka/kafka-version.properties</exclude>
-                                <exclude>LICENSE</exclude>
-                                <!-- Does not contain anything relevant.
-                                    Cites a binary dependency on jersey, but this is neither reflected in the
-                                    dependency graph, nor are any jersey files bundled. -->
-                                <exclude>NOTICE</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>javax.validation:validation-api:*</artifact>
-                            <excludes>
-                                <!-- Their header simply points to a ASLv2 license; excluded to have duplicate license files packaged -->
-                                <exclude>license.header</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
This PR makes us no longer deploy / release Maven artifacts for the examples, starting from the next release.
We never expect users to try out the examples via Maven artifacts.

## Brief change log

- 498bebc Configure the `maven-deploy-plugin` to skip deployment for `statefun-examples`
- 35de6fb Is a nice cleanup we can now do to the packaging setup of the `statefun-ridesharing-example-simulator`. Before, since we were publishing Maven artifacts, we had to use the Maven shade plugin for packaging because `spring-boot-maven-plugin` doesn't support adding custom transformers which was required for merging NOTICE and license files for ASF legal
purposes. Since we now no longer release these artifacts, we can revert back to use the simple `spring-boot-maven-plugin` for the packaging the simulator.