### PR TITLE
[FLINK-23293] [core] Support extendable transports for remote invocations

### DIFF
--- a/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/Selectors.java
+++ b/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/Selectors.java
@@ -23,9 +23,21 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.util.TimeUtils;
 
 public final class Selectors {
+
+  public static Optional<ObjectNode> optionalObjectAt(JsonNode node, JsonPointer pointer) {
+    node = node.at(pointer);
+    if (node.isMissingNode()) {
+      return Optional.empty();
+    }
+    if (!node.isObject()) {
+      throw new WrongTypeException(pointer, "not an object");
+    }
+    return Optional.of((ObjectNode) node);
+  }
 
   public static String textAt(JsonNode node, JsonPointer pointer) {
     node = dereference(node, pointer);

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverse.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverse.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.flink.core.types.StaticallyRegisteredTypes;
 import org.apache.flink.statefun.flink.io.spi.FlinkIoModule;
 import org.apache.flink.statefun.flink.io.spi.SinkProvider;
@@ -40,7 +41,6 @@ import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.io.Router;
 import org.apache.flink.statefun.sdk.spi.ExtensionModule;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 
 public final class StatefulFunctionsUniverse

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
@@ -39,14 +39,14 @@ import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
 import org.apache.flink.util.IOUtils;
 
-final class HttpRequestReplyClient implements RequestReplyClient {
+final class DefaultHttpRequestReplyClient implements RequestReplyClient {
   private static final MediaType MEDIA_TYPE_BINARY = MediaType.parse("application/octet-stream");
 
   private final HttpUrl url;
   private final OkHttpClient client;
   private final BooleanSupplier isShutdown;
 
-  HttpRequestReplyClient(HttpUrl url, OkHttpClient client, BooleanSupplier isShutdown) {
+  DefaultHttpRequestReplyClient(HttpUrl url, OkHttpClient client, BooleanSupplier isShutdown) {
     this.url = Objects.requireNonNull(url);
     this.client = Objects.requireNonNull(client);
     this.isShutdown = Objects.requireNonNull(isShutdown);
@@ -67,7 +67,7 @@ final class HttpRequestReplyClient implements RequestReplyClient {
     RetryingCallback callback =
         new RetryingCallback(requestSummary, metrics, newCall.timeout(), isShutdown);
     callback.attachToCall(newCall);
-    return callback.future().thenApply(HttpRequestReplyClient::parseResponse);
+    return callback.future().thenApply(DefaultHttpRequestReplyClient::parseResponse);
   }
 
   private static FromFunction parseResponse(Response response) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.apache.flink.statefun.flink.core.httpfn.OkHttpUnixSocketBridge.configureUnixDomainSocket;
+
+import java.net.URI;
+import javax.annotation.Nullable;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
+
+public final class DefaultHttpRequestReplyClientFactory implements RequestReplyClientFactory {
+
+  /** Unknown fields in client properties are silently ignored. */
+  private static final ObjectMapper OBJ_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  /** lazily initialized by {@link #createTransportClient} */
+  @Nullable private OkHttpClient sharedClient;
+
+  private volatile boolean shutdown;
+
+  @Override
+  public RequestReplyClient createTransportClient(ObjectNode transportProperties, URI endpointUrl) {
+    if (sharedClient == null) {
+      sharedClient = OkHttpUtils.newClient();
+    }
+    final OkHttpClient.Builder clientBuilder = sharedClient.newBuilder();
+
+    final DefaultHttpRequestReplyClientSpec transportClientSpec =
+        parseTransportProperties(transportProperties);
+
+    clientBuilder.callTimeout(transportClientSpec.getTimeouts().getCallTimeout());
+    clientBuilder.connectTimeout(transportClientSpec.getTimeouts().getConnectTimeout());
+    clientBuilder.readTimeout(transportClientSpec.getTimeouts().getReadTimeout());
+    clientBuilder.writeTimeout(transportClientSpec.getTimeouts().getWriteTimeout());
+
+    final HttpUrl url;
+    if (UnixDomainHttpEndpoint.validate(endpointUrl)) {
+      UnixDomainHttpEndpoint endpoint = UnixDomainHttpEndpoint.parseFrom(endpointUrl);
+
+      url =
+          new HttpUrl.Builder()
+              .scheme("http")
+              .host("unused")
+              .addPathSegment(endpoint.pathSegment)
+              .build();
+
+      configureUnixDomainSocket(clientBuilder, endpoint.unixDomainFile);
+    } else {
+      url = HttpUrl.get(endpointUrl);
+    }
+    return new DefaultHttpRequestReplyClient(url, clientBuilder.build(), () -> shutdown);
+  }
+
+  @Override
+  public void cleanup() {
+    if (!shutdown) {
+      shutdown = true;
+      OkHttpUtils.closeSilently(sharedClient);
+    }
+  }
+
+  private static DefaultHttpRequestReplyClientSpec parseTransportProperties(
+      ObjectNode transportClientProperties) {
+    try {
+      return OBJ_MAPPER.treeToValue(
+          transportClientProperties, DefaultHttpRequestReplyClientSpec.class);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Unable to parse transport client properties when creating client: ", e);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactory.java
@@ -28,7 +28,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Deseriali
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.statefun.flink.common.SetContextClassLoader;
-import org.apache.flink.statefun.flink.core.reqreply.ContextSafeRequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.ClassLoaderSafeRequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
 
@@ -50,7 +50,7 @@ public final class DefaultHttpRequestReplyClientFactory implements RequestReplyC
     if (Thread.currentThread().getContextClassLoader() == getClass().getClassLoader()) {
       return client;
     } else {
-      return new ContextSafeRequestReplyClient(client);
+      return new ClassLoaderSafeRequestReplyClient(client);
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpec.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSetter;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.util.TimeUtils;
+
+public final class DefaultHttpRequestReplyClientSpec {
+
+  @JsonProperty("timeouts")
+  private Timeouts timeouts = new Timeouts();
+
+  @JsonSetter("timeouts")
+  public void setTimeouts(Timeouts timeouts) {
+    validateTimeouts(
+        timeouts.callTimeout, timeouts.connectTimeout, timeouts.readTimeout, timeouts.writeTimeout);
+    this.timeouts = timeouts;
+  }
+
+  public Timeouts getTimeouts() {
+    return timeouts;
+  }
+
+  private static void validateTimeouts(
+      Duration callTimeout, Duration connectTimeout, Duration readTimeout, Duration writeTimeout) {
+
+    if (connectTimeout.compareTo(callTimeout) > 0) {
+      throw new IllegalArgumentException("Connect timeout cannot be larger than request timeout.");
+    }
+
+    if (readTimeout.compareTo(callTimeout) > 0) {
+      throw new IllegalArgumentException("Read timeout cannot be larger than request timeout.");
+    }
+
+    if (writeTimeout.compareTo(callTimeout) > 0) {
+      throw new IllegalArgumentException("Write timeout cannot be larger than request timeout.");
+    }
+  }
+
+  public static final class Timeouts {
+
+    private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_HTTP_READ_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_HTTP_WRITE_TIMEOUT = Duration.ofSeconds(10);
+
+    private Duration callTimeout = DEFAULT_HTTP_TIMEOUT;
+    private Duration connectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT;
+    private Duration readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
+    private Duration writeTimeout = DEFAULT_HTTP_WRITE_TIMEOUT;
+
+    @JsonSetter("call")
+    @JsonDeserialize(using = DurationJsonDeserialize.class)
+    public void setCallTimeout(Duration callTimeout) {
+      this.callTimeout = requireNonZeroDuration(callTimeout);
+    }
+
+    @JsonSetter("connect")
+    @JsonDeserialize(using = DurationJsonDeserialize.class)
+    public void setConnectTimeout(Duration connectTimeout) {
+      this.connectTimeout = requireNonZeroDuration(connectTimeout);
+    }
+
+    @JsonSetter("read")
+    @JsonDeserialize(using = DurationJsonDeserialize.class)
+    public void setReadTimeout(Duration readTimeout) {
+      this.readTimeout = requireNonZeroDuration(readTimeout);
+    }
+
+    @JsonSetter("write")
+    @JsonDeserialize(using = DurationJsonDeserialize.class)
+    public void setWriteTimeout(Duration writeTimeout) {
+      this.writeTimeout = requireNonZeroDuration(writeTimeout);
+    }
+
+    public Duration getCallTimeout() {
+      return callTimeout;
+    }
+
+    public Duration getConnectTimeout() {
+      return connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+      return readTimeout;
+    }
+
+    public Duration getWriteTimeout() {
+      return writeTimeout;
+    }
+
+    private static Duration requireNonZeroDuration(Duration duration) {
+      Objects.requireNonNull(duration);
+      if (duration.equals(Duration.ZERO)) {
+        throw new IllegalArgumentException("Timeout durations must be larger than 0.");
+      }
+
+      return duration;
+    }
+  }
+
+  private static final class DurationJsonDeserialize extends JsonDeserializer<Duration> {
+    @Override
+    public Duration deserialize(
+        JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+      return TimeUtils.parseDuration(jsonParser.getText());
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
@@ -18,28 +18,32 @@
 package org.apache.flink.statefun.flink.core.httpfn;
 
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.Objects;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
 
 public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Serializable {
 
   private static final long serialVersionUID = 1;
 
-  private static final Duration DEFAULT_HTTP_TIMEOUT = Duration.ofMinutes(1);
-  private static final Duration DEFAULT_HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
-  private static final Duration DEFAULT_HTTP_READ_TIMEOUT = Duration.ofSeconds(10);
-  private static final Duration DEFAULT_HTTP_WRITE_TIMEOUT = Duration.ofSeconds(10);
   private static final Integer DEFAULT_MAX_NUM_BATCH_REQUESTS = 1000;
+
+  // ============================================================
+  //  Request-Reply invocation protocol configurations
+  // ============================================================
 
   private final Target target;
   private final UrlPathTemplate urlPathTemplate;
-
-  private final Duration maxRequestDuration;
-  private final Duration connectTimeout;
-  private final Duration readTimeout;
-  private final Duration writeTimeout;
   private final int maxNumBatchRequests;
+
+  // ============================================================
+  //  HTTP transport related properties
+  // ============================================================
+
+  private final RequestReplyClientFactory transportClientFactory;
+  private final ObjectNode transportClientProps;
 
   public static Builder builder(Target target, UrlPathTemplate urlPathTemplate) {
     return new Builder(target, urlPathTemplate);
@@ -48,18 +52,14 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
   private HttpFunctionEndpointSpec(
       Target target,
       UrlPathTemplate urlPathTemplate,
-      Duration maxRequestDuration,
-      Duration connectTimeout,
-      Duration readTimeout,
-      Duration writeTimeout,
-      int maxNumBatchRequests) {
+      int maxNumBatchRequests,
+      RequestReplyClientFactory transportClientFactory,
+      ObjectNode transportClientProps) {
     this.target = target;
     this.urlPathTemplate = urlPathTemplate;
-    this.maxRequestDuration = maxRequestDuration;
-    this.connectTimeout = connectTimeout;
-    this.readTimeout = readTimeout;
-    this.writeTimeout = writeTimeout;
     this.maxNumBatchRequests = maxNumBatchRequests;
+    this.transportClientFactory = transportClientFactory;
+    this.transportClientProps = transportClientProps;
   }
 
   @Override
@@ -77,60 +77,31 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
     return urlPathTemplate;
   }
 
-  public Duration maxRequestDuration() {
-    return maxRequestDuration;
-  }
-
-  public Duration connectTimeout() {
-    return connectTimeout;
-  }
-
-  public Duration readTimeout() {
-    return readTimeout;
-  }
-
-  public Duration writeTimeout() {
-    return writeTimeout;
-  }
-
   public int maxNumBatchRequests() {
     return maxNumBatchRequests;
+  }
+
+  public RequestReplyClientFactory transportClientFactory() {
+    return transportClientFactory;
+  }
+
+  public ObjectNode transportClientProperties() {
+    return transportClientProps;
   }
 
   public static final class Builder {
 
     private final Target target;
     private final UrlPathTemplate urlPathTemplate;
-
-    private Duration maxRequestDuration = DEFAULT_HTTP_TIMEOUT;
-    private Duration connectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT;
-    private Duration readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
-    private Duration writeTimeout = DEFAULT_HTTP_WRITE_TIMEOUT;
     private int maxNumBatchRequests = DEFAULT_MAX_NUM_BATCH_REQUESTS;
+
+    private RequestReplyClientFactory transportClientFactory =
+        new DefaultHttpRequestReplyClientFactory();
+    private ObjectNode transportClientProperties = new ObjectMapper().createObjectNode();
 
     private Builder(Target target, UrlPathTemplate urlPathTemplate) {
       this.target = Objects.requireNonNull(target);
       this.urlPathTemplate = Objects.requireNonNull(urlPathTemplate);
-    }
-
-    public Builder withMaxRequestDuration(Duration duration) {
-      this.maxRequestDuration = requireNonZeroDuration(duration);
-      return this;
-    }
-
-    public Builder withConnectTimeoutDuration(Duration duration) {
-      this.connectTimeout = requireNonZeroDuration(duration);
-      return this;
-    }
-
-    public Builder withReadTimeoutDuration(Duration duration) {
-      this.readTimeout = requireNonZeroDuration(duration);
-      return this;
-    }
-
-    public Builder withWriteTimeoutDuration(Duration duration) {
-      this.writeTimeout = requireNonZeroDuration(duration);
-      return this;
     }
 
     public Builder withMaxNumBatchRequests(int maxNumBatchRequests) {
@@ -138,41 +109,24 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
       return this;
     }
 
+    public Builder withTransportClientFactory(RequestReplyClientFactory transportClientFactory) {
+      this.transportClientFactory = Objects.requireNonNull(transportClientFactory);
+      return this;
+    }
+
+    public Builder withTransportClientProperties(ObjectNode transportClientProperties) {
+      this.transportClientProperties = Objects.requireNonNull(transportClientProperties);
+      return this;
+    }
+
     public HttpFunctionEndpointSpec build() {
-      validateTimeouts();
 
       return new HttpFunctionEndpointSpec(
           target,
           urlPathTemplate,
-          maxRequestDuration,
-          connectTimeout,
-          readTimeout,
-          writeTimeout,
-          maxNumBatchRequests);
-    }
-
-    private Duration requireNonZeroDuration(Duration duration) {
-      Objects.requireNonNull(duration);
-      if (duration.equals(Duration.ZERO)) {
-        throw new IllegalArgumentException("Timeout durations must be larger than 0.");
-      }
-
-      return duration;
-    }
-
-    private void validateTimeouts() {
-      if (connectTimeout.compareTo(maxRequestDuration) > 0) {
-        throw new IllegalArgumentException(
-            "Connect timeout cannot be larger than request timeout.");
-      }
-
-      if (readTimeout.compareTo(maxRequestDuration) > 0) {
-        throw new IllegalArgumentException("Read timeout cannot be larger than request timeout.");
-      }
-
-      if (writeTimeout.compareTo(maxRequestDuration) > 0) {
-        throw new IllegalArgumentException("Write timeout cannot be larger than request timeout.");
-      }
+          maxNumBatchRequests,
+          transportClientFactory,
+          transportClientProperties);
     }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
@@ -17,12 +17,14 @@
  */
 package org.apache.flink.statefun.flink.core.httpfn;
 
+import static org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE;
+
 import java.io.Serializable;
 import java.util.Objects;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec;
-import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
+import org.apache.flink.statefun.sdk.TypeName;
 
 public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Serializable {
 
@@ -42,7 +44,7 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
   //  HTTP transport related properties
   // ============================================================
 
-  private final RequestReplyClientFactory transportClientFactory;
+  private final TypeName transportClientFactoryType;
   private final ObjectNode transportClientProps;
 
   public static Builder builder(Target target, UrlPathTemplate urlPathTemplate) {
@@ -53,12 +55,12 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
       Target target,
       UrlPathTemplate urlPathTemplate,
       int maxNumBatchRequests,
-      RequestReplyClientFactory transportClientFactory,
+      TypeName transportClientFactoryType,
       ObjectNode transportClientProps) {
     this.target = target;
     this.urlPathTemplate = urlPathTemplate;
     this.maxNumBatchRequests = maxNumBatchRequests;
-    this.transportClientFactory = transportClientFactory;
+    this.transportClientFactoryType = transportClientFactoryType;
     this.transportClientProps = transportClientProps;
   }
 
@@ -81,8 +83,8 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
     return maxNumBatchRequests;
   }
 
-  public RequestReplyClientFactory transportClientFactory() {
-    return transportClientFactory;
+  public TypeName transportClientFactoryType() {
+    return transportClientFactoryType;
   }
 
   public ObjectNode transportClientProperties() {
@@ -95,8 +97,7 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
     private final UrlPathTemplate urlPathTemplate;
     private int maxNumBatchRequests = DEFAULT_MAX_NUM_BATCH_REQUESTS;
 
-    private RequestReplyClientFactory transportClientFactory =
-        new DefaultHttpRequestReplyClientFactory();
+    private TypeName transportClientFactoryType = OKHTTP_CLIENT_FACTORY_TYPE;
     private ObjectNode transportClientProperties = new ObjectMapper().createObjectNode();
 
     private Builder(Target target, UrlPathTemplate urlPathTemplate) {
@@ -109,8 +110,8 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
       return this;
     }
 
-    public Builder withTransportClientFactory(RequestReplyClientFactory transportClientFactory) {
-      this.transportClientFactory = Objects.requireNonNull(transportClientFactory);
+    public Builder withTransportClientFactoryType(TypeName transportClientFactoryType) {
+      this.transportClientFactoryType = Objects.requireNonNull(transportClientFactoryType);
       return this;
     }
 
@@ -125,7 +126,7 @@ public final class HttpFunctionEndpointSpec implements FunctionEndpointSpec, Ser
           target,
           urlPathTemplate,
           maxNumBatchRequests,
-          transportClientFactory,
+          transportClientFactoryType,
           transportClientProperties);
     }
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -99,7 +99,7 @@ public final class HttpFunctionProvider implements StatefulFunctionProvider, Man
     } else {
       url = HttpUrl.get(endpointUrl);
     }
-    return new HttpRequestReplyClient(url, clientBuilder.build(), () -> shutdown);
+    return new DefaultHttpRequestReplyClient(url, clientBuilder.build(), () -> shutdown);
   }
 
   @Override

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -22,9 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.flink.statefun.flink.common.SetContextClassLoader;
 import org.apache.flink.statefun.flink.core.common.ManagingResources;
-import org.apache.flink.statefun.flink.core.reqreply.ContextSafeRequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyFunction;
@@ -73,30 +71,12 @@ public final class HttpFunctionProvider implements StatefulFunctionProvider, Man
     final RequestReplyClientFactory factory = endpointsSpec.transportClientFactory();
     final ObjectNode properties = endpointsSpec.transportClientProperties();
 
-    if (Thread.currentThread().getContextClassLoader() == factory.getClass().getClassLoader()) {
-      // in this case, we're using one of our own shipped transport client factory
-      return factory.createTransportClient(properties, endpointUrl);
-    } else {
-      try (SetContextClassLoader ignored = new SetContextClassLoader(factory)) {
-        return new ContextSafeRequestReplyClient(
-            factory.createTransportClient(properties, endpointUrl));
-      }
-    }
+    return factory.createTransportClient(properties, endpointUrl);
   }
 
   @Override
   public void shutdown() {
-    specificTypeEndpointSpecs
-        .values()
-        .forEach(spec -> shutdownTransportClientFactory(spec.transportClientFactory()));
-    perNamespaceEndpointSpecs
-        .values()
-        .forEach(spec -> shutdownTransportClientFactory(spec.transportClientFactory()));
-  }
-
-  private static void shutdownTransportClientFactory(RequestReplyClientFactory factory) {
-    try (SetContextClassLoader ignored = new SetContextClassLoader(factory)) {
-      factory.cleanup();
-    }
+    specificTypeEndpointSpecs.values().forEach(spec -> spec.transportClientFactory().cleanup());
+    perNamespaceEndpointSpecs.values().forEach(spec -> spec.transportClientFactory().cleanup());
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientConstants.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import org.apache.flink.statefun.sdk.TypeName;
+
+public final class TransportClientConstants {
+
+  public static final TypeName OKHTTP_CLIENT_FACTORY_TYPE =
+      TypeName.parseFrom("io.statefun.transports/okhttp");
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientsModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientsModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import org.apache.flink.statefun.sdk.spi.ExtensionModule;
+
+@AutoService(ExtensionModule.class)
+public class TransportClientsModule implements ExtensionModule {
+  @Override
+  public void configure(Map<String, String> globalConfigurations, Binder binder) {
+    binder.bindExtension(
+        TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE,
+        new DefaultHttpRequestReplyClientFactory());
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/EgressJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/EgressJsonEntity.java
@@ -22,11 +22,11 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.statefun.flink.common.json.NamespaceNamePair;
 import org.apache.flink.statefun.flink.common.json.Selectors;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.flink.io.spi.JsonEgressSpec;
 import org.apache.flink.statefun.sdk.EgressType;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class EgressJsonEntity implements JsonEntity {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/EgressJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/EgressJsonEntity.java
@@ -26,6 +26,7 @@ import org.apache.flink.statefun.flink.io.spi.JsonEgressSpec;
 import org.apache.flink.statefun.sdk.EgressType;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class EgressJsonEntity implements JsonEntity {
@@ -38,7 +39,11 @@ final class EgressJsonEntity implements JsonEntity {
   }
 
   @Override
-  public void bind(Binder binder, JsonNode moduleSpecRootNode, FormatVersion formatVersion) {
+  public void bind(
+      Binder binder,
+      ExtensionResolver extensionResolver,
+      JsonNode moduleSpecRootNode,
+      FormatVersion formatVersion) {
     final Iterable<? extends JsonNode> egressNodes =
         Selectors.listAt(moduleSpecRootNode, EGRESS_SPECS_POINTER);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FormatVersion.java
@@ -30,7 +30,8 @@ enum FormatVersion {
   //  Supported versions
   // ============================================================
 
-  v3_0("3.0");
+  v3_0("3.0"),
+  v3_1("3.1");
 
   private String versionStr;
 
@@ -51,6 +52,8 @@ enum FormatVersion {
         return v2_0;
       case "3.0":
         return v3_0;
+      case "3.1":
+        return v3_1;
       default:
         throw new IllegalArgumentException("Unrecognized format version: " + versionStr);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
@@ -171,9 +171,7 @@ public final class FunctionEndpointJsonEntity implements JsonEntity {
             .map(TypeName::parseFrom);
     transportClientFactoryType.ifPresent(endpointSpecBuilder::withTransportClientFactoryType);
 
-    // retain everything except "type" field, and use that directly as the transport client
-    // properties
-    transportSpecNode.remove("type");
+    // pass the transport spec node as is as the client properties
     endpointSpecBuilder.withTransportClientProperties(transportSpecNode);
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
@@ -36,11 +36,11 @@ import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionProvider;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
 import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 import org.apache.flink.statefun.sdk.TypeName;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 import org.apache.flink.util.TimeUtils;
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/FunctionEndpointJsonEntity.java
@@ -37,6 +37,7 @@ import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
 import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
 import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 import org.apache.flink.util.TimeUtils;
 
@@ -67,7 +68,10 @@ public final class FunctionEndpointJsonEntity implements JsonEntity {
 
   @Override
   public void bind(
-      StatefulFunctionModule.Binder binder, JsonNode moduleSpecNode, FormatVersion formatVersion) {
+      StatefulFunctionModule.Binder binder,
+      ExtensionResolver extensionResolver,
+      JsonNode moduleSpecNode,
+      FormatVersion formatVersion) {
     if (formatVersion != FormatVersion.v3_0) {
       throw new IllegalArgumentException("endpoints is only supported with format version 3.0.");
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/IngressJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/IngressJsonEntity.java
@@ -29,6 +29,7 @@ import org.apache.flink.statefun.flink.io.kinesis.PolyglotKinesisIOTypes;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class IngressJsonEntity implements JsonEntity {
@@ -41,7 +42,11 @@ final class IngressJsonEntity implements JsonEntity {
   }
 
   @Override
-  public void bind(Binder binder, JsonNode moduleSpecRootNode, FormatVersion formatVersion) {
+  public void bind(
+      Binder binder,
+      ExtensionResolver extensionResolver,
+      JsonNode moduleSpecRootNode,
+      FormatVersion formatVersion) {
     final Iterable<? extends JsonNode> ingressNodes =
         Selectors.listAt(moduleSpecRootNode, INGRESS_SPECS_POINTER);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/IngressJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/IngressJsonEntity.java
@@ -24,12 +24,12 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.statefun.flink.common.json.NamespaceNamePair;
 import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.core.protorouter.AutoRoutableProtobufRouter;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.flink.io.kafka.ProtobufKafkaIngressTypes;
 import org.apache.flink.statefun.flink.io.kinesis.PolyglotKinesisIOTypes;
 import org.apache.flink.statefun.flink.io.spi.JsonIngressSpec;
 import org.apache.flink.statefun.sdk.IngressType;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class IngressJsonEntity implements JsonEntity {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonEntity.java
@@ -19,7 +19,7 @@
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 /**

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonEntity.java
@@ -19,6 +19,7 @@
 package org.apache.flink.statefun.flink.core.jsonmodule;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 /**
@@ -35,5 +36,9 @@ interface JsonEntity {
    * @param moduleSpecNode the root module spec node.
    * @param formatVersion the format version of the module spec.
    */
-  void bind(Binder binder, JsonNode moduleSpecNode, FormatVersion formatVersion);
+  void bind(
+      Binder binder,
+      ExtensionResolver extensionResolver,
+      JsonNode moduleSpecNode,
+      FormatVersion formatVersion);
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 
 final class JsonModule implements StatefulFunctionModule {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModule.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 
 final class JsonModule implements StatefulFunctionModule {
@@ -49,10 +50,17 @@ final class JsonModule implements StatefulFunctionModule {
 
   public void configure(Map<String, String> conf, Binder binder) {
     try {
-      ENTITIES.forEach(jsonEntity -> jsonEntity.bind(binder, moduleSpecNode, formatVersion));
+      ENTITIES.forEach(
+          jsonEntity ->
+              jsonEntity.bind(binder, getExtensionResolver(binder), moduleSpecNode, formatVersion));
     } catch (Throwable t) {
       throw new ModuleConfigurationException(
           format("Error while parsing module at %s", moduleUrl), t);
     }
+  }
+
+  // TODO expose ExtensionResolver properly once we have more usages
+  private static ExtensionResolver getExtensionResolver(Binder binder) {
+    return (ExtensionResolver) binder;
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RouterJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RouterJsonEntity.java
@@ -32,6 +32,7 @@ import org.apache.flink.statefun.flink.common.protobuf.ProtobufDescriptorMap;
 import org.apache.flink.statefun.flink.core.protorouter.ProtobufRouter;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.Router;
+import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class RouterJsonEntity implements JsonEntity {
@@ -50,7 +51,11 @@ final class RouterJsonEntity implements JsonEntity {
   }
 
   @Override
-  public void bind(Binder binder, JsonNode moduleSpecRootNode, FormatVersion formatVersion) {
+  public void bind(
+      Binder binder,
+      ExtensionResolver extensionResolver,
+      JsonNode moduleSpecRootNode,
+      FormatVersion formatVersion) {
     final Iterable<? extends JsonNode> routerNodes =
         Selectors.listAt(moduleSpecRootNode, ROUTER_SPECS_POINTER);
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RouterJsonEntity.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RouterJsonEntity.java
@@ -30,9 +30,9 @@ import org.apache.flink.statefun.flink.common.json.NamespaceNamePair;
 import org.apache.flink.statefun.flink.common.json.Selectors;
 import org.apache.flink.statefun.flink.common.protobuf.ProtobufDescriptorMap;
 import org.apache.flink.statefun.flink.core.protorouter.ProtobufRouter;
+import org.apache.flink.statefun.flink.core.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.Router;
-import org.apache.flink.statefun.sdk.spi.ExtensionResolver;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule.Binder;
 
 final class RouterJsonEntity implements JsonEntity {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ClassLoaderSafeRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ClassLoaderSafeRequestReplyClient.java
@@ -28,12 +28,12 @@ import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
  * Decorator for a {@link RequestReplyClient} that makes sure we always use the correct classloader.
  * This is required since client implementation may be user provided.
  */
-public final class ContextSafeRequestReplyClient implements RequestReplyClient {
+public final class ClassLoaderSafeRequestReplyClient implements RequestReplyClient {
 
   private final ClassLoader delegateClassLoader;
   private final RequestReplyClient delegate;
 
-  public ContextSafeRequestReplyClient(RequestReplyClient delegate) {
+  public ClassLoaderSafeRequestReplyClient(RequestReplyClient delegate) {
     this.delegate = Objects.requireNonNull(delegate);
     this.delegateClassLoader = delegate.getClass().getClassLoader();
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ContextSafeRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ContextSafeRequestReplyClient.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core.reqreply;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
+import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
+import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
+
+/**
+ * Decorator for a {@link RequestReplyClient} that makes sure we always use the correct classloader.
+ * This is required since client implementation may be user provided.
+ */
+public final class ContextSafeRequestReplyClient implements RequestReplyClient {
+
+  private final ClassLoader delegateClassLoader;
+  private final RequestReplyClient delegate;
+
+  public ContextSafeRequestReplyClient(RequestReplyClient delegate) {
+    this.delegate = Objects.requireNonNull(delegate);
+    this.delegateClassLoader = delegate.getClass().getClassLoader();
+  }
+
+  @Override
+  public CompletableFuture<FromFunction> call(
+      ToFunctionRequestSummary requestSummary,
+      RemoteInvocationMetrics metrics,
+      ToFunction toFunction) {
+    final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+    try {
+      Thread.currentThread().setContextClassLoader(delegateClassLoader);
+      return delegate.call(requestSummary, metrics, toFunction);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClientFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClientFactory.java
@@ -18,17 +18,13 @@
 
 package org.apache.flink.statefun.flink.core.reqreply;
 
-import java.util.concurrent.CompletableFuture;
+import java.net.URI;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
-import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
-import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 @PublicEvolving
-public interface RequestReplyClient {
+public interface RequestReplyClientFactory {
+  RequestReplyClient createTransportClient(ObjectNode transportProperties, URI endpointUrl);
 
-  CompletableFuture<FromFunction> call(
-      ToFunctionRequestSummary requestSummary,
-      RemoteInvocationMetrics metrics,
-      ToFunction toFunction);
+  void cleanup();
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/ExtensionResolver.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/ExtensionResolver.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.statefun.sdk.spi;
+package org.apache.flink.statefun.flink.core.spi;
 
 import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.spi.ExtensionModule;
 
 /**
  * Resolves a bound extension (bound by {@link ExtensionModule}s) given specified {@link TypeName}s.

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.core;
+
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.Test;
+
+public class StatefulFunctionsUniverseTest {
+
+  @Test
+  public void testExtensions() {
+    final StatefulFunctionsUniverse universe = emptyUniverse();
+
+    final ExtensionImpl extension = new ExtensionImpl();
+    universe.bindExtension(TypeName.parseFrom("test.namespace/test.name"), extension);
+
+    assertThat(
+        extension,
+        sameInstance(
+            universe.resolveExtension(
+                TypeName.parseFrom("test.namespace/test.name"), BaseExtension.class)));
+  }
+
+  private static StatefulFunctionsUniverse emptyUniverse() {
+    return new StatefulFunctionsUniverse(
+        MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+  }
+
+  private interface BaseExtension {}
+
+  private static class ExtensionImpl implements BaseExtension {}
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonModuleTest.java
@@ -25,22 +25,43 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.protobuf.Message;
+import java.net.URI;
 import java.net.URL;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClientFactory;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.TypeName;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.spi.ExtensionModule;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class JsonModuleTest {
 
-  private static final String modulePath = "module-v3_0/module.yaml";
+  private final String modulePath;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<String> modulePaths() {
+    return Arrays.asList("module-v3_0/module.yaml", "module-v3_1/module.yaml");
+  }
+
+  public JsonModuleTest(String modulePath) {
+    this.modulePath = modulePath;
+  }
 
   @Test
   public void exampleUsage() {
@@ -52,9 +73,11 @@ public class JsonModuleTest {
   @Test
   public void testFunctions() {
     StatefulFunctionModule module = fromPath(modulePath);
+    ExtensionModule extensionModule =
+        transportClientExtensions(TypeName.parseFrom("my.custom/http.transport.type"));
 
     StatefulFunctionsUniverse universe = emptyUniverse();
-    module.configure(Collections.emptyMap(), universe);
+    setupUniverse(universe, module, extensionModule);
 
     assertThat(
         universe.functions(),
@@ -68,9 +91,11 @@ public class JsonModuleTest {
   @Test
   public void testRouters() {
     StatefulFunctionModule module = fromPath(modulePath);
+    ExtensionModule extensionModule =
+        transportClientExtensions(TypeName.parseFrom("my.custom/http.transport.type"));
 
     StatefulFunctionsUniverse universe = emptyUniverse();
-    module.configure(Collections.emptyMap(), universe);
+    setupUniverse(universe, module, extensionModule);
 
     assertThat(
         universe.routers(),
@@ -80,9 +105,11 @@ public class JsonModuleTest {
   @Test
   public void testIngresses() {
     StatefulFunctionModule module = fromPath(modulePath);
+    ExtensionModule extensionModule =
+        transportClientExtensions(TypeName.parseFrom("my.custom/http.transport.type"));
 
     StatefulFunctionsUniverse universe = emptyUniverse();
-    module.configure(Collections.emptyMap(), universe);
+    setupUniverse(universe, module, extensionModule);
 
     assertThat(
         universe.ingress(),
@@ -92,9 +119,11 @@ public class JsonModuleTest {
   @Test
   public void testEgresses() {
     StatefulFunctionModule module = fromPath(modulePath);
+    ExtensionModule extensionModule =
+        transportClientExtensions(TypeName.parseFrom("my.custom/http.transport.type"));
 
     StatefulFunctionsUniverse universe = emptyUniverse();
-    module.configure(Collections.emptyMap(), universe);
+    setupUniverse(universe, module, extensionModule);
 
     assertThat(
         universe.egress(),
@@ -108,8 +137,48 @@ public class JsonModuleTest {
     return JsonServiceLoader.fromUrl(mapper, moduleUrl);
   }
 
+  private static ExtensionModule transportClientExtensions(TypeName type) {
+    return new TransportClientBindingModule(type);
+  }
+
   private static StatefulFunctionsUniverse emptyUniverse() {
     return new StatefulFunctionsUniverse(
         MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+  }
+
+  private static void setupUniverse(
+      StatefulFunctionsUniverse universe,
+      StatefulFunctionModule functionModule,
+      ExtensionModule extensionModule) {
+    final Map<String, String> globalConfig = new HashMap<>();
+    extensionModule.configure(globalConfig, universe);
+    functionModule.configure(globalConfig, universe);
+  }
+
+  private static class TransportClientBindingModule implements ExtensionModule {
+
+    private final TypeName transportClientType;
+
+    TransportClientBindingModule(TypeName transportClientType) {
+      this.transportClientType = transportClientType;
+    }
+
+    @Override
+    public void configure(Map<String, String> globalConfigurations, Binder binder) {
+      binder.bindExtension(transportClientType, new TestRequestReplyClientFactory());
+    }
+  }
+
+  private static class TestRequestReplyClientFactory implements RequestReplyClientFactory {
+    @Override
+    public RequestReplyClient createTransportClient(
+        ObjectNode transportProperties, URI endpointUrl) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void cleanup() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v3_1/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v3_1/module.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.0"
+version: "3.1"
 
 module:
   meta:
@@ -26,12 +26,25 @@ module:
           spec:
             functions: com.foo.bar/*
             urlPathTemplate: http://bar.foo.com:8080/functions/{function.name}
-            timeouts:
-              call: 1minutes
-              connect: 10seconds
-              read: 10second
-              write: 10seconds
             maxNumBatchRequests: 10000
+            transport:
+              timeouts:
+                call: 1minutes
+                connect: 10seconds
+                read: 10second
+                write: 10seconds
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            functions: com.foo.bar.2/*
+            urlPathTemplate: http://2.bar.foo.com:8080/functions/{function.name}
+            transport:
+              type: my.custom/http.transport.type
+              property1: value1
+              property2:
+                - k1: v1
+                - k2: v2
       - endpoint:
           meta:
             kind: http

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v3_1/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v3_1/module.yaml
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.0"
+
+module:
+  meta:
+    type: remote
+  spec:
+    endpoints:
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            functions: com.foo.bar/*
+            urlPathTemplate: http://bar.foo.com:8080/functions/{function.name}
+            timeouts:
+              call: 1minutes
+              connect: 10seconds
+              read: 10second
+              write: 10seconds
+            maxNumBatchRequests: 10000
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            functions: com.foo.bar/specific_function
+            urlPathTemplate: http://bar.foo.com:8080/functions/abc
+      - endpoint:
+          meta:
+            kind: http
+          spec:
+            functions: com.other.namespace/hello
+            urlPathTemplate: http://namespace.other.com:8080/hello
+    routers:
+      - router:
+          meta:
+            type: org.apache.flink.statefun.sdk/protobuf-router
+          spec:
+            ingress: com.mycomp.igal/names
+            target: "com.example/hello/{{$.name}}"
+            messageType: org.apache.flink.test.SimpleMessage
+            descriptorSet: classpath:test.desc
+    ingresses:
+      - ingress:
+          meta:
+            type: statefun.kafka.io/protobuf-ingress
+            id: com.mycomp.igal/names
+          spec:
+            address: kafka-broker:9092
+            topics:
+              - names
+            properties:
+              - consumer.group: greeter
+            messageType: org.apache.flink.test.SimpleMessage
+            descriptorSet: classpath:test.desc
+    egresses:
+      - egress:
+          meta:
+            type: io.statefun.kafka/egress
+            id: com.mycomp.foo/bar
+          spec:
+            address: kafka-broker:9092
+            deliverySemantic:
+              type: exactly-once
+              transactionTimeoutMillis: 100000
+            properties:
+              - foo.config: bar

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -21,8 +21,11 @@ package org.apache.flink.statefun.flink.datastream;
 import java.net.URI;
 import java.time.Duration;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
+import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec.Target;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec.UrlPathTemplate;
 import org.apache.flink.statefun.sdk.FunctionType;
@@ -111,7 +114,18 @@ public class RequestReplyFunctionBuilder {
 
   @Internal
   HttpFunctionEndpointSpec spec() {
-    // builder.withTransportClientProperties(transportClientTimeoutsSpec)
+    builder.withTransportClientFactoryType(TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE);
+    builder.withTransportClientProperties(
+        transportClientPropertiesAsObjectNode(transportClientTimeoutsSpec));
     return builder.build();
+  }
+
+  private static ObjectNode transportClientPropertiesAsObjectNode(
+      DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec) {
+    final DefaultHttpRequestReplyClientSpec transportClientSpecPojo =
+        new DefaultHttpRequestReplyClientSpec();
+    transportClientSpecPojo.setTimeouts(transportClientTimeoutsSpec);
+
+    return new ObjectMapper().valueToTree(transportClientSpecPojo);
   }
 }

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -21,6 +21,7 @@ package org.apache.flink.statefun.flink.datastream;
 import java.net.URI;
 import java.time.Duration;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec.Target;
 import org.apache.flink.statefun.flink.core.jsonmodule.FunctionEndpointSpec.UrlPathTemplate;
@@ -28,6 +29,9 @@ import org.apache.flink.statefun.sdk.FunctionType;
 
 /** A Builder for RequestReply remote function type. */
 public class RequestReplyFunctionBuilder {
+
+  private final DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec =
+      new DefaultHttpRequestReplyClientSpec.Timeouts();
 
   /**
    * Create a new builder for a remote function with a given type and an endpoint.
@@ -57,7 +61,7 @@ public class RequestReplyFunctionBuilder {
    * @return this builder.
    */
   public RequestReplyFunctionBuilder withMaxRequestDuration(Duration duration) {
-    builder.withMaxRequestDuration(duration);
+    transportClientTimeoutsSpec.setCallTimeout(duration);
     return this;
   }
 
@@ -68,7 +72,7 @@ public class RequestReplyFunctionBuilder {
    * @return this builder.
    */
   public RequestReplyFunctionBuilder withConnectTimeout(Duration duration) {
-    builder.withConnectTimeoutDuration(duration);
+    transportClientTimeoutsSpec.setConnectTimeout(duration);
     return this;
   }
 
@@ -79,7 +83,7 @@ public class RequestReplyFunctionBuilder {
    * @return this builder.
    */
   public RequestReplyFunctionBuilder withReadTimeout(Duration duration) {
-    builder.withReadTimeoutDuration(duration);
+    transportClientTimeoutsSpec.setReadTimeout(duration);
     return this;
   }
 
@@ -90,7 +94,7 @@ public class RequestReplyFunctionBuilder {
    * @return this builder.
    */
   public RequestReplyFunctionBuilder withWriteTimeout(Duration duration) {
-    builder.withWriteTimeoutDuration(duration);
+    transportClientTimeoutsSpec.setWriteTimeout(duration);
     return this;
   }
 
@@ -107,6 +111,7 @@ public class RequestReplyFunctionBuilder {
 
   @Internal
   HttpFunctionEndpointSpec spec() {
+    // builder.withTransportClientProperties(transportClientTimeoutsSpec)
     return builder.build();
   }
 }

--- a/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionModule.java
+++ b/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionModule.java
@@ -24,11 +24,6 @@ import org.apache.flink.statefun.sdk.TypeName;
 /**
  * A module that binds multiple extension objects to the Stateful Functions application. Each
  * extension is uniquely identified by a {@link TypeName}.
- *
- * <p>After being bound, {@link StatefulFunctionModule}s may have access to bound extensions through
- * an {@link ExtensionResolver}.
- *
- * @see ExtensionResolver
  */
 public interface ExtensionModule {
 

--- a/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionModule.java
+++ b/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionModule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.spi;
+
+import java.util.Map;
+import org.apache.flink.statefun.sdk.TypeName;
+
+/**
+ * A module that binds multiple extension objects to the Stateful Functions application. Each
+ * extension is uniquely identified by a {@link TypeName}.
+ *
+ * <p>After being bound, {@link StatefulFunctionModule}s may have access to bound extensions through
+ * an {@link ExtensionResolver}.
+ *
+ * @see ExtensionResolver
+ */
+public interface ExtensionModule {
+
+  /**
+   * This method binds multiple extension objects to the Stateful Functions application.
+   *
+   * @param globalConfigurations global configuration of the Stateful Functions application.
+   * @param binder binder for binding extensions.
+   */
+  void configure(Map<String, String> globalConfigurations, Binder binder);
+
+  interface Binder {
+    <T> void bindExtension(TypeName typeName, T extension);
+  }
+}

--- a/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionResolver.java
+++ b/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/spi/ExtensionResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.spi;
+
+import org.apache.flink.statefun.sdk.TypeName;
+
+/**
+ * Resolves a bound extension (bound by {@link ExtensionModule}s) given specified {@link TypeName}s.
+ */
+public interface ExtensionResolver {
+  <T> T resolveExtension(TypeName typeName, Class<T> extensionClass);
+}


### PR DESCRIPTION
The goal of this PR is to allow pluggable / extendable transport clients for invoking remote functions.

There are a few major changes included:

- (1st commit) Add new SPI interfaces for binding extension objects by `TypeName`. Specifically, these new interfaces are `ExtensionModule` and `ExtensionResolver`, the former used for binding extensions to the application universe, and former used for getting access to bound extensions within the main modules, etc. `StatefulFunctionModules` or `FlinkIOModules`. 2cdddf9

- Introduces a new interface, `RequestReplyClientFactory`, that is responsible for creating the client for each individual remote function endpoint. This interface is public to users as an extension, by binding client factory instances using `ExtensionModule`s. Later on, the factory to use can be referenced using the `TypeName` that was used when binding the factory. a808653 84bce57 45aa1b4 c4f37da

- Furthermore, the original OkHttp client's instantiation logic has been refactored as a `RequestReplyClientFactory`. This factory is used by default if users do not specify any transport extensions. 387f7e2 84be2ba

- Last of all, we bump the module YAML format version, and rework how transport properties are specified. b6f847b af7f337