### PR TITLE
[FLINK-21530] Precompute TypeName's canonical representation

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -54,7 +54,7 @@ public final class PersistedRemoteFunctionValues {
       if (stateBytes != null) {
         final TypedValue stateValue =
             TypedValue.newBuilder()
-                .setTypename(registeredHandle.type().toString())
+                .setTypename(registeredHandle.type().canonicalTypenameString())
                 .setHasValue(true)
                 .setValue(MoreByteStrings.wrap(stateBytes))
                 .build();

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
@@ -184,7 +184,7 @@ public class PersistedRemoteFunctionValuesTest {
 
   private static TypedValue protocolTypedValue(TypeName typename, ByteString value) {
     return TypedValue.newBuilder()
-        .setTypename(typename.toString())
+        .setTypename(typename.canonicalTypenameString())
         .setHasValue(value != null)
         .setValue(value)
         .build();
@@ -193,7 +193,7 @@ public class PersistedRemoteFunctionValuesTest {
   private static PersistedValueSpec protocolPersistedValueSpec(String stateName, TypeName type) {
     return PersistedValueSpec.newBuilder()
         .setStateName(stateName)
-        .setTypeTypename(type.toString())
+        .setTypeTypename(type.canonicalTypenameString())
         .build();
   }
 

--- a/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/TypeName.java
+++ b/statefun-sdk/src/main/java/org/apache/flink/statefun/sdk/TypeName.java
@@ -29,6 +29,7 @@ public final class TypeName implements Serializable {
 
   private final String namespace;
   private final String name;
+  private final String canonicalTypenameString;
 
   public static TypeName parseFrom(String typeNameString) {
     final String[] split = typeNameString.split(DELIMITER);
@@ -46,6 +47,7 @@ public final class TypeName implements Serializable {
   public TypeName(String namespace, String name) {
     this.namespace = Objects.requireNonNull(namespace);
     this.name = Objects.requireNonNull(name);
+    this.canonicalTypenameString = canonicalTypeNameString(namespace, name);
   }
 
   public String namespace() {
@@ -56,8 +58,16 @@ public final class TypeName implements Serializable {
     return name;
   }
 
+  public String canonicalTypenameString() {
+    return canonicalTypenameString;
+  }
+
   @Override
   public String toString() {
+    return "TypeName(" + namespace + ", " + name + ")";
+  }
+
+  private static String canonicalTypeNameString(String namespace, String name) {
     return namespace + DELIMITER + name;
   }
 
@@ -66,11 +76,13 @@ public final class TypeName implements Serializable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     TypeName typeName = (TypeName) o;
-    return Objects.equals(namespace, typeName.namespace) && Objects.equals(name, typeName.name);
+    return Objects.equals(namespace, typeName.namespace)
+        && Objects.equals(name, typeName.name)
+        && Objects.equals(canonicalTypenameString, typeName.canonicalTypenameString);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, name);
+    return Objects.hash(namespace, name, canonicalTypenameString);
   }
 }


### PR DESCRIPTION
There's room for improvement in `PersistedRemoteFunctionValues`, where we currently concatenate strings to build the typename string for each state value we attach to a `ToFunction` message.

This extra work can be easily avoided by precomputing the canonical typename string, since `TypeName`'s are immutable.