### PR TITLE
[hotfix] Correct endpoint definition in docs

### DIFF
--- a/docs/content/docs/deployment/module.md
+++ b/docs/content/docs/deployment/module.md
@@ -155,8 +155,8 @@ It is recommended to have endpoints only specified against a namespace to enable
 endpoint:
   meta:
     kind: http
-    functions: com.example/*
   spec:
+    functions: com.example/*
 ```
 
 #### Url Path Template


### PR DESCRIPTION
Just a quick fix for an `endpoint` def typo. 