### PR TITLE
[FLINK-21577] [java] Fix instantiation error with SimpleType.simpleTypeFrom()

### DIFF
--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/types/SimpleType.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/types/SimpleType.java
@@ -47,14 +47,14 @@ public final class SimpleType<T> implements Type<T> {
   private final TypeSerializer<T> serializer;
   private final Set<TypeCharacteristics> typeCharacteristics;
 
-  public SimpleType(
+  private SimpleType(
       TypeName typeName,
       Fn<T, byte[]> serialize,
       Fn<byte[], T> deserialize,
       Set<TypeCharacteristics> typeCharacteristics) {
     this.typeName = Objects.requireNonNull(typeName);
     this.serializer = new Serializer<>(serialize, deserialize);
-    this.typeCharacteristics = Collections.unmodifiableSet(EnumSet.copyOf(typeCharacteristics));
+    this.typeCharacteristics = Collections.unmodifiableSet(typeCharacteristics);
   }
 
   @Override

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SimpleTypeTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SimpleTypeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.java.types;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.junit.Test;
+
+public class SimpleTypeTest {
+
+  @Test
+  public void mutableType() {
+    final Type<String> type =
+        SimpleType.simpleTypeFrom(
+            TypeName.typeNameFromString("test/simple-mutable-type"), String::getBytes, String::new);
+
+    assertThat(type.typeName(), is(TypeName.typeNameFromString("test/simple-mutable-type")));
+    assertRoundTrip(type, "hello world!");
+  }
+
+  @Test
+  public void immutableType() {
+    final Type<String> type =
+        SimpleType.simpleImmutableTypeFrom(
+            TypeName.typeNameFromString("test/simple-immutable-type"),
+            String::getBytes,
+            String::new);
+
+    assertThat(type.typeName(), is(TypeName.typeNameFromString("test/simple-immutable-type")));
+    assertRoundTrip(type, "hello world!");
+  }
+
+  public <T> void assertRoundTrip(Type<T> type, T element) {
+    final Slice slice;
+    {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      slice = serializer.serialize(element);
+    }
+    TypeSerializer<T> serializer = type.typeSerializer();
+    T deserialized = serializer.deserialize(slice);
+    assertEquals(element, deserialized);
+  }
+}


### PR DESCRIPTION
This was failing with an `Collection is empty` when attempting to copy the enum set of `TypeCharacteristic`s.

I think the only reason we need to do a copy, is if users instantiate a `SimpleType` directly with the constructor (and not the `simpleTypeFrom`, `simpleImmutableTypeFrom` factory methods).
IMO, we probably can expect users to just use the factory methods, and not the constructor.
If they need to do anything more complex, they should just create a `Type` subclass directly.

Therefore, this PR makes the constructor private to enforce instantiation a `SimpleType` via the factory methods.
This would allow the constructor to be simpler and remove the `EnumSet.copyOf` operation.