### PR TITLE
[FLINK-21904] Sync standalone-job.sh with recent Flink 1.12.x changes

### DIFF
--- a/tools/docker/flink-distribution-template/bin/standalone-job.sh
+++ b/tools/docker/flink-distribution-template/bin/standalone-job.sh
@@ -40,7 +40,11 @@ ARGS=("--configDir" "${FLINK_CONF_DIR}" "${@:2}")
 if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # Add cluster entry point specific JVM options
     export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_JM}"
-    parseJmJvmArgsAndExportLogs "${ARGS[@]}"
+    parseJmArgsAndExportLogs "${ARGS[@]}"
+
+    if [ ! -z "${DYNAMIC_PARAMETERS}" ]; then
+        ARGS+=(${DYNAMIC_PARAMETERS[@]})
+    fi
 fi
 
 if [[ $STARTSTOP == "start-foreground" ]]; then


### PR DESCRIPTION
I discovered a mismatch in our modified `standalone-job.sh` script with the Flink 1.12.x latest changes, by noticing this line in the StateFun image startup logs:
```
11:37:12,572 ERROR org.apache.flink.statefun.e2e.remote.ExactlyOnceWithRemoteFnE2E  - /opt/flink/bin/standalone-job.sh: line 43: parseJmJvmArgsAndExportLogs: command not found
```

You'll be able to fine this line in any of the previous CI runs in the E2E logs.

This was caused by FLINK-19662: https://issues.apache.org/jira/browse/FLINK-19662,
which renamed `parseJmJvmArgsAndExportLogs` to `parseJmArgsAndExportLogs`.

Apart from addressing that rename, this PR syncs the addition of `DYNAMIC_PARAMETERS`, also added by FLINK-19662.