### PR TITLE
[FLINK-20987] Upgrade to Flink 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ under the License.
         <protobuf.version>3.7.1</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.11.3</flink.version>
+        <flink.version>1.12.0</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <root.dir>${rootDir}</root.dir>
     </properties>

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -45,7 +45,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
-            <version>2.10.1-11.0</version>
+            <version>2.10.1-12.0</version>
         </dependency>
 
         <!-- tests -->

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
@@ -91,7 +91,8 @@ public class StatefulFunctionsJob {
           FlinkUserCodeClassLoaders.parentFirst(
               new URL[0],
               StatefulFunctionsJob.class.getClassLoader(),
-              FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER);
+              FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER,
+              false);
       Thread.currentThread().setContextClassLoader(flinkClassLoader);
     }
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FlinkTimerServiceFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FlinkTimerServiceFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
-import org.apache.flink.streaming.api.operators.TimerSerializer;
 import org.apache.flink.streaming.api.operators.Triggerable;
 
 final class FlinkTimerServiceFactory implements TimerServiceFactory {
@@ -41,10 +40,11 @@ final class FlinkTimerServiceFactory implements TimerServiceFactory {
   @Override
   public InternalTimerService<VoidNamespace> createTimerService(
       Triggerable<String, VoidNamespace> triggerable) {
-    final TimerSerializer<String, VoidNamespace> timerSerializer =
-        new TimerSerializer<>(StringSerializer.INSTANCE, VoidNamespaceSerializer.INSTANCE);
 
     return timeServiceManager.getInternalTimerService(
-        DELAYED_MSG_TIMER_SERVICE_NAME, timerSerializer, triggerable);
+        DELAYED_MSG_TIMER_SERVICE_NAME,
+        StringSerializer.INSTANCE,
+        VoidNamespaceSerializer.INSTANCE,
+        triggerable);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -236,11 +237,6 @@ public class ReductionsTest {
     }
 
     @Override
-    public Map<String, Accumulator<?, ?>> getAllAccumulators() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public IntCounter getIntCounter(String name) {
       throw new UnsupportedOperationException();
     }
@@ -299,6 +295,11 @@ public class ReductionsTest {
     @Override
     public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(
         AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerUserCodeClassLoaderReleaseHookIfAbsent(String s, Runnable runnable) {
       throw new UnsupportedOperationException();
     }
   }
@@ -367,6 +368,11 @@ public class ReductionsTest {
 
     @Override
     public TypeSerializer<Object> getKeySerializer() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <N> Stream<Tuple2<Object, N>> getKeysAndNamespaces(String state) {
       throw new UnsupportedOperationException();
     }
   }

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.kohlschutter.junixsocket:junixsocket-core:2.3.2
 - com.kohlschutter.junixsocket:junixsocket-common:2.3.2
 - com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - com.google.auto.service:auto-service-annotations:1.0-rc6
 - com.google.guava:guava:18.0
 - org.apache.commons:commons-lang3:3.3.2

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:1.11.3-scala_2.12-java8
+FROM apache/flink:1.12.0-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
This PR upgrades the Flink dependency to Flink 1.12.

Only a few minor changes to some used internal APIs were required.
The legal NOTICE files have also been updated accordingly.

The change is covered by the E2E tests.