### PR TITLE
[FLINK-22242][python] Improve missing attribute error on GeneratedAddressedScopedStorage

### DIFF
--- a/statefun-sdk-python/statefun/request_reply_v3.py
+++ b/statefun-sdk-python/statefun/request_reply_v3.py
@@ -209,7 +209,7 @@ class RequestReplyHandler(object):
         if not target_fn:
             raise ValueError(f"Unable to find a function of type {sdk_address.typename}")
         # resolve state
-        res = resolve(target_fn.storage_spec, pb_to_function.invocation.state)
+        res = resolve(target_fn.storage_spec, sdk_address.typename, pb_to_function.invocation.state)
         if res.missing_specs:
             pb_from_function = collect_failure(res.missing_specs)
             return pb_from_function.SerializeToString()

--- a/statefun-sdk-python/tests/storage_test.py
+++ b/statefun-sdk-python/tests/storage_test.py
@@ -39,7 +39,7 @@ class StorageTestCase(unittest.TestCase):
         values = [PbPersistedValueLike("a", 1, IntType), PbPersistedValueLike("b", "hello", StringType)]
 
         # resolve spec and values
-        resolution = resolve(storage_spec, values)
+        resolution = resolve(storage_spec, "example/func", values)
         store = resolution.storage
 
         self.assertEqual(store.a, 1)
@@ -53,7 +53,7 @@ class StorageTestCase(unittest.TestCase):
         values = []
 
         # resolve spec and values
-        resolution = resolve(storage_spec, values)
+        resolution = resolve(storage_spec, "example/func", values)
         self.assertListEqual(resolution.missing_specs, specs)
 
     def test_partial_failed_resolution(self):
@@ -64,7 +64,7 @@ class StorageTestCase(unittest.TestCase):
         values = [PbPersistedValueLike("a", 1, IntType)]
 
         # resolve spec and values
-        resolution = resolve(storage_spec, values)
+        resolution = resolve(storage_spec, "example/func", values)
         self.assertListEqual(resolution.missing_specs, specs[1:])
 
     def test_ignore_unknown(self):
@@ -75,7 +75,7 @@ class StorageTestCase(unittest.TestCase):
         values = [PbPersistedValueLike("a", 1, IntType), PbPersistedValueLike("b", "hello", StringType)]
 
         # resolve spec and values
-        resolution = resolve(storage_spec, values)
+        resolution = resolve(storage_spec, "example/func", values)
         store = resolution.storage
 
         self.assertEqual(store.a, 1)
@@ -157,5 +157,5 @@ def store_from(*args):
         else:
             vals.append(arg)
     storage_spec = make_address_storage_spec(specs)
-    resolution = resolve(storage_spec, vals)
+    resolution = resolve(storage_spec, "example/func", vals)
     return resolution.storage


### PR DESCRIPTION
```python
@functions.bind('example/func', [ValueSpec('state', IntType)]
def my_func(ctx, msg): 
     ctx.storage.sate
```

Previous Error: 
> AttributeError: No attribute sate in type GeneratedAddressedScopedStorage

New Error: 

> AttributeError: 'sate' is not a registered ValueSpec for the function 'example/func'
