### PR TITLE
[hotfix] [java] Set has_value appropriately for TypedValues

### DIFF
--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ProtoUtils.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ProtoUtils.java
@@ -82,6 +82,7 @@ final class ProtoUtils {
     return TypedValue.newBuilder()
         .setTypenameBytes(ApiExtension.typeNameByteString(message.valueTypeName()))
         .setValue(SliceProtobufUtil.asByteString(message.rawValue()))
+        .setHasValue(true)
         .build();
   }
 
@@ -92,6 +93,7 @@ final class ProtoUtils {
     return TypedValue.newBuilder()
         .setTypenameBytes(ApiExtension.typeNameByteString(message.egressMessageValueType()))
         .setValue(SliceProtobufUtil.asByteString(message.egressMessageValueBytes()))
+        .setHasValue(true)
         .build();
   }
 }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -119,6 +119,7 @@ public final class KafkaEgressMessage {
           TypedValue.newBuilder()
               .setTypenameBytes(ApiExtension.typeNameByteString(KAFKA_PRODUCER_RECORD_TYPENAME))
               .setValue(record.toByteString())
+              .setHasValue(true)
               .build();
 
       return new EgressMessageWrapper(targetEgressId, typedValue);

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KinesisEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KinesisEgressMessage.java
@@ -138,6 +138,7 @@ public final class KinesisEgressMessage {
           TypedValue.newBuilder()
               .setTypenameBytes(ApiExtension.typeNameByteString(KINESIS_PRODUCER_RECORD_TYPENAME))
               .setValue(builder.build().toByteString())
+              .setHasValue(true)
               .build();
 
       return new EgressMessageWrapper(targetEgressId, typedValue);

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageBuilder.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageBuilder.java
@@ -98,6 +98,7 @@ public final class MessageBuilder {
     Slice serialized = typeSerializer.serialize(element);
     ByteString serializedByteString = SliceProtobufUtil.asByteString(serialized);
     builder.setValue(serializedByteString);
+    builder.setHasValue(true);
     return this;
   }
 
@@ -108,6 +109,9 @@ public final class MessageBuilder {
   private static TypedValue.Builder typedValueBuilder(Message message) {
     ByteString typenameBytes = ApiExtension.typeNameByteString(message.valueTypeName());
     ByteString valueBytes = SliceProtobufUtil.asByteString(message.rawValue());
-    return TypedValue.newBuilder().setTypenameBytes(typenameBytes).setValue(valueBytes);
+    return TypedValue.newBuilder()
+        .setTypenameBytes(typenameBytes)
+        .setHasValue(true)
+        .setValue(valueBytes);
   }
 }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
@@ -35,6 +35,10 @@ public final class MessageWrapper implements Message {
 
   public MessageWrapper(Address targetAddress, TypedValue typedValue) {
     this.targetAddress = Objects.requireNonNull(targetAddress);
+
+    if (!typedValue.getHasValue()) {
+      throw new IllegalStateException("Unset empty TypedValue's are prohibited.");
+    }
     this.typedValue = Objects.requireNonNull(typedValue);
   }
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentRequestReplyHandlerTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentRequestReplyHandlerTest.java
@@ -106,7 +106,6 @@ public class ConcurrentRequestReplyHandlerTest {
     @Override
     public CompletableFuture<Void> apply(Context context, Message argument) {
       int seen = context.storage().get(SEEN_INT_SPEC).orElse(0);
-      System.out.println("Hello there " + argument.asUtf8String() + " state=" + seen);
 
       context.storage().set(SEEN_INT_SPEC, seen + 1);
 


### PR DESCRIPTION
Did a grep for `TypedValue.newBuilder` and `TypedValue.Builder` to see where we are constructing `TypedValue`s, and make sure we appropriately set the `has_value` flag (by default, the flag is `false`).

It doesn't really matter for invocation arguments for now, since we don't do any explicit checks on the flag for arguments.
This is important only for keeping the semantics of the flag consistent across invocation argument values and state values.