### PR TITLE
[FLINK-21498] Avoid copying when converting byte[] to ByteString

### DIFF
--- a/statefun-flink/statefun-flink-common/src/main/java/com/google/protobuf/MoreByteStrings.java
+++ b/statefun-flink/statefun-flink-common/src/main/java/com/google/protobuf/MoreByteStrings.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.protobuf;
+
+import java.nio.ByteBuffer;
+
+public class MoreByteStrings {
+
+  public static ByteString wrap(byte[] bytes) {
+    return ByteString.wrap(bytes);
+  }
+
+  public static ByteString wrap(byte[] bytes, int offset, int len) {
+    return ByteString.wrap(bytes, offset, len);
+  }
+
+  public static ByteString wrap(ByteBuffer buffer) {
+    return ByteString.wrap(buffer);
+  }
+
+  public static ByteString concat(ByteString first, ByteString second) {
+    return first.concat(second);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerKryo.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerKryo.java
@@ -18,6 +18,7 @@
 package org.apache.flink.statefun.flink.core.message;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -40,8 +41,7 @@ public final class MessagePayloadSerializerKryo implements MessagePayloadSeriali
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
-    // TODO: avoid copying, consider adding a zero-copy ByteString.
-    ByteString serializedBytes = ByteString.copyFrom(target.getSharedBuffer(), 0, target.length());
+    ByteString serializedBytes = MoreByteStrings.wrap(target.getSharedBuffer(), 0, target.length());
     return Payload.newBuilder()
         .setClassName(payloadObject.getClass().getName())
         .setPayloadBytes(serializedBytes)

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerRaw.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerRaw.java
@@ -18,6 +18,7 @@
 package org.apache.flink.statefun.flink.core.message;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.flink.statefun.flink.core.generated.Payload;
@@ -33,7 +34,7 @@ public class MessagePayloadSerializerRaw implements MessagePayloadSerializer {
   @Override
   public Payload serialize(@Nonnull Object what) {
     byte[] bytes = (byte[]) what;
-    ByteString bs = ByteString.copyFrom(bytes);
+    ByteString bs = MoreByteStrings.wrap(bytes);
     return Payload.newBuilder().setPayloadBytes(bs).build();
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.statefun.flink.core.reqreply;
 
-import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +56,7 @@ public final class PersistedRemoteFunctionValues {
             TypedValue.newBuilder()
                 .setTypename(registeredHandle.type().toString())
                 .setHasValue(true)
-                .setValue(ByteString.copyFrom(stateBytes))
+                .setValue(MoreByteStrings.wrap(stateBytes))
                 .build();
         valueBuilder.setStateValue(stateValue);
       }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/JavaPayloadSerializer.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/JavaPayloadSerializer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.message;
 
-import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
 import java.io.*;
 import javax.annotation.Nonnull;
 import org.apache.flink.statefun.flink.core.generated.Payload;
@@ -37,7 +37,7 @@ public class JavaPayloadSerializer implements MessagePayloadSerializer {
           byte[] bytes = bos.toByteArray();
           return Payload.newBuilder()
               .setClassName(className)
-              .setPayloadBytes(ByteString.copyFrom(bytes))
+              .setPayloadBytes(MoreByteStrings.wrap(bytes))
               .build();
         }
       }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/RoutableProtobufKafkaIngressDeserializer.java
@@ -17,8 +17,8 @@
  */
 package org.apache.flink.statefun.flink.io.kafka;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import com.google.protobuf.MoreByteStrings;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
@@ -55,7 +55,7 @@ public final class RoutableProtobufKafkaIngressDeserializer
     return AutoRoutable.newBuilder()
         .setConfig(routingConfig)
         .setId(id)
-        .setPayloadBytes(ByteString.copyFrom(payload))
+        .setPayloadBytes(MoreByteStrings.wrap(payload))
         .build();
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kinesis/polyglot/RoutableProtobufKinesisIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kinesis/polyglot/RoutableProtobufKinesisIngressDeserializer.java
@@ -17,8 +17,8 @@
  */
 package org.apache.flink.statefun.flink.io.kinesis.polyglot;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import com.google.protobuf.MoreByteStrings;
 import java.util.Map;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
@@ -53,7 +53,7 @@ public final class RoutableProtobufKinesisIngressDeserializer
     return AutoRoutable.newBuilder()
         .setConfig(routingConfig)
         .setId(ingressRecord.getPartitionKey())
-        .setPayloadBytes(ByteString.copyFrom(ingressRecord.getData()))
+        .setPayloadBytes(MoreByteStrings.wrap(ingressRecord.getData()))
         .build();
   }
 }


### PR DESCRIPTION
There's a few places where we can be more efficient by avoiding byte array copying and we know that it is safe to do so (because we won't be mutating the byte array):

- The message payload serializers
- In `PersistedRemoteFunctionValues`, when attaching state bytes to a ToFunction
- In deserializers used by auto-routable Kafka / Kinesis ingresses.

---

## Verifying the change

E2E tests pass