### PR TITLE
[FLINK-21308] Support delayed message cancellation

### DIFF
--- a/statefun-e2e-tests/statefun-smoke-e2e/src/test/java/org/apache/flink/statefun/e2e/smoke/CommandInterpreterTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e/src/test/java/org/apache/flink/statefun/e2e/smoke/CommandInterpreterTest.java
@@ -68,6 +68,12 @@ public class CommandInterpreterTest {
     public void sendAfter(Duration duration, Address address, Object o) {}
 
     @Override
+    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
+
+    @Override
+    public void cancelDelayedMessage(String cancellationToken) {}
+
+    @Override
     public <M, T> void registerAsyncOperation(M m, CompletableFuture<T> completableFuture) {}
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/AsyncMessageDecorator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/AsyncMessageDecorator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.statefun.flink.core.functions;
 
+import java.util.Optional;
 import java.util.OptionalLong;
 import javax.annotation.Nullable;
 import org.apache.flink.core.memory.DataOutputView;
@@ -90,6 +91,11 @@ final class AsyncMessageDecorator<T> implements Message {
   @Override
   public OptionalLong isBarrierMessage() {
     return OptionalLong.empty();
+  }
+
+  @Override
+  public Optional<String> cancellationToken() {
+    return message.cancellationToken();
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/DelayMessageHandler.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/DelayMessageHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.functions;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.apache.flink.statefun.flink.core.di.Inject;
+import org.apache.flink.statefun.flink.core.di.Label;
+import org.apache.flink.statefun.flink.core.di.Lazy;
+import org.apache.flink.statefun.flink.core.message.Message;
+
+/**
+ * Handles any of the delayed message that needs to be fired at a specific timestamp. This handler
+ * dispatches {@linkplain Message}s to either remotely (shuffle) or locally.
+ */
+final class DelayMessageHandler implements Consumer<Message> {
+  private final RemoteSink remoteSink;
+  private final Lazy<Reductions> reductions;
+  private final Partition thisPartition;
+
+  @Inject
+  public DelayMessageHandler(
+      RemoteSink remoteSink,
+      @Label("reductions") Lazy<Reductions> reductions,
+      Partition partition) {
+    this.remoteSink = Objects.requireNonNull(remoteSink);
+    this.reductions = Objects.requireNonNull(reductions);
+    this.thisPartition = Objects.requireNonNull(partition);
+  }
+
+  @Override
+  public void accept(Message message) {
+    if (thisPartition.contains(message.target())) {
+      reductions.get().enqueue(message);
+    } else {
+      remoteSink.accept(message);
+    }
+  }
+
+  public void onStart() {}
+
+  public void onComplete() {
+    reductions.get().processEnvelopes();
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/DelayedMessagesBuffer.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/DelayedMessagesBuffer.java
@@ -17,13 +17,23 @@
  */
 package org.apache.flink.statefun.flink.core.functions;
 
+import java.util.OptionalLong;
+import java.util.function.Consumer;
 import org.apache.flink.statefun.flink.core.message.Message;
 
 interface DelayedMessagesBuffer {
 
+  /** Add a message to be fired at a specific timestamp */
   void add(Message message, long untilTimestamp);
 
-  Iterable<Message> getForTimestamp(long timestamp);
+  /** Apply @fn for each delayed message that is meant to be fired at @timestamp. */
+  void forEachMessageAt(long timestamp, Consumer<Message> fn);
 
-  void clearForTimestamp(long timestamp);
+  /**
+   * @param token a message cancellation token to delete.
+   * @return an optional timestamp that this message was meant to be fired at. The timestamp will be
+   *     present only if this message was the last message registered to fire at that timestamp.
+   *     (hence: safe to clear any underlying timer)
+   */
+  OptionalLong removeMessageByCancellationToken(String token);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FlinkStateDelayedMessagesBuffer.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FlinkStateDelayedMessagesBuffer.java
@@ -17,7 +17,14 @@
  */
 package org.apache.flink.statefun.flink.core.functions;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.statefun.flink.core.di.Inject;
 import org.apache.flink.statefun.flink.core.di.Label;
@@ -26,41 +33,121 @@ import org.apache.flink.statefun.flink.core.message.Message;
 final class FlinkStateDelayedMessagesBuffer implements DelayedMessagesBuffer {
 
   static final String BUFFER_STATE_NAME = "delayed-messages-buffer";
+  static final String INDEX_STATE_NAME = "delayed-message-index";
 
   private final InternalListState<String, Long, Message> bufferState;
+  private final MapState<String, Long> messageIdToTimestamp;
 
   @Inject
   FlinkStateDelayedMessagesBuffer(
-      @Label("delayed-messages-buffer-state")
-          InternalListState<String, Long, Message> bufferState) {
+      @Label("delayed-messages-buffer-state") InternalListState<String, Long, Message> bufferState,
+      @Label("delayed-message-index") MapState<String, Long> messageIdToTimestamp) {
     this.bufferState = Objects.requireNonNull(bufferState);
+    this.messageIdToTimestamp = Objects.requireNonNull(messageIdToTimestamp);
+  }
+
+  @Override
+  public void forEachMessageAt(long timestamp, Consumer<Message> fn) {
+    try {
+      forEachMessageThrows(timestamp, fn);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public OptionalLong removeMessageByCancellationToken(String token) {
+    try {
+      return remove(token);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed clearing a message with id " + token, e);
+    }
   }
 
   @Override
   public void add(Message message, long untilTimestamp) {
-    bufferState.setCurrentNamespace(untilTimestamp);
     try {
-      bufferState.add(message);
+      addThrows(message, untilTimestamp);
     } catch (Exception e) {
       throw new RuntimeException("Error adding delayed message to state buffer: " + message, e);
     }
   }
 
-  @Override
-  public Iterable<Message> getForTimestamp(long timestamp) {
-    bufferState.setCurrentNamespace(timestamp);
+  // -----------------------------------------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------------------------------------
 
-    try {
-      return bufferState.get();
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Error accessing delayed message in state buffer for timestamp: " + timestamp, e);
+  private void forEachMessageThrows(long timestamp, Consumer<Message> fn) throws Exception {
+    bufferState.setCurrentNamespace(timestamp);
+    for (Message message : bufferState.get()) {
+      removeMessageIdMapping(message);
+      fn.accept(message);
+    }
+    bufferState.clear();
+  }
+
+  private void addThrows(Message message, long untilTimestamp) throws Exception {
+    bufferState.setCurrentNamespace(untilTimestamp);
+    bufferState.add(message);
+    Optional<String> maybeId = message.cancellationToken();
+    if (!maybeId.isPresent()) {
+      return;
+    }
+    String messageId = maybeId.get();
+    @Nullable Long previousTimestamp = messageIdToTimestamp.get(messageId);
+    if (previousTimestamp != null) {
+      throw new IllegalStateException(
+          "Trying to associate a message with id "
+              + messageId
+              + " and timestamp "
+              + untilTimestamp
+              + ", but a message with the same id exists and with a timestamp "
+              + previousTimestamp);
+    }
+    messageIdToTimestamp.put(messageId, untilTimestamp);
+  }
+
+  private OptionalLong remove(String cancellationToken) throws Exception {
+    final @Nullable Long untilTimestamp = messageIdToTimestamp.get(cancellationToken);
+    if (untilTimestamp == null) {
+      // The message associated with @cancellationToken has already been delivered, or previously
+      // removed.
+      return OptionalLong.empty();
+    }
+    messageIdToTimestamp.remove(cancellationToken);
+    bufferState.setCurrentNamespace(untilTimestamp);
+    List<Message> newList = removeMessageByToken(bufferState.get(), cancellationToken);
+    if (!newList.isEmpty()) {
+      // There are more messages to process, so we indicate to the caller that
+      // they should NOT cancel the timer.
+      bufferState.update(newList);
+      return OptionalLong.empty();
+    }
+    // There are no more message to remove, we clear the buffer and indicate
+    // to our caller to remove the timer for @untilTimestamp
+    bufferState.clear();
+    return OptionalLong.of(untilTimestamp);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------------------------
+
+  private void removeMessageIdMapping(Message message) throws Exception {
+    Optional<String> maybeToken = message.cancellationToken();
+    if (maybeToken.isPresent()) {
+      messageIdToTimestamp.remove(maybeToken.get());
     }
   }
 
-  @Override
-  public void clearForTimestamp(long timestamp) {
-    bufferState.setCurrentNamespace(timestamp);
-    bufferState.clear();
+  private static List<Message> removeMessageByToken(Iterable<Message> messages, String token) {
+    ArrayList<Message> newList = new ArrayList<>();
+    for (Message message : messages) {
+      Optional<String> thisMessageId = message.cancellationToken();
+      if (!thisMessageId.isPresent() || !Objects.equals(thisMessageId.get(), token)) {
+        newList.add(message);
+      }
+    }
+    return newList;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -104,6 +104,11 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
     final ListStateDescriptor<Message> delayedMessageStateDescriptor =
         new ListStateDescriptor<>(
             FlinkStateDelayedMessagesBuffer.BUFFER_STATE_NAME, envelopeSerializer.duplicate());
+    final MapStateDescriptor<String, Long> delayedMessageIndexDescriptor =
+        new MapStateDescriptor<>(
+            FlinkStateDelayedMessagesBuffer.INDEX_STATE_NAME, String.class, Long.class);
+    final MapState<String, Long> delayedMessageIndex =
+        getRuntimeContext().getMapState(delayedMessageIndexDescriptor);
     final MapState<Long, Message> asyncOperationState =
         getRuntimeContext().getMapState(asyncOperationStateDescriptor);
 
@@ -130,6 +135,7 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
             new FlinkTimerServiceFactory(
                 super.getTimeServiceManager().orElseThrow(IllegalStateException::new)),
             delayedMessagesBufferState(delayedMessageStateDescriptor),
+            delayedMessageIndex,
             sideOutputs,
             output,
             MessageFactory.forKey(statefulFunctionsUniverse.messageFactoryKey()),

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -62,6 +62,7 @@ final class Reductions {
       KeyedStateBackend<Object> keyedStateBackend,
       TimerServiceFactory timerServiceFactory,
       InternalListState<String, Long, Message> delayedMessagesBufferState,
+      MapState<String, Long> delayMessageIndex,
       Map<EgressIdentifier<?>, OutputTag<Object>> sideOutputs,
       Output<StreamRecord<Message>> output,
       MessageFactory messageFactory,
@@ -117,6 +118,7 @@ final class Reductions {
     // for delayed messages
     container.add(
         "delayed-messages-buffer-state", InternalListState.class, delayedMessagesBufferState);
+    container.add("delayed-message-index", MapState.class, delayMessageIndex);
     container.add(
         "delayed-messages-buffer",
         DelayedMessagesBuffer.class,
@@ -124,6 +126,7 @@ final class Reductions {
     container.add(
         "delayed-messages-timer-service-factory", TimerServiceFactory.class, timerServiceFactory);
     container.add(DelaySink.class);
+    container.add(DelayMessageHandler.class);
 
     // lazy providers for the sinks
     container.add("function-group", new Lazy<>(LocalFunctionGroup.class));

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/ReusableContext.java
@@ -109,6 +109,23 @@ final class ReusableContext implements ApplyingContext, InternalContext {
   }
 
   @Override
+  public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {
+    Objects.requireNonNull(delay);
+    Objects.requireNonNull(to);
+    Objects.requireNonNull(message);
+    Objects.requireNonNull(cancellationToken);
+
+    Message envelope = messageFactory.from(self(), to, message, cancellationToken);
+    delaySink.accept(envelope, delay.toMillis());
+  }
+
+  @Override
+  public void cancelDelayedMessage(String cancellationToken) {
+    Objects.requireNonNull(cancellationToken);
+    delaySink.removeMessageByCancellationToken(cancellationToken);
+  }
+
+  @Override
   public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {
     Objects.requireNonNull(metadata);
     Objects.requireNonNull(future);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/Message.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/Message.java
@@ -18,6 +18,7 @@
 package org.apache.flink.statefun.flink.core.message;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.OptionalLong;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -34,6 +35,8 @@ public interface Message extends RoutableMessage {
    * Payload}) this method returns an empty {@code Optional}.
    */
   OptionalLong isBarrierMessage();
+
+  Optional<String> cancellationToken();
 
   Message copy(MessageFactory context);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessageFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/MessageFactory.java
@@ -54,6 +54,10 @@ public final class MessageFactory {
     return new SdkMessage(from, to, payload);
   }
 
+  public Message from(Address from, Address to, Object payload, String messageId) {
+    return new SdkMessage(from, to, payload, messageId);
+  }
+
   // -------------------------------------------------------------------------------------------------------
 
   void copy(DataInputView source, DataOutputView target) throws IOException {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/ProtobufMessage.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/ProtobufMessage.java
@@ -19,6 +19,7 @@ package org.apache.flink.statefun.flink.core.message;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import javax.annotation.Nullable;
 import org.apache.flink.core.memory.DataOutputView;
@@ -79,6 +80,15 @@ final class ProtobufMessage implements Message {
     }
     final long checkpointId = envelope.getCheckpoint().getCheckpointId();
     return OptionalLong.of(checkpointId);
+  }
+
+  @Override
+  public Optional<String> cancellationToken() {
+    String token = envelope.getCancellationToken();
+    if (token.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(token);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/protobuf/stateful-functions.proto
+++ b/statefun-flink/statefun-flink-core/src/main/protobuf/stateful-functions.proto
@@ -37,9 +37,13 @@ message Checkpoint {
     int64 checkpoint_id = 1;
 }
 
+
 message Envelope {
     EnvelopeAddress source = 1;
     EnvelopeAddress target = 2;
+
+    // an optional token that can be used track delayed message cancellation.
+    string cancellation_token = 10;
 
     oneof body {
         Checkpoint checkpoint = 4;

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/LocalStatefulFunctionGroupTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/LocalStatefulFunctionGroupTest.java
@@ -133,6 +133,12 @@ public class LocalStatefulFunctionGroupTest {
     public void sendAfter(Duration duration, Address to, Object message) {}
 
     @Override
+    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
+
+    @Override
+    public void cancelDelayedMessage(String cancellationToken) {}
+
+    @Override
     public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
 
     @Override

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -100,12 +100,13 @@ public class ReductionsTest {
             new FakeKeyedStateBackend(),
             new FakeTimerServiceFactory(),
             new FakeInternalListState(),
+            new FakeMapState<>(),
             new HashMap<>(),
             new FakeOutput(),
             TestUtils.ENVELOPE_FACTORY,
             MoreExecutors.directExecutor(),
             new FakeMetricGroup(),
-            new FakeMapState());
+            new FakeMapState<>());
 
     assertThat(reductions, notNullValue());
   }
@@ -517,44 +518,44 @@ public class ReductionsTest {
     }
   }
 
-  private static final class FakeMapState implements MapState<Long, Message> {
+  private static final class FakeMapState<K, V> implements MapState<K, V> {
 
     @Override
-    public Message get(Long key) throws Exception {
+    public V get(K key) throws Exception {
       return null;
     }
 
     @Override
-    public void put(Long key, Message value) throws Exception {}
+    public void put(K key, V value) throws Exception {}
 
     @Override
-    public void putAll(Map<Long, Message> map) throws Exception {}
+    public void putAll(Map<K, V> map) throws Exception {}
 
     @Override
-    public void remove(Long key) throws Exception {}
+    public void remove(K key) throws Exception {}
 
     @Override
-    public boolean contains(Long key) throws Exception {
+    public boolean contains(K key) throws Exception {
       return false;
     }
 
     @Override
-    public Iterable<Entry<Long, Message>> entries() throws Exception {
+    public Iterable<Entry<K, V>> entries() throws Exception {
       return null;
     }
 
     @Override
-    public Iterable<Long> keys() throws Exception {
+    public Iterable<K> keys() throws Exception {
       return null;
     }
 
     @Override
-    public Iterable<Message> values() throws Exception {
+    public Iterable<V> values() throws Exception {
       return null;
     }
 
     @Override
-    public Iterator<Entry<Long, Message>> iterator() throws Exception {
+    public Iterator<Entry<K, V>> iterator() throws Exception {
       return null;
     }
 

--- a/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/Context.java
+++ b/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/Context.java
@@ -75,6 +75,33 @@ public interface Context {
   void sendAfter(Duration delay, Address to, Object message);
 
   /**
+   * Invokes another function with an input (associated with a {@code cancellationToken}),
+   * identified by the target function's {@link Address}, after a given delay.
+   *
+   * <p>Providing an id to a message, allows "unsending" this message later. ({@link
+   * #cancelDelayedMessage(String)}).
+   *
+   * @param delay the amount of delay before invoking the target function. Value needs to be &gt;=
+   *     0.
+   * @param to the target function's address.
+   * @param message the input to provide for the delayed invocation.
+   * @param cancellationToken the non-empty, non-null, unique token to attach to this message, to be
+   *     used for message cancellation. (see {@link #cancelDelayedMessage(String)}.)
+   */
+  void sendAfter(Duration delay, Address to, Object message, String cancellationToken);
+
+  /**
+   * Cancel a delayed message (a message that was send via {@link #sendAfter(Duration, Address,
+   * Object, String)}).
+   *
+   * <p>NOTE: this is a best-effort operation, since the message might have been already delivered.
+   * If the message was delivered, this is a no-op operation.
+   *
+   * @param cancellationToken the id of the message to un-send.
+   */
+  void cancelDelayedMessage(String cancellationToken);
+
+  /**
    * Invokes another function with an input, identified by the target function's {@link
    * FunctionType} and unique id.
    *

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Context.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Context.java
@@ -56,6 +56,26 @@ public interface Context {
   void sendAfter(Duration duration, Message message);
 
   /**
+   * Sends out a {@link Message} to another function, after a specified {@link Duration} delay.
+   *
+   * @param duration the amount of time to delay the message delivery. * @param cancellationToken
+   * @param cancellationToken the non-empty, non-null, unique token to attach to this message, to be
+   *     used for message cancellation. (see {@link #cancelDelayedMessage(String)}.)
+   * @param message the message to send.
+   */
+  void sendAfter(Duration duration, String cancellationToken, Message message);
+
+  /**
+   * Cancel a delayed message (a message that was send via {@link #sendAfter(Duration, Message)}).
+   *
+   * <p>NOTE: this is a best-effort operation, since the message might have been already delivered.
+   * If the message was delivered, this is a no-op operation.
+   *
+   * @param cancellationToken the id of the message to un-send.
+   */
+  void cancelDelayedMessage(String cancellationToken);
+
+  /**
    * Sends out a {@link EgressMessage} to an egress.
    *
    * @param message the message to send.

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContext.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContext.java
@@ -143,12 +143,15 @@ final class ConcurrentContext implements Context {
       throw new IllegalArgumentException("message cancellation token can not be empty or null.");
     }
 
-    FromFunction.DelayCancellation cancellation =
-        FromFunction.DelayCancellation.newBuilder().setCancellationToken(cancellationToken).build();
+    FromFunction.DelayedInvocation cancellation =
+        FromFunction.DelayedInvocation.newBuilder()
+            .setIsCancellationRequest(true)
+            .setCancellationToken(cancellationToken)
+            .build();
 
     synchronized (responseBuilder) {
       checkNotDone();
-      responseBuilder.addOutgoingDelayCancellations(cancellation);
+      responseBuilder.addDelayedInvocations(cancellation);
     }
   }
 

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContext.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContext.java
@@ -116,6 +116,43 @@ final class ConcurrentContext implements Context {
   }
 
   @Override
+  public void sendAfter(Duration duration, String cancellationToken, Message message) {
+    Objects.requireNonNull(duration);
+    if (cancellationToken == null || cancellationToken.isEmpty()) {
+      throw new IllegalArgumentException("message cancellation token can not be empty or null.");
+    }
+    Objects.requireNonNull(message);
+
+    FromFunction.DelayedInvocation outInvocation =
+        FromFunction.DelayedInvocation.newBuilder()
+            .setArgument(getTypedValue(message))
+            .setTarget(protoAddressFromSdk(message.targetAddress()))
+            .setDelayInMs(duration.toMillis())
+            .setCancellationToken(cancellationToken)
+            .build();
+
+    synchronized (responseBuilder) {
+      checkNotDone();
+      responseBuilder.addDelayedInvocations(outInvocation);
+    }
+  }
+
+  @Override
+  public void cancelDelayedMessage(String cancellationToken) {
+    if (cancellationToken == null || cancellationToken.isEmpty()) {
+      throw new IllegalArgumentException("message cancellation token can not be empty or null.");
+    }
+
+    FromFunction.DelayCancellation cancellation =
+        FromFunction.DelayCancellation.newBuilder().setCancellationToken(cancellationToken).build();
+
+    synchronized (responseBuilder) {
+      checkNotDone();
+      responseBuilder.addOutgoingDelayCancellations(cancellation);
+    }
+  }
+
+  @Override
   public void send(EgressMessage message) {
     Objects.requireNonNull(message);
 

--- a/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
+++ b/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
@@ -115,8 +115,15 @@ message FromFunction {
     // DelayedInvocation represents a delayed remote function call with a target address, an argument
     // and a delay in milliseconds, after which this message to be sent.
     message DelayedInvocation {
+        // a boolean value (default false) that indicates rather this is a regular delayed message, or (true) a message
+        // cancellation request.
+        // in case of a regular delayed message all other fields are expected to be preset, otherwise only the
+        // cancellation_token is expected
+        bool is_cancellation_request = 10;
+
         // an optional cancellation token that can be used to request the "unsending" of a delayed message.
-        string cancellation_token = 10;
+        string cancellation_token = 11;
+
         // the amount of milliseconds to wait before sending this message
         int64 delay_in_ms = 1;
         // the target address to send this message to
@@ -137,11 +144,6 @@ message FromFunction {
         TypedValue argument = 3;
     }
 
-    // DelayCancellation represents a single delayed-message cancellation request.
-    message DelayCancellation {
-        string cancellation_token = 1;
-    }
-
     // InvocationResponse represents a result of an io.statefun.sdk.reqreply.ToFunction.InvocationBatchRequest
     // it contains a list of state mutation to preform as a result of computing this batch, and a list of outgoing messages.
     message InvocationResponse {
@@ -149,7 +151,6 @@ message FromFunction {
         repeated Invocation outgoing_messages = 2;
         repeated DelayedInvocation delayed_invocations = 3;
         repeated EgressMessage outgoing_egresses = 4;
-        repeated DelayCancellation outgoing_delay_cancellations = 5;
     }
 
     // ExpirationSpec represents TTL (Time-To-Live) configuration for persisted states.

--- a/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
+++ b/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
@@ -115,6 +115,8 @@ message FromFunction {
     // DelayedInvocation represents a delayed remote function call with a target address, an argument
     // and a delay in milliseconds, after which this message to be sent.
     message DelayedInvocation {
+        // an optional cancellation token that can be used to request the "unsending" of a delayed message.
+        string cancellation_token = 10;
         // the amount of milliseconds to wait before sending this message
         int64 delay_in_ms = 1;
         // the target address to send this message to
@@ -135,6 +137,11 @@ message FromFunction {
         TypedValue argument = 3;
     }
 
+    // DelayCancellation represents a single delayed-message cancellation request.
+    message DelayCancellation {
+        string cancellation_token = 1;
+    }
+
     // InvocationResponse represents a result of an io.statefun.sdk.reqreply.ToFunction.InvocationBatchRequest
     // it contains a list of state mutation to preform as a result of computing this batch, and a list of outgoing messages.
     message InvocationResponse {
@@ -142,6 +149,7 @@ message FromFunction {
         repeated Invocation outgoing_messages = 2;
         repeated DelayedInvocation delayed_invocations = 3;
         repeated EgressMessage outgoing_egresses = 4;
+        repeated DelayCancellation outgoing_delay_cancellations = 5;
     }
 
     // ExpirationSpec represents TTL (Time-To-Live) configuration for persisted states.

--- a/statefun-sdk-python/statefun/context.py
+++ b/statefun-sdk-python/statefun/context.py
@@ -24,7 +24,6 @@ from statefun.messages import Message, EgressMessage
 
 
 class Context(abc.ABC):
-
     __slots__ = ()
 
     @property
@@ -62,13 +61,24 @@ class Context(abc.ABC):
         """
         pass
 
-    def send_after(self, duration: timedelta, message: Message):
+    def send_after(self, duration: timedelta, message: Message, cancellation_token: str = ""):
         """
         Send a message to a target function after a specified delay.
 
         :param duration: the amount of time to wait before sending this message out.
         :param message: the message to send.
+        :param cancellation_token: an optional cancellation token to associate with this message.
         """
+        pass
+
+    def cancel_delayed_message(self, cancellation_token: str):
+        """
+        Cancel a delayed message (message that was sent using send_after) with a given token.
+
+        Please note that this is a best-effort operation, since the message might have been already delivered.
+        If the message was delivered, this is a no-op operation.
+        """
+        pass
 
     def send_egress(self, message: EgressMessage):
         """

--- a/statefun-sdk-python/tests/request_reply_test.py
+++ b/statefun-sdk-python/tests/request_reply_test.py
@@ -181,7 +181,8 @@ class RequestReplyTestCase(unittest.TestCase):
         self.assertEqual(second_delayed['cancellation_token'], "token-1234")
 
         # assert cancellation
-        first_cancellation = json_at(result_json, NTH_CANCELLATION_MESSAGE(0))
+        first_cancellation = json_at(result_json, NTH_DELAYED_MESSAGE(2))
+        self.assertTrue(first_cancellation['is_cancellation_request'])
         self.assertEqual(first_cancellation['cancellation_token'], "token-1234")
 
         # assert egresses


### PR DESCRIPTION
### This PR adds the ability to cancel delayed messages.

- see [FLINK-21308](https://issues.apache.org/jira/browse/FLINK-21308) for the detailed use case that drives this PR.

## High level changes

This PR introduces the following methods in the embedded SDK, and the corresponding remote SDKs (language specific flavors)


```java
/**
   * Invokes another function with an input (associated with a {@code cancellationToken}),
   * identified by the target function's {@link Address}, after a given delay.
   *
   * <p>Providing an id to a message, allows "unsending" this message later. ({@link
   * #cancelDelayedMessage(String)}).
   *
   * @param delay the amount of delay before invoking the target function. Value needs to be &gt;=
   *     0.
   * @param to the target function's address.
   * @param message the input to provide for the delayed invocation.
   * @param cancellationToken the non-empty, non-null, unique token to attach to this message, to be
   *     used for message cancellation. (see {@link #cancelDelayedMessage(String)}.)
   */
  void sendAfter(Duration delay, Address to, Object message, String cancellationToken);

  /**
   * Cancel a delayed message (a message that was send via {@link #sendAfter(Duration, Address,
   * Object, String)}).
   *
   * <p>NOTE: this is a best-effort operation, since the message might have been already delivered.
   * If the message was delivered, this is a no-op operation.
   *
   * @param cancellationToken the id of the message to un-send.
   */
  void cancelDelayedMessage(String cancellationToken);
```

* The semantic of the cancellation token is opaque to StateFun, its content and uniqueness is completely user defined.
* violating uniqueness constraint for two different methods will result in a runtime error.
* Once the delayed message has been dispatched, the cancellation token is forgotten.

### Internal Changes

## request reply protocol:

We attach the (optional) `cancelltion_token` to the delayed invocation in the request-reply protocol.

```protobuf
// DelayedInvocation represents a delayed remote function call with a target address, an argument
// and a delay in milliseconds, after which this message to be sent.
    message DelayedInvocation {
        // an optional cancellation token that can be used to request the "unsending" of a delayed message.
        string cancellation_token = 10;
        // the amount of milliseconds to wait before sending this message
        int64 delay_in_ms = 1;
        // the target address to send this message to
        Address target = 2;
        // the invocation argument
        TypedValue argument = 3;
    }
```

In addition, a new response message:

```protobuf
// DelayCancellation represents a single delayed-message cancellation request.
message DelayCancellation {
        string cancellation_token = 1;
}
```

## State

We add an additional state handle (`delayed-message-index`) to keep track of the mapping between a `cancellation_token` and the absolute timestamp that this message needs to be dispatched at.



These changes are then wired throughout the SDK and the runtime to make the magic happen.

  
