### PR TITLE
[FLINK-20336] [core] Do not silently pass UNRECOGNIZED state mutations

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValues.java
@@ -83,9 +83,6 @@ public final class PersistedRemoteFunctionValues {
             break;
           }
         case UNRECOGNIZED:
-          {
-            break;
-          }
         default:
           throw new IllegalStateException("Unexpected value: " + mutate.getMutationType());
       }


### PR DESCRIPTION
We should throw if the state mutation returned from remote functions is of type `UNRECOGNIZED`.

The `UNRECOGNIZED` enum constant is a Protobuf auto-generated constant that is used if the enum to deserialize does not exist on the receiving side. Thus, this should only happen in the case of mismatching protocol versions between StateFun and the remote function.

In this case, we should definitely not silently pass.