### PR TITLE
[hotfix] fix non-resolvable Docker images in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can quickly get started building Stateful Functions applications using the p
 mvn archetype:generate \
   -DarchetypeGroupId=org.apache.flink \
   -DarchetypeArtifactId=statefun-quickstart \
-  -DarchetypeVersion=2.2-SNAPSHOT
+  -DarchetypeVersion=2.2.2
 ```
 
 This allows you to name your newly created project. It will interactively ask you for the `GroupId`,
@@ -212,7 +212,7 @@ simply include `statefun-flink-distribution` as a dependency to your application
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>statefun-flink-distribution</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
 </dependency>
 ```
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@
 # we change the version for the complete docs when forking of a release branch
 # etc.
 # The full version string as referenced in Maven (e.g. 1.2.1)
-version: "2.2.0"
+version: "2.2.2"
 # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
 # release this should be the same as the regular version
 version_title: "2.2"

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <artifactId>statefun-parent</artifactId>
     <groupId>org.apache.flink</groupId>
     <name>statefun-parent</name>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <url>http://flink.apache.org</url>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-exactly-once-e2e/pom.xml
+++ b/statefun-e2e-tests/statefun-exactly-once-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-exactly-once-e2e/src/test/resources/Dockerfile
+++ b/statefun-e2e-tests/statefun-exactly-once-e2e/src/test/resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-exactly-once-e2e
 COPY statefun-exactly-once-e2e*.jar /opt/statefun/modules/statefun-exactly-once-e2e/

--- a/statefun-e2e-tests/statefun-remote-module-e2e/pom.xml
+++ b/statefun-e2e-tests/statefun-remote-module-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-remote-module-e2e/src/test/resources/Dockerfile
+++ b/statefun-e2e-tests/statefun-remote-module-e2e/src/test/resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-remote-module-e2e
 COPY remote-module/ /opt/statefun/modules/statefun-remote-module-e2e/

--- a/statefun-e2e-tests/statefun-sanity-e2e/pom.xml
+++ b/statefun-e2e-tests/statefun-sanity-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-sanity-e2e/src/test/resources/Dockerfile
+++ b/statefun-e2e-tests/statefun-sanity-e2e/src/test/resources/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-sanity-e2e
 COPY statefun-sanity-e2e*.jar /opt/statefun/modules/statefun-sanity-e2e/

--- a/statefun-examples/pom.xml
+++ b/statefun-examples/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
 
     <artifactId>statefun-examples</artifactId>

--- a/statefun-examples/statefun-async-example/pom.xml
+++ b/statefun-examples/statefun-async-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-async-python-example/statefun/Dockerfile
+++ b/statefun-examples/statefun-async-python-example/statefun/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-async-python-example/statefun/Dockerfile
+++ b/statefun-examples/statefun-async-python-example/statefun/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-flink-datastream-example/pom.xml
+++ b/statefun-examples/statefun-flink-datastream-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-flink-harness-example/pom.xml
+++ b/statefun-examples/statefun-flink-harness-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-greeter-example/Dockerfile
+++ b/statefun-examples/statefun-greeter-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-greeter-example
 COPY target/statefun-greeter-example*jar /opt/statefun/modules/statefun-greeter-example/

--- a/statefun-examples/statefun-greeter-example/Dockerfile
+++ b/statefun-examples/statefun-greeter-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-greeter-example
 COPY target/statefun-greeter-example*jar /opt/statefun/modules/statefun-greeter-example/

--- a/statefun-examples/statefun-greeter-example/pom.xml
+++ b/statefun-examples/statefun-greeter-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-python-greeter-example/Dockerfile
+++ b/statefun-examples/statefun-python-greeter-example/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-python-greeter-example/Dockerfile
+++ b/statefun-examples/statefun-python-greeter-example/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-python-k8s-example/Dockerfile.statefun
+++ b/statefun-examples/statefun-python-k8s-example/Dockerfile.statefun
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-python-k8s-example/Dockerfile.statefun
+++ b/statefun-examples/statefun-python-k8s-example/Dockerfile.statefun
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/greeter
 ADD module.yaml /opt/statefun/modules/greeter

--- a/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
+++ b/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-ridesharing-example
 COPY statefun-ridesharing-example-functions/target/statefun-ridesharing-example*jar /opt/statefun/modules/statefun-ridesharing-example/

--- a/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
+++ b/statefun-examples/statefun-ridesharing-example/Dockerfile.functions
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-ridesharing-example
 COPY statefun-ridesharing-example-functions/target/statefun-ridesharing-example*jar /opt/statefun/modules/statefun-ridesharing-example/

--- a/statefun-examples/statefun-ridesharing-example/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-functions/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-functions/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-ridesharing-example</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-example-simulator/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-ridesharing-example</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-protocol/pom.xml
+++ b/statefun-examples/statefun-ridesharing-example/statefun-ridesharing-protocol/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-ridesharing-example</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-examples/statefun-shopping-cart-example/Dockerfile
+++ b/statefun-examples/statefun-shopping-cart-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2-SNAPSHOT
+FROM flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-shopping-cart-example
 COPY target/statefun-shopping-cart-example*jar /opt/statefun/modules/statefun-shopping-cart-example/

--- a/statefun-examples/statefun-shopping-cart-example/Dockerfile
+++ b/statefun-examples/statefun-shopping-cart-example/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink-statefun:2.2.2
+FROM ververica/flink-statefun:2.2.2
 
 RUN mkdir -p /opt/statefun/modules/statefun-shopping-cart-example
 COPY target/statefun-shopping-cart-example*jar /opt/statefun/modules/statefun-shopping-cart-example/

--- a/statefun-examples/statefun-shopping-cart-example/pom.xml
+++ b/statefun-examples/statefun-shopping-cart-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-examples/statefun-state-processor-example/pom.xml
+++ b/statefun-examples/statefun-state-processor-example/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-examples</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-python-sdk/setup.py
+++ b/statefun-python-sdk/setup.py
@@ -27,7 +27,7 @@ with io.open(os.path.join(this_directory, 'README.md'), 'r', encoding='utf-8') a
 
 setup(
     name='apache-flink-statefun',
-    version='2.2-SNAPSHOT',
+    version='2.2.2',
     packages=["statefun"],
     url='https://github.com/apache/flink-statefun',
     license='https://www.apache.org/licenses/LICENSE-2.0',

--- a/statefun-quickstart/pom.xml
+++ b/statefun-quickstart/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk/pom.xml
+++ b/statefun-sdk/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -21,7 +21,7 @@ set -e
 # Do not change the name of this variable;
 # it is referenced in the tools/releasing/update_branch_version.sh script
 #
-VERSION_TAG=2.2-SNAPSHOT
+VERSION_TAG=2.2.2
 
 #
 # setup the environment 

--- a/tools/k8s/Chart.yaml
+++ b/tools/k8s/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: statefun-k8s
 description: A Helm chart for a Stateful function pplication deployed on Kubernetes
 type: application
-version: 2.2-SNAPSHOT
+version: 2.2.2
 appVersion: 1.16.0


### PR DESCRIPTION
Following the documentation to run an example currently fails at the `docker-compose build` stage because `flink-statefun:2.2.2` is not a valid image name (`ververica/flink-statefun:2.2.2` is).

Let me know if this is intended, I will then instead update the README to add the instructions to build the image locally from `tools/docker/`.

We could alternatively add it as an automatic step via a maven plugin, so this gets incorporated into the instruction to first build everything locally with mvn.