### PR TITLE
[FLINK-21642] Make a retry batch on recovery

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunction.java
@@ -127,7 +127,13 @@ public final class RequestReplyFunction implements StatefulFunction {
       InternalContext context, AsyncOperationResult<ToFunction, FromFunction> asyncResult) {
     if (asyncResult.unknown()) {
       ToFunction batch = asyncResult.metadata();
-      sendToFunction(context, batch);
+      // According to the request-reply protocol, on recovery
+      // we re-send the uncompleted (in-flight during a failure)
+      // messages. But we shouldn't assume that the state
+      // definitions are the same as in the previous attempt.
+      // We create a retry batch and let the SDK reply
+      // with the correct state specs.
+      sendToFunction(context, createRetryBatch(batch));
       return;
     }
     if (asyncResult.failure()) {


### PR DESCRIPTION
According to the request-reply protocol, on recovery
we re-send the uncompleted (in-flight during failure)
messages. But we shouldn't assume that the state
definitions are the same as in the previous attempt.
We create a retry batch and let the SDK to reply with
the correct state specs. 
see the JIRA issue with more details about the failure scenario