### PR TITLE
[FLINK-22552] Update Flink dependency to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ under the License.
         <protobuf.version>3.7.1</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.12.1</flink.version>
+        <flink.version>1.13.0</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <root.dir>${rootDir}</root.dir>
     </properties>

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -49,7 +49,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
-            <version>2.10.1-12.0</version>
+            <version>2.12.1-13.0</version>
         </dependency>
 
         <!-- tests -->

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -302,6 +303,11 @@ public class ReductionsTest {
     public void registerUserCodeClassLoaderReleaseHookIfAbsent(String s, Runnable runnable) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public JobID getJobId() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   private static final class FakeKeyedStateBackend implements KeyedStateBackend<Object> {
@@ -352,9 +358,9 @@ public class ReductionsTest {
 
     @Nonnull
     @Override
-    public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed>
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
         KeyGroupedInternalPriorityQueue<T> create(
-            @Nonnull String stateName, @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            @Nonnull String s, @Nonnull TypeSerializer<T> typeSerializer) {
       throw new UnsupportedOperationException();
     }
 

--- a/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
+++ b/statefun-flink/statefun-flink-launcher/src/main/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
@@ -119,12 +119,13 @@ public final class StatefulFunctionsClusterEntryPoint extends JobClusterEntrypoi
     if (isNoExecutionModeConfigured(configuration)) {
       // In contrast to other places, the default for standalone job clusters is
       // ExecutionMode.DETACHED
-      configuration.setString(ClusterEntrypoint.EXECUTION_MODE, ExecutionMode.DETACHED.toString());
+      configuration.setString(
+          ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, ExecutionMode.DETACHED.toString());
     }
   }
 
   private static boolean isNoExecutionModeConfigured(Configuration configuration) {
-    return configuration.getString(ClusterEntrypoint.EXECUTION_MODE, null) == null;
+    return configuration.getString(ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, null) == null;
   }
 
   private static void addStatefulFunctionsConfiguration(Configuration configuration) {

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/flink:1.12.1-scala_2.12-java8
+FROM apache/flink:1.13.0-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost
@@ -37,8 +37,6 @@ RUN mkdir -p $STATEFUN_MODULES && \
 # add filesystem plugins
 RUN mkdir -p $FLINK_HOME/plugins/s3-fs-presto && \
     mv $FLINK_HOME/opt/flink-s3-fs-presto-*.jar $FLINK_HOME/plugins/s3-fs-presto
-RUN mkdir -p $FLINK_HOME/plugins/swift-fs-hadoop && \
-    mv $FLINK_HOME/opt/flink-swift-fs-hadoop-*.jar $FLINK_HOME/plugins/swift-fs-hadoop
 RUN mkdir -p $FLINK_HOME/plugins/oss-fs-hadoop && \
     mv $FLINK_HOME/opt/flink-oss-fs-hadoop-*.jar $FLINK_HOME/plugins/oss-fs-hadoop
 RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \


### PR DESCRIPTION
This PR rebases StateFun to be compatible with Flink 1.13.x.
While the PR upgrades to 1.13.0, ultimately, we want to at least update to 1.13.1. We may postpone the merge of this PR until 1.13.1 is out, or already merge this so that once 1.13.1 is out it'll be just a simple version bump.