### PR TITLE
[FLINK-21061] [reqrep] Support state type for remote function state values in request-reply protocol

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -28,19 +28,23 @@ import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.Pers
 import org.apache.flink.statefun.flink.core.polyglot.generated.FromFunction.PersistedValueSpec;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction;
 import org.apache.flink.statefun.flink.core.polyglot.generated.ToFunction.InvocationBatchRequest;
+import org.apache.flink.statefun.flink.core.types.remote.RemoteValueTypeMismatchException;
+import org.apache.flink.statefun.sdk.TypeName;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.state.Expiration;
 import org.apache.flink.statefun.sdk.state.PersistedStateRegistry;
-import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 
 public final class PersistedRemoteFunctionValues {
 
+  private static final TypeName UNSET_STATE_TYPE = TypeName.parseFrom("io.statefun.types/unset");
+
   @Persisted private final PersistedStateRegistry stateRegistry = new PersistedStateRegistry();
 
-  private final Map<String, PersistedValue<byte[]>> managedStates = new HashMap<>();
+  private final Map<String, RemotePersistedValue> managedStates = new HashMap<>();
 
   void attachStateValues(InvocationBatchRequest.Builder batchBuilder) {
-    for (Map.Entry<String, PersistedValue<byte[]>> managedStateEntry : managedStates.entrySet()) {
+    for (Map.Entry<String, RemotePersistedValue> managedStateEntry : managedStates.entrySet()) {
       final ToFunction.PersistedValue.Builder valueBuilder =
           ToFunction.PersistedValue.newBuilder().setStateName(managedStateEntry.getKey());
 
@@ -92,17 +96,61 @@ public final class PersistedRemoteFunctionValues {
   }
 
   private void createAndRegisterValueStateIfAbsent(PersistedValueSpec protocolPersistedValueSpec) {
+    final RemotePersistedValue stateHandle =
+        managedStates.get(protocolPersistedValueSpec.getStateName());
+
+    if (stateHandle == null) {
+      registerValueState(protocolPersistedValueSpec);
+    } else {
+      validateType(stateHandle, protocolPersistedValueSpec);
+    }
+  }
+
+  private void registerValueState(PersistedValueSpec protocolPersistedValueSpec) {
     final String stateName = protocolPersistedValueSpec.getStateName();
 
-    if (!managedStates.containsKey(stateName)) {
-      final PersistedValue<byte[]> stateValue =
-          PersistedValue.of(
-              stateName,
-              byte[].class,
-              sdkTtlExpiration(protocolPersistedValueSpec.getExpirationSpec()));
-      stateRegistry.registerValue(stateValue);
-      managedStates.put(stateName, stateValue);
+    final RemotePersistedValue remoteValueState =
+        RemotePersistedValue.of(
+            stateName,
+            sdkStateType(protocolPersistedValueSpec),
+            sdkTtlExpiration(protocolPersistedValueSpec.getExpirationSpec()));
+
+    managedStates.put(stateName, remoteValueState);
+
+    try {
+      stateRegistry.registerRemoteValue(remoteValueState);
+    } catch (RemoteValueTypeMismatchException e) {
+      throwStateTypeMismatchException(stateName, e);
     }
+  }
+
+  private void validateType(
+      RemotePersistedValue previousStateHandle, PersistedValueSpec protocolPersistedValueSpec) {
+    final TypeName newStateType = sdkStateType(protocolPersistedValueSpec);
+    if (!newStateType.equals(previousStateHandle.type())) {
+      throwStateTypeMismatchException(
+          protocolPersistedValueSpec.getStateName(),
+          new RemoteValueTypeMismatchException(previousStateHandle.type(), newStateType));
+    }
+  }
+
+  private static TypeName sdkStateType(PersistedValueSpec protocolPersistedValueSpec) {
+    final String typeStringPair = protocolPersistedValueSpec.getTypeTypename();
+
+    // TODO type field may be empty in current master only because SDKs are not yet updated;
+    // TODO once SDKs are updated, we should expect that the type is always specified
+    return protocolPersistedValueSpec.getTypeTypename().isEmpty()
+        ? UNSET_STATE_TYPE
+        : TypeName.parseFrom(typeStringPair);
+  }
+
+  private static void throwStateTypeMismatchException(
+      String stateName, RemoteValueTypeMismatchException cause) {
+    throw new IllegalStateException(
+        String.format(
+            "Found a state type mismatch for state [%s]. The typename for registered state types cannot change across StateFun restarts or function upgrades.",
+            stateName),
+        cause);
   }
 
   private static Expiration sdkTtlExpiration(ExpirationSpec protocolExpirationSpec) {
@@ -119,8 +167,8 @@ public final class PersistedRemoteFunctionValues {
     }
   }
 
-  private PersistedValue<byte[]> getStateHandleOrThrow(String stateName) {
-    final PersistedValue<byte[]> handle = managedStates.get(stateName);
+  private RemotePersistedValue getStateHandleOrThrow(String stateName) {
+    final RemotePersistedValue handle = managedStates.get(stateName);
     if (handle == null) {
       throw new IllegalStateException(
           "Accessing a non-existing function state: "

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
@@ -44,20 +44,30 @@ public final class FlinkStateBinder extends StateBinder {
   }
 
   @Override
-  public void bindValue(PersistedValue<?> persistedValue) {
+  public void bind(Object stateObject) {
+    if (stateObject instanceof PersistedValue) {
+      bindValue((PersistedValue<?>) stateObject);
+    } else if (stateObject instanceof PersistedTable) {
+      bindTable((PersistedTable<?, ?>) stateObject);
+    } else if (stateObject instanceof PersistedAppendingBuffer) {
+      bindAppendingBuffer((PersistedAppendingBuffer<?>) stateObject);
+    } else {
+      throw new IllegalArgumentException("Unknown persisted state object " + stateObject);
+    }
+  }
+
+  private void bindValue(PersistedValue<?> persistedValue) {
     Accessor<?> accessor = state.createFlinkStateAccessor(functionType, persistedValue);
     setAccessorRaw(persistedValue, accessor);
   }
 
-  @Override
-  public void bindTable(PersistedTable<?, ?> persistedTable) {
+  private void bindTable(PersistedTable<?, ?> persistedTable) {
     TableAccessor<?, ?> accessor =
         state.createFlinkStateTableAccessor(functionType, persistedTable);
     setAccessorRaw(persistedTable, accessor);
   }
 
-  @Override
-  public void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer) {
+  private void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer) {
     AppendingBufferAccessor<?> accessor =
         state.createFlinkStateAppendingBufferAccessor(functionType, persistedAppendingBuffer);
     setAccessorRaw(persistedAppendingBuffer, accessor);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/FlinkStateBinder.java
@@ -26,6 +26,7 @@ import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
 import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.StateBinder;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 
@@ -51,6 +52,8 @@ public final class FlinkStateBinder extends StateBinder {
       bindTable((PersistedTable<?, ?>) stateObject);
     } else if (stateObject instanceof PersistedAppendingBuffer) {
       bindAppendingBuffer((PersistedAppendingBuffer<?>) stateObject);
+    } else if (stateObject instanceof RemotePersistedValue) {
+      bindRemoteValue((RemotePersistedValue) stateObject);
     } else {
       throw new IllegalArgumentException("Unknown persisted state object " + stateObject);
     }
@@ -73,6 +76,12 @@ public final class FlinkStateBinder extends StateBinder {
     setAccessorRaw(persistedAppendingBuffer, accessor);
   }
 
+  private void bindRemoteValue(RemotePersistedValue remotePersistedValue) {
+    Accessor<byte[]> accessor =
+        state.createFlinkRemoteStateAccessor(functionType, remotePersistedValue);
+    setAccessorRaw(remotePersistedValue, accessor);
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   private void setAccessorRaw(PersistedTable<?, ?> persistedTable, TableAccessor<?, ?> accessor) {
     ApiExtension.setPersistedTableAccessor((PersistedTable) persistedTable, accessor);
@@ -88,5 +97,10 @@ public final class FlinkStateBinder extends StateBinder {
       PersistedAppendingBuffer<?> persistedAppendingBuffer, AppendingBufferAccessor<?> accessor) {
     ApiExtension.setPersistedAppendingBufferAccessor(
         (PersistedAppendingBuffer) persistedAppendingBuffer, accessor);
+  }
+
+  private static void setAccessorRaw(
+      RemotePersistedValue remotePersistedValue, Accessor<byte[]> accessor) {
+    ApiExtension.setRemotePersistedValueAccessor(remotePersistedValue, accessor);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/PersistedStates.java
@@ -32,6 +32,7 @@ import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedStateRegistry;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 
 public final class PersistedStates {
 
@@ -95,7 +96,8 @@ public final class PersistedStates {
     return fieldType == PersistedValue.class
         || fieldType == PersistedTable.class
         || fieldType == PersistedAppendingBuffer.class
-        || fieldType == PersistedStateRegistry.class;
+        || fieldType == PersistedStateRegistry.class
+        || fieldType == RemotePersistedValue.class;
   }
 
   private static Object getPersistedStateReflectively(Object instance, Field persistedField) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/state/State.java
@@ -24,6 +24,7 @@ import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
 import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 
 public interface State {
@@ -36,6 +37,9 @@ public interface State {
 
   <E> AppendingBufferAccessor<E> createFlinkStateAppendingBufferAccessor(
       FunctionType functionType, PersistedAppendingBuffer<E> persistedAppendingBuffer);
+
+  Accessor<byte[]> createFlinkRemoteStateAccessor(
+      FunctionType functionType, RemotePersistedValue remotePersistedValue);
 
   void setCurrentKey(Address address);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializer.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializer.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.statefun.sdk.TypeName;
+
+final class RemoteValueSerializer extends TypeSerializer<byte[]> {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final byte[] EMPTY = new byte[0];
+
+  private final TypeName type;
+
+  public RemoteValueSerializer(TypeName type) {
+    this.type = Objects.requireNonNull(type);
+  }
+
+  public TypeName getType() {
+    return type;
+  }
+
+  @Override
+  public boolean isImmutableType() {
+    return false;
+  }
+
+  @Override
+  public byte[] createInstance() {
+    return EMPTY;
+  }
+
+  @Override
+  public byte[] copy(byte[] from) {
+    byte[] copy = new byte[from.length];
+    System.arraycopy(from, 0, copy, 0, from.length);
+    return copy;
+  }
+
+  @Override
+  public byte[] copy(byte[] from, byte[] reuse) {
+    return copy(from);
+  }
+
+  @Override
+  public int getLength() {
+    return -1;
+  }
+
+  @Override
+  public void serialize(byte[] record, DataOutputView target) throws IOException {
+    if (record == null) {
+      throw new IllegalArgumentException("The record must not be null.");
+    }
+
+    final int len = record.length;
+    target.writeInt(len);
+    target.write(record);
+  }
+
+  @Override
+  public byte[] deserialize(DataInputView source) throws IOException {
+    final int len = source.readInt();
+    byte[] result = new byte[len];
+    source.readFully(result);
+    return result;
+  }
+
+  @Override
+  public byte[] deserialize(byte[] reuse, DataInputView source) throws IOException {
+    return deserialize(source);
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    final int len = source.readInt();
+    target.writeInt(len);
+    target.write(source, len);
+  }
+
+  @Override
+  public TypeSerializer<byte[]> duplicate() {
+    return new RemoteValueSerializer(type);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || RemoteValueSerializer.class != o.getClass()) return false;
+    RemoteValueSerializer that = (RemoteValueSerializer) o;
+    return Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type);
+  }
+
+  @Override
+  public TypeSerializerSnapshot<byte[]> snapshotConfiguration() {
+    return new RemoteValueSerializerSnapshot(type);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializerSnapshot.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializerSnapshot.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import java.io.IOException;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.statefun.sdk.TypeName;
+
+public class RemoteValueSerializerSnapshot implements TypeSerializerSnapshot<byte[]> {
+  private static final Integer VERSION = 1;
+
+  private TypeName type;
+
+  // empty constructor for restore paths
+  public RemoteValueSerializerSnapshot() {}
+
+  RemoteValueSerializerSnapshot(TypeName type) {
+    this.type = type;
+  }
+
+  public TypeName type() {
+    return type;
+  }
+
+  @Override
+  public int getCurrentVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public void writeSnapshot(DataOutputView dataOutputView) throws IOException {
+    dataOutputView.writeUTF(type.namespace());
+    dataOutputView.writeUTF(type.name());
+  }
+
+  @Override
+  public void readSnapshot(int i, DataInputView dataInputView, ClassLoader classLoader)
+      throws IOException {
+    final String namespace = dataInputView.readUTF();
+    final String name = dataInputView.readUTF();
+    this.type = new TypeName(namespace, name);
+  }
+
+  @Override
+  public TypeSerializer<byte[]> restoreSerializer() {
+    return new RemoteValueSerializer(type);
+  }
+
+  @Override
+  public TypeSerializerSchemaCompatibility<byte[]> resolveSchemaCompatibility(
+      TypeSerializer<byte[]> otherSerializer) {
+    if (!(otherSerializer instanceof RemoteValueSerializer)) {
+      return TypeSerializerSchemaCompatibility.incompatible();
+    }
+
+    final RemoteValueSerializer otherRemoteTypeSerializer = (RemoteValueSerializer) otherSerializer;
+    if (!type.equals(otherRemoteTypeSerializer.getType())) {
+      // throw an exception to bubble up information about the previous snapshotted typename
+      // TODO would this mess with Flink's schema compatibility checks?
+      // TODO this should be fine, since at the moment, if we return incompatible, Flink immediately
+      // fails anyways
+      throw new RemoteValueTypeMismatchException(type, otherRemoteTypeSerializer.getType());
+    }
+    return TypeSerializerSchemaCompatibility.compatibleAsIs();
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeInfo.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import java.util.Objects;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.TypeName;
+
+public final class RemoteValueTypeInfo extends TypeInformation<byte[]> {
+
+  private static final long serialVersionUID = 1L;
+
+  private final TypeName type;
+
+  public RemoteValueTypeInfo(TypeName type) {
+    this.type = Objects.requireNonNull(type);
+  }
+
+  @Override
+  public TypeSerializer<byte[]> createSerializer(ExecutionConfig executionConfig) {
+    return new RemoteValueSerializer(type);
+  }
+
+  @Override
+  public boolean isBasicType() {
+    return false;
+  }
+
+  @Override
+  public boolean isTupleType() {
+    return false;
+  }
+
+  @Override
+  public int getArity() {
+    return 0;
+  }
+
+  @Override
+  public int getTotalFields() {
+    return 0;
+  }
+
+  @Override
+  public Class<byte[]> getTypeClass() {
+    return byte[].class;
+  }
+
+  @Override
+  public boolean isKeyType() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "RemoteValueTypeInfo{" + "type=" + type + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RemoteValueTypeInfo that = (RemoteValueTypeInfo) o;
+    return type.equals(that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(type);
+  }
+
+  @Override
+  public boolean canEqual(Object obj) {
+    return obj instanceof RemoteValueTypeInfo;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeMismatchException.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeMismatchException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import org.apache.flink.statefun.sdk.TypeName;
+
+public final class RemoteValueTypeMismatchException extends IllegalStateException {
+
+  private static final long serialVersionUID = 1L;
+
+  public RemoteValueTypeMismatchException(TypeName previousValueType, TypeName newValueType) {
+    super(String.format("Previous type was: %s, new type is: %s", previousValueType, newValueType));
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/sdk/state/ApiExtension.java
@@ -33,6 +33,11 @@ public class ApiExtension {
     persistedAppendingBuffer.setAccessor(accessor);
   }
 
+  public static void setRemotePersistedValueAccessor(
+      RemotePersistedValue remotePersistedValue, Accessor<byte[]> accessor) {
+    remotePersistedValue.setAccessor(accessor);
+  }
+
   public static void bindPersistedStateRegistry(
       PersistedStateRegistry persistedStateRegistry, StateBinder stateBinder) {
     persistedStateRegistry.bind(stateBinder);

--- a/statefun-flink/statefun-flink-core/src/main/protobuf/request-reply.proto
+++ b/statefun-flink/statefun-flink-core/src/main/protobuf/request-reply.proto
@@ -152,6 +152,7 @@ message FromFunction {
     message PersistedValueSpec {
         string state_name = 1;
         ExpirationSpec expiration_spec = 2;
+        string type_typename = 3;
     }
 
     // IncompleteInvocationContext represents a result of an org.apache.flink.statefun.flink.core.polyglot.ToFunction.InvocationBatchRequest,

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedStateRegistry;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 import org.junit.Test;
 
@@ -224,6 +225,31 @@ public class PersistedStatesTest {
 
         @Override
         public T get() {
+          return value;
+        }
+
+        @Override
+        public void clear() {
+          value = null;
+        }
+      };
+    }
+
+    @Override
+    public Accessor<byte[]> createFlinkRemoteStateAccessor(
+        FunctionType functionType, RemotePersistedValue remotePersistedValue) {
+      boundNames.add(remotePersistedValue.name());
+
+      return new Accessor<byte[]>() {
+        byte[] value;
+
+        @Override
+        public void set(byte[] value) {
+          this.value = value;
+        }
+
+        @Override
+        public byte[] get() {
           return value;
         }
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -31,6 +31,7 @@ import javax.annotation.Nonnull;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.TypeName;
 import org.apache.flink.statefun.sdk.annotations.Persisted;
 import org.apache.flink.statefun.sdk.state.Accessor;
 import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
@@ -94,6 +95,13 @@ public class PersistedStatesTest {
     PersistedStates.findReflectivelyAndBind(new PersistedAppendingBufferState(), binderUnderTest);
 
     assertThat(state.boundNames, hasItems("buffer"));
+  }
+
+  @Test
+  public void bindRemotePersistedValue() {
+    PersistedStates.findReflectivelyAndBind(new RemotePersistedValueState(), binderUnderTest);
+
+    assertThat(state.boundNames, hasItems("remote"));
   }
 
   @Test
@@ -173,6 +181,13 @@ public class PersistedStatesTest {
     @Persisted
     @SuppressWarnings("unused")
     PersistedAppendingBuffer<Boolean> value = PersistedAppendingBuffer.of("buffer", Boolean.class);
+  }
+
+  static final class RemotePersistedValueState {
+    @Persisted
+    @SuppressWarnings("unused")
+    RemotePersistedValue remoteValue =
+        RemotePersistedValue.of("remote", TypeName.parseFrom("io.statefun.types/raw"));
   }
 
   static final class DynamicState {

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.statefun.sdk.state.AppendingBufferAccessor;
 import org.apache.flink.statefun.sdk.state.PersistedAppendingBuffer;
 import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
+import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
 import org.junit.Test;
 
@@ -195,6 +196,12 @@ public class StateBootstrapperTest {
     @Override
     public <E> AppendingBufferAccessor<E> createFlinkStateAppendingBufferAccessor(
         FunctionType functionType, PersistedAppendingBuffer<E> persistedAppendingBuffer) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Accessor<byte[]> createFlinkRemoteStateAccessor(
+        FunctionType functionType, RemotePersistedValue remotePersistedValue) {
       throw new UnsupportedOperationException();
     }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/TypeName.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/TypeName.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class TypeName implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final String DELIMITER = "/";
+
+  private final String namespace;
+  private final String name;
+
+  public static TypeName parseFrom(String typeNameString) {
+    final String[] split = typeNameString.split(DELIMITER);
+    if (split.length != 2) {
+      throw new IllegalArgumentException(
+          "Invalid type name string: "
+              + typeNameString
+              + ". Must be of format <namespace>"
+              + DELIMITER
+              + "<name>.");
+    }
+    return new TypeName(split[0], split[1]);
+  }
+
+  public TypeName(String namespace, String name) {
+    this.namespace = Objects.requireNonNull(namespace);
+    this.name = Objects.requireNonNull(name);
+  }
+
+  public String namespace() {
+    return namespace;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return namespace + DELIMITER + name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TypeName typeName = (TypeName) o;
+    return Objects.equals(namespace, typeName.namespace) && Objects.equals(name, typeName.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, name);
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/annotations/ForRuntime.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/annotations/ForRuntime.java
@@ -26,5 +26,5 @@ import java.lang.annotation.Target;
  * API with specialized implementation
  */
 @Documented
-@Target({ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
 public @interface ForRuntime {}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
@@ -84,6 +84,20 @@ public final class PersistedStateRegistry {
   }
 
   /**
+   * Registers a {@link RemotePersistedValue}. If a registered state already exists for the
+   * specified name of the table, the registration fails.
+   *
+   * <p>This method is intended only for internal use by the runtime.
+   *
+   * @param remoteValueState the remote value to register.
+   * @throws IllegalStateException if a previous registration exists for the given state name.
+   */
+  @ForRuntime
+  public void registerRemoteValue(RemotePersistedValue remoteValueState) {
+    acceptRegistrationOrThrowIfPresent(remoteValueState.name(), remoteValueState);
+  }
+
+  /**
    * Binds this state registry to a given function. All existing registered state in this registry
    * will also be bound to the system.
    *

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistry.java
@@ -123,12 +123,6 @@ public final class PersistedStateRegistry {
 
   private static final class NonFaultTolerantStateBinder extends StateBinder {
     @Override
-    public void bindValue(PersistedValue<?> persistedValue) {}
-
-    @Override
-    public void bindTable(PersistedTable<?, ?> persistedTable) {}
-
-    @Override
-    public void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer) {}
+    public void bind(Object stateObject) {}
   }
 }

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/RemotePersistedValue.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/RemotePersistedValue.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.state;
+
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.annotations.ForRuntime;
+
+@ForRuntime
+public final class RemotePersistedValue {
+  private final String name;
+  private final TypeName type;
+  private final Expiration expiration;
+  private Accessor<byte[]> accessor;
+
+  private RemotePersistedValue(
+      String name, TypeName type, Expiration expiration, Accessor<byte[]> accessor) {
+    this.name = Objects.requireNonNull(name);
+    this.type = Objects.requireNonNull(type);
+    this.expiration = Objects.requireNonNull(expiration);
+    this.accessor = Objects.requireNonNull(accessor);
+  }
+
+  public static RemotePersistedValue of(String stateName, TypeName typeName) {
+    return new RemotePersistedValue(
+        stateName, typeName, Expiration.none(), new NonFaultTolerantAccessor<>());
+  }
+
+  public static RemotePersistedValue of(
+      String stateName, TypeName typeName, Expiration expiration) {
+    return new RemotePersistedValue(
+        stateName, typeName, expiration, new NonFaultTolerantAccessor<>());
+  }
+
+  public byte[] get() {
+    return accessor.get();
+  }
+
+  public void set(byte[] value) {
+    accessor.set(value);
+  }
+
+  public void clear() {
+    accessor.clear();
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public TypeName type() {
+    return type;
+  }
+
+  public Expiration expiration() {
+    return expiration;
+  }
+
+  @ForRuntime
+  void setAccessor(Accessor<byte[]> newAccessor) {
+    this.accessor = Objects.requireNonNull(newAccessor);
+  }
+
+  private static final class NonFaultTolerantAccessor<E> implements Accessor<E> {
+    private E element;
+
+    @Override
+    public void set(E element) {
+      this.element = element;
+    }
+
+    @Override
+    public E get() {
+      return element;
+    }
+
+    @Override
+    public void clear() {
+      element = null;
+    }
+  }
+}

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/StateBinder.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/state/StateBinder.java
@@ -18,22 +18,9 @@
 
 package org.apache.flink.statefun.sdk.state;
 
+import org.apache.flink.statefun.sdk.annotations.ForRuntime;
+
+@ForRuntime
 public abstract class StateBinder {
-  public abstract void bindValue(PersistedValue<?> persistedValue);
-
-  public abstract void bindTable(PersistedTable<?, ?> persistedTable);
-
-  public abstract void bindAppendingBuffer(PersistedAppendingBuffer<?> persistedAppendingBuffer);
-
-  public final void bind(Object stateObject) {
-    if (stateObject instanceof PersistedValue) {
-      bindValue((PersistedValue<?>) stateObject);
-    } else if (stateObject instanceof PersistedTable) {
-      bindTable((PersistedTable<?, ?>) stateObject);
-    } else if (stateObject instanceof PersistedAppendingBuffer) {
-      bindAppendingBuffer((PersistedAppendingBuffer<?>) stateObject);
-    } else {
-      throw new IllegalArgumentException("Unknown persisted state object " + stateObject);
-    }
-  }
+  public abstract void bind(Object stateObject);
 }

--- a/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
+++ b/statefun-sdk/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.statefun.sdk.state;
 
+import org.apache.flink.statefun.sdk.TypeName;
 import org.junit.Test;
 
 public class PersistedStateRegistryTest {
@@ -29,6 +30,8 @@ public class PersistedStateRegistryTest {
     registry.registerValue(PersistedValue.of("value", String.class));
     registry.registerTable(PersistedTable.of("table", String.class, Integer.class));
     registry.registerAppendingBuffer(PersistedAppendingBuffer.of("buffer", String.class));
+    registry.registerRemoteValue(
+        RemotePersistedValue.of("remote", TypeName.parseFrom("io.statefun.types/raw")));
   }
 
   @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
This is a first step towards the new upcoming cross-language type system in StateFun.

The end result of this PR is:
- Remote functions may now specify the typename (of format `<namespace>/<name>`, e.g. `com.foo.bar/my-type`) of the types of their state. This is specified via a returned `PersistedValueSpec` from the functions.
- On the runtime side, we use this information to detect any mismatches of the type across registrations.
- The typename is also persisted in snapshots via Flink's serializer snapshots, so that the mismatch detection can also be done across StateFun cluster restores.

To allow incremental development without lock-stepping also updating the SDKs at the same time, the current implementation leaves room for the type to be left unset by SDKs, but eventually by the time we release, all SDKs should be updated to always set the state type typename when responding with a state spec.

---

## Changes

- 4fe1efc Some preliminary changes for cleaning up `StateBinder` interface and logic.
- d50c1bd Introduces the `RemotePersistedValue` state class in the SDK. A `RemotePersistedValue` directly maps to a single registered state value in remote functions. In contrast to the old `PersistedValue` class, instead of accepting a `Class<T>` as the type of the state, `RemotePersistedValue` accepts a `TypeName` to represent the state type, and always just work against bytes.
- 5978253 Implements the `TypeInformation`, `TypeSerializer`, `TypeSerializerSnapshot` that will be used specifically for `RemotePersistedValue` states. It is essentially a primitive byte array serializer, with the addition of a `TypeName` configuration that's sole purpose is to be persisted in the serializer snapshot.
- 49efb7a and cc7ff2f Wires everything together to enable the usage of the new `RemotePersistedValue` construct in functions.
- 7655b5c Extends the request-reply protocol to actually contain state types in `PersistedValueSpec`
- 9a04e9a And finally, the final result of using the new `RemotePersistedValue` in the `PersistedRemoteFunctionValues` class. Essentially, this replaces the original usages of `PersistedValue<byte[]>` with `RemotePersistedValue`, and using the new information to throw meaningful exceptions where a type mismatch is found.

---

## Testing the change

Various UT was added to cover the new functionality around registering a `RemotePersistedValue`.
Also, a new UT for `PersistedRemoteFunctionsValues` was added to cover the contract that an exception is thrown if the typename of state types was changed across multiple registrations.