### PR TITLE
[FLINK-23520][datastream] Improve StateFun <-> DataStream Interop

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpec.java
@@ -23,10 +23,14 @@ import java.time.Duration;
 import java.util.Objects;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSetter;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.flink.util.TimeUtils;
 
 public final class DefaultHttpRequestReplyClientSpec {
@@ -97,18 +101,22 @@ public final class DefaultHttpRequestReplyClientSpec {
       this.writeTimeout = requireNonZeroDuration(writeTimeout);
     }
 
+    @JsonSerialize(using = DurationJsonSerialize.class)
     public Duration getCallTimeout() {
       return callTimeout;
     }
 
+    @JsonSerialize(using = DurationJsonSerialize.class)
     public Duration getConnectTimeout() {
       return connectTimeout;
     }
 
+    @JsonSerialize(using = DurationJsonSerialize.class)
     public Duration getReadTimeout() {
       return readTimeout;
     }
 
+    @JsonSerialize(using = DurationJsonSerialize.class)
     public Duration getWriteTimeout() {
       return writeTimeout;
     }
@@ -120,6 +128,16 @@ public final class DefaultHttpRequestReplyClientSpec {
       }
 
       return duration;
+    }
+  }
+
+  private static final class DurationJsonSerialize extends JsonSerializer<Duration> {
+
+    @Override
+    public void serialize(
+        Duration duration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+        throws IOException {
+      jsonGenerator.writeString(TimeUtils.formatWithHighestUnit(duration));
     }
   }
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -29,10 +29,21 @@ under the License.
 
     <artifactId>statefun-flink-datastream</artifactId>
 
+    <properties>
+        <protocol-messages.dir>${basedir}/target/generated-sources/protocol-messages/</protocol-messages.dir>
+        <proto-sources.dir>target/proto-sources</proto-sources.dir>
+        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-sdk-embedded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-sdk-protos</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -77,11 +88,121 @@ under the License.
             <version>${flink.version}</version>
             <scope>provided</scope>
        </dependency>
-        
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Step 1: (generate-sources) unpack protocol source proto files -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-protobuf</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.flink</groupId>
+                                    <artifactId>statefun-sdk-protos</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${proto-sources.dir}</outputDirectory>
+                                    <includes>types/*.proto</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Step 2: (generate-sources) generate protocol java messages with protoc -->
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>${protoc-jar-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-protobuf-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <includeStdTypes>true</includeStdTypes>
+                            <protocVersion>${protobuf.version}</protocVersion>
+                            <cleanOutputFolder>true</cleanOutputFolder>
+                            <inputDirectories>
+                                <inputDirectory>src/main/protobuf</inputDirectory>
+                                <inputDirectory>${proto-sources.dir}</inputDirectory>
+                            </inputDirectories>
+                            <outputDirectory>${protocol-messages.dir}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${protocol-messages.dir}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/FunctionRegistry.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/FunctionRegistry.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+
+class FunctionRegistry {
+  private final Map<FunctionType, SerializableStatefulFunctionProvider> specificTypeProviders =
+      new HashMap<>();
+  private final Map<FunctionType, HttpFunctionEndpointSpec> specificTypeEndpointSpecs =
+      new HashMap<>();
+  private final Map<FunctionTypeNamespaceMatcher, HttpFunctionEndpointSpec>
+      perNamespaceEndpointSpecs = new HashMap<>();
+
+  void put(FunctionType functionType, SerializableStatefulFunctionProvider provider) {
+    putAndThrowIfPresent(specificTypeProviders, functionType, provider);
+  }
+
+  void add(HttpFunctionEndpointSpec spec) {
+    if (spec.target().isSpecificFunctionType()) {
+      putAndThrowIfPresent(specificTypeEndpointSpecs, spec.target().asSpecificFunctionType(), spec);
+    } else {
+      putAndThrowIfPresent(perNamespaceEndpointSpecs, spec.target().asNamespace(), spec);
+    }
+  }
+
+  Functions getFunctions() {
+    Map<String, HttpFunctionEndpointSpec> namespaceSpecs = new HashMap<>();
+    perNamespaceEndpointSpecs.forEach(
+        (namespace, spec) -> namespaceSpecs.put(namespace.targetNamespace(), spec));
+
+    SerializableHttpFunctionProvider httpFunctionProvider =
+        new SerializableHttpFunctionProvider(specificTypeEndpointSpecs, namespaceSpecs);
+    specificTypeEndpointSpecs.forEach(
+        (type, unused) -> specificTypeProviders.put(type, httpFunctionProvider));
+
+    Map<FunctionTypeNamespaceMatcher, SerializableStatefulFunctionProvider> namespaceTypeProviders =
+        new HashMap<>();
+    perNamespaceEndpointSpecs.forEach(
+        (type, unused) -> namespaceTypeProviders.put(type, httpFunctionProvider));
+
+    return new Functions(specificTypeProviders, namespaceTypeProviders);
+  }
+
+  private static <K, V> void putAndThrowIfPresent(Map<K, V> map, K key, V value) {
+    @Nullable V previous = map.put(key, value);
+    if (previous == null) {
+      return;
+    }
+    throw new IllegalStateException(
+        String.format("A binding for the key %s was previously defined.", key));
+  }
+
+  static class Functions {
+    private final Map<FunctionType, SerializableStatefulFunctionProvider> specificFunctions;
+    private final Map<FunctionTypeNamespaceMatcher, SerializableStatefulFunctionProvider>
+        namespaceFunctions;
+
+    private Functions(
+        Map<FunctionType, SerializableStatefulFunctionProvider> specificFunctions,
+        Map<FunctionTypeNamespaceMatcher, SerializableStatefulFunctionProvider>
+            namespaceFunctions) {
+      this.specificFunctions = specificFunctions;
+      this.namespaceFunctions = namespaceFunctions;
+    }
+
+    public Map<FunctionType, SerializableStatefulFunctionProvider> getSpecificFunctions() {
+      return specificFunctions;
+    }
+
+    public Map<FunctionTypeNamespaceMatcher, SerializableStatefulFunctionProvider>
+        getNamespaceFunctions() {
+      return namespaceFunctions;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/GenericEgress.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/GenericEgress.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.TypedValue;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.TypeSerializer;
+import org.apache.flink.statefun.sdk.types.Types;
+
+/**
+ * Identifies a generic egress.
+ *
+ * @param <T> The Java object of the output records.
+ */
+public class GenericEgress<T> {
+  private final EgressIdentifier<org.apache.flink.statefun.sdk.reqreply.generated.TypedValue> id;
+
+  private final Type<T> type;
+
+  private final TypeInformation<T> typeInfo;
+
+  private GenericEgress(TypeName typeName, Type<T> type, TypeInformation<T> typeInfo) {
+    this.id =
+        new EgressIdentifier<>(
+            typeName.name(),
+            typeName.name(),
+            org.apache.flink.statefun.sdk.reqreply.generated.TypedValue.class);
+    this.type = type;
+    this.typeInfo = typeInfo;
+  }
+
+  @Override
+  public String toString() {
+    return "GenericEgress{"
+        + "typeName="
+        + id.namespace()
+        + "/"
+        + id.name()
+        + ", type="
+        + type
+        + '}';
+  }
+
+  @Internal
+  EgressIdentifier<org.apache.flink.statefun.sdk.reqreply.generated.TypedValue> getId() {
+    return this.id;
+  }
+
+  @Internal
+  public Type<T> getType() {
+    return this.type;
+  }
+
+  @Internal
+  public TypeInformation<T> getTypeInfo() {
+    return this.typeInfo;
+  }
+
+  /**
+   * Creates an {@link Untyped} generic egress with the given name. To complete the creation of a
+   * {@link GenericEgress}, please specify the {@link Type} of the value. For example:
+   *
+   * <pre>{@code
+   * final GenericEgress<Integer> intEgress =
+   *    GenericEgress.named(TypeName.parseFrom("example/egress")).withIntType();
+   * }</pre>
+   *
+   * @param typeName unique name for the GenericEgress.
+   * @return an {@link Untyped} spec. Specify the {@link Type} of the value to instantiate a {@link
+   *     GenericEgress}.
+   */
+  public static Untyped named(TypeName typeName) {
+    return new Untyped(typeName);
+  }
+
+  public static class Untyped {
+    private final TypeName typeName;
+
+    private Untyped(TypeName typeName) {
+      this.typeName = typeName;
+    }
+
+    /** @return A {@link GenericEgress} for consuming integers. */
+    public GenericEgress<Integer> withIntType() {
+      return withCustomType(Types.integerType(), BasicTypeInfo.INT_TYPE_INFO);
+    }
+
+    /** @return A {@link GenericEgress} for consuming longs. */
+    public GenericEgress<Long> withLongType() {
+      return withCustomType(Types.longType(), BasicTypeInfo.LONG_TYPE_INFO);
+    }
+
+    /** @return A {@link GenericEgress} for consuming floats. */
+    public GenericEgress<Float> withFloatType() {
+      return withCustomType(Types.floatType(), BasicTypeInfo.FLOAT_TYPE_INFO);
+    }
+
+    /** @return A {@link GenericEgress} for consuming doubles. */
+    public GenericEgress<Double> withDoubleType() {
+      return withCustomType(Types.doubleType(), BasicTypeInfo.DOUBLE_TYPE_INFO);
+    }
+
+    /** @return A {@link GenericEgress} for consuming strings. */
+    public GenericEgress<String> withUtf8StringType() {
+      return withCustomType(Types.stringType(), BasicTypeInfo.STRING_TYPE_INFO);
+    }
+
+    /** @return A {@link GenericEgress} for consuming booleans. */
+    public GenericEgress<Boolean> withBooleanType() {
+      return withCustomType(Types.booleanType(), BasicTypeInfo.BOOLEAN_TYPE_INFO);
+    }
+
+    /**
+     * @return A {@link GenericEgress} that does not decode the output messages. It instead returns
+     *     each {@link TypedValue} containing the {@link TypeName} and serialized bytes.
+     */
+    public GenericEgress<TypedValue> withTypedValue() {
+      return withCustomType(new TypedValueType(), TypeInformation.of(TypedValue.class));
+    }
+
+    /**
+     * A {@link GenericEgress} for custom types.
+     *
+     * @param type The decoding type.
+     * @param clazz The resulting Java class.
+     * @param <T> The resulting Java type.
+     * @return A custom generic egress.
+     */
+    public <T> GenericEgress<T> withCustomType(Type<T> type, Class<T> clazz) {
+      return new GenericEgress<>(typeName, type, TypeInformation.of(clazz));
+    }
+
+    /**
+     * A {@link GenericEgress} for custom types.
+     *
+     * @param type The decoding type.
+     * @param typeInfo The resulting Java {@link TypeInformation}.
+     * @param <T> The resulting Java type.
+     * @return A custom generic egress.
+     */
+    public <T> GenericEgress<T> withCustomType(Type<T> type, TypeInformation<T> typeInfo) {
+      return new GenericEgress<>(typeName, type, typeInfo);
+    }
+  }
+
+  /** A shim class that is never used. */
+  private static class TypedValueType implements Type<TypedValue> {
+
+    @Override
+    public TypeName typeName() {
+      throw new RuntimeException();
+    }
+
+    @Override
+    public TypeSerializer<TypedValue> typeSerializer() {
+      throw new RuntimeException();
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/Router.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/Router.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+
+/**
+ * A {@link org.apache.flink.statefun.sdk.io.Router} routes messages from ingresses to individual
+ * {@link StatefulFunction}s.
+ *
+ * <p>Implementations should be stateless, as any state in routers are not persisted by the system.
+ *
+ * @param <InT> the type of messages being routed.
+ */
+@FunctionalInterface
+public interface Router<InT> extends Function {
+
+  /**
+   * Routes a given message to downstream {@code StatefulFunction} instance. The target address may
+   * either be remote or embedded.
+   *
+   * @param message The outgoing message.
+   * @return The destination address.
+   */
+  Address route(InT message);
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProvider.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.statefun.flink.datastream;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -41,10 +40,15 @@ final class SerializableHttpFunctionProvider implements SerializableStatefulFunc
   private static final long serialVersionUID = 1;
 
   private final Map<FunctionType, HttpFunctionEndpointSpec> supportedTypes;
+  private final Map<String, HttpFunctionEndpointSpec> perNamespaceEndpointSpecs;
+
   private transient @Nullable HttpFunctionProvider delegate;
 
-  SerializableHttpFunctionProvider(Map<FunctionType, HttpFunctionEndpointSpec> supportedTypes) {
+  SerializableHttpFunctionProvider(
+      Map<FunctionType, HttpFunctionEndpointSpec> supportedTypes,
+      Map<String, HttpFunctionEndpointSpec> perNamespaceEndpointSpecs) {
     this.supportedTypes = Objects.requireNonNull(supportedTypes);
+    this.perNamespaceEndpointSpecs = Objects.requireNonNull(perNamespaceEndpointSpecs);
   }
 
   @Override
@@ -52,7 +56,9 @@ final class SerializableHttpFunctionProvider implements SerializableStatefulFunc
     if (delegate == null) {
       delegate =
           new HttpFunctionProvider(
-              supportedTypes, Collections.emptyMap(), new OkHttpTransportClientExtensionResolver());
+              supportedTypes,
+              perNamespaceEndpointSpecs,
+              new OkHttpTransportClientExtensionResolver());
     }
     return delegate.functionOfType(type);
   }

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
@@ -19,31 +19,93 @@
 package org.apache.flink.statefun.flink.datastream;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.flink.shaded.guava18.com.google.common.base.Optional;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
-import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
-import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.RoutableMessage;
 import org.apache.flink.statefun.flink.core.translation.EmbeddedTranslator;
+import org.apache.flink.statefun.flink.datastream.types.ExternalTypeConverter;
+import org.apache.flink.statefun.flink.datastream.types.TypeConverterFactory;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.types.Type;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 /**
  * Builder for a Stateful Function Application.
  *
- * <p>This builder allows defining all the aspects of a stateful function application. define input
- * streams as ingresses, define function providers and egress ids.
+ * <p>This builder is the entry point and central context for creating Stateful Functions' programs
+ * that integrate with the Java-specific {@link DataStream} API.
+ *
+ * <p>A builder is responsible for:
+ *
+ * <ul>
+ *   <li>Convert a {@link DataStream} into an ingress.
+ *   <li>Convert messages targeting an egress into a {@link DataStream}
+ *   <li>Connect to {@link Endpoint}'s and manage all communication with remote function instances.
+ *   <li>Offering further configuration options.
+ * </ul>
+ *
+ * <h1>Example</h1>
+ *
+ *<p>Suppose the following Python Stateful Function:
+ *
+ *<pre>{@code
+ * from statefun import *
+ *
+ * functions = StatefulFunctions()
+ *
+ * @functions.bind("example/greeter", [ValueSpec("count", IntType)])
+ * async def greeter(context: Context, message: Message):
+ *    visits = ctx.storage.count or 0
+ *    visits += 1
+ *    ctx.storage.count = visits
+ *
+ *    templates = ["", "Welcome %s", "Nice to see you again %s", "Third time is a charm %s"]
+ *    if seen < len(templates):
+ *         greeting = templates[seen] % name
+ *    else:
+ *         greeting = f"Nice to see you at the {seen}-nth time {name}!"
+ *
+ *     context.send_egress(egress_message_builder(
+ *         typename='com.example/datastream-egress',
+ *         value=greeting,
+ *         value_type=StringType))
+ * }</pre>
+ *
+ * You can interoperate with this function from a {@code DataStream} application.
+ *
+ * <pre>{@code
+ *    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+ *    DataStream<String> names = env.fromElements("John", "Sally", "John", "John");
+ *
+ *    GenericEgress<String> greetings = GenericEgress
+ *        .named(TypeName.parseFrom("com.example/datastream-egress"))
+ *        .withUtf8StringType();
+ *
+ *        StatefulFunctionEgressStreams egressStreams = StatefulFunctionDataStreamBuilder
+ *             .builder("datastream-interop")
+ *             .withDataStreamIngress(stream, name -> new Address(new FunctionType("example", "greeter"), name))
+ *             .withEndpoint(Endpoint.withSpec("example/*", "https://endpoint/{function.name}"))
+ *             .withGenericEgress(greetings)
+ *             .build(env);
+ *
+ *    DataStream<String> greetings = egressStreams.getDataStream(greetings);
+ *    greetings.print();
+ *
+ *    env.execute();
+ * }</pre>
+ *
+ * <p>Note: If you don't intend to use the {@link DataStream} API, image based deployment with
+ * {@code module.yaml} configuration files are preferred.
  */
 public final class StatefulFunctionDataStreamBuilder {
 
@@ -60,15 +122,71 @@ public final class StatefulFunctionDataStreamBuilder {
 
   private final String pipelineName;
   private final List<DataStream<RoutableMessage>> definedIngresses = new ArrayList<>();
-  private final Map<FunctionType, SerializableStatefulFunctionProvider> functionProviders =
-      new HashMap<>();
-  private final Map<FunctionType, HttpFunctionEndpointSpec> requestReplyFunctions = new HashMap<>();
+  private final FunctionRegistry registry = new FunctionRegistry();
   private final Set<EgressIdentifier<?>> egressesIds = new LinkedHashSet<>();
 
   @Nullable private StatefulFunctionsConfig config;
 
   /**
-   * Adds an ingress of incoming messages.
+   * Converts the given {@link DataStream} into an ingress, using the {@link Router} to extract the
+   * destination address from each message.
+   *
+   * <p>Types are automatically derived based on the {@link
+   * org.apache.flink.api.common.typeinfo.TypeInformation} of the {@link DataStream}. Primitive
+   * types - boolean, integer, long, float, double, and string - are automatically converted to
+   * their corresponding StateFun {@link Type}. These messages will be automatically consumable by
+   * functions written in any remote SDK (Java, Python, etc). For all other types, use {@link
+   * #withDataStreamIngress(DataStream, Type, Router)} providing a specific {@link Type}.
+   *
+   * @param ingress an incoming stream of messages.
+   * @return this builder.
+   * @see #withDataStreamIngress(DataStream, Type, Router).
+   */
+  public <T> StatefulFunctionDataStreamBuilder withDataStreamIngress(
+      DataStream<T> ingress, Router<T> router) {
+    Type<T> deducedType =
+        ExternalTypeConverter.fromTypeInformation(ingress.getType())
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Unable to automatically derive Type for DataStream with TypeInformation "
+                            + ingress.getType().toString()
+                            + ". Instead, use #withDataStreamIngress(DataStream, Type, Router) and a manually specified Type."));
+
+    return withDataStreamIngress(ingress, deducedType, router);
+  }
+
+  /**
+   * Converts the given {@link DataStream} into an ingress, using the {@link Router} to extract the
+   * destination address from each message.
+   *
+   * <p>Types are manually specified based on the provided {@link Type}. This is important when
+   * working with complex classes so they can be serialized in such a way to be consumed by remote
+   * SDK functions. When working with primitive types - boolean, integer, long, float, double, and
+   * string - the {@link Type} parameter can be automatically derived using {@link
+   * #withDataStreamIngress(DataStream, Router)}.
+   *
+   * @param ingress an incoming stream of messages.
+   * @param type the {@link Type} used to serialize each message.
+   * @return this builder.
+   * @see #withDataStreamIngress(DataStream, Router).
+   */
+  public <T> StatefulFunctionDataStreamBuilder withDataStreamIngress(
+      DataStream<T> ingress, Type<T> type, Router<T> router) {
+    Objects.requireNonNull(ingress);
+    Objects.requireNonNull(type);
+    Objects.requireNonNull(router);
+
+    DataStream<RoutableMessage> routable =
+        ingress.map(TypeConverterFactory.toInternalType(type, router)).name("to-internal-type");
+
+    definedIngresses.add(routable);
+    return this;
+  }
+
+  /**
+   * Adds an ingress of incoming messages. For working with remote functions, it is recommended to
+   * use {@link #withDataStreamIngress(DataStream, Router)}.
    *
    * @param ingress an incoming stream of messages.
    * @return this builder.
@@ -91,7 +209,19 @@ public final class StatefulFunctionDataStreamBuilder {
       FunctionType functionType, SerializableStatefulFunctionProvider provider) {
     Objects.requireNonNull(functionType);
     Objects.requireNonNull(provider);
-    putAndThrowIfPresent(functionProviders, functionType, provider);
+    registry.put(functionType, provider);
+    return this;
+  }
+
+  /**
+   * Adds an {@link Endpoint} for connecting to remote functions.
+   *
+   * @param endpoint A configured {@link Endpoint}.
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withEndpoint(Endpoint endpoint) {
+    Objects.requireNonNull(endpoint);
+    registry.add(endpoint.spec());
     return this;
   }
 
@@ -100,12 +230,29 @@ public final class StatefulFunctionDataStreamBuilder {
    *
    * @param builder an already configured {@code RequestReplyFunctionBuilder}.
    * @return this builder.
+   * @deprecated see {@link #withEndpoint(Endpoint)}.
    */
+  @Deprecated
   public StatefulFunctionDataStreamBuilder withRequestReplyRemoteFunction(
       RequestReplyFunctionBuilder builder) {
     Objects.requireNonNull(builder);
-    HttpFunctionEndpointSpec spec = builder.spec();
-    putAndThrowIfPresent(requestReplyFunctions, spec.target().asSpecificFunctionType(), spec);
+    registry.add(builder.spec());
+    return this;
+  }
+
+  /**
+   * Registers a {@link GenericEgress} to create an output stream. Generic egresses automatically
+   * handle type conversions between the Stateful Functions ecosystem and Flink's {@link
+   * org.apache.flink.api.common.typeinfo.TypeInformation}.
+   *
+   * <p>Generic egresses must be eagerly registered with the environment.
+   *
+   * @param egressId The typed identifier
+   * @return this builder
+   */
+  public StatefulFunctionDataStreamBuilder withGenericEgress(GenericEgress<?> egressId) {
+    Objects.requireNonNull(egressId);
+    putAndThrowIfPresent(egressesIds, egressId.getId());
     return this;
   }
 
@@ -143,18 +290,21 @@ public final class StatefulFunctionDataStreamBuilder {
    */
   public StatefulFunctionEgressStreams build(StreamExecutionEnvironment env) {
     final StatefulFunctionsConfig config =
-        Optional.fromNullable(this.config).or(() -> StatefulFunctionsConfig.fromEnvironment(env));
+        Optional.ofNullable(this.config)
+            .orElseGet(() -> StatefulFunctionsConfig.fromEnvironment(env));
 
-    SerializableHttpFunctionProvider httpFunctionProvider =
-        new SerializableHttpFunctionProvider(requestReplyFunctions);
-    requestReplyFunctions.forEach(
-        (type, unused) -> functionProviders.put(type, httpFunctionProvider));
-
-    FeedbackKey<Message> key =
+    FeedbackKey<org.apache.flink.statefun.flink.core.message.Message> key =
         new FeedbackKey<>(pipelineName, FEEDBACK_INVOCATION_ID_SEQ.incrementAndGet());
     EmbeddedTranslator embeddedTranslator = new EmbeddedTranslator(config, key);
+
+    FunctionRegistry.Functions functions = registry.getFunctions();
     Map<EgressIdentifier<?>, DataStream<?>> sideOutputs =
-        embeddedTranslator.translate(definedIngresses, egressesIds, functionProviders);
+        embeddedTranslator.translate(
+            definedIngresses,
+            egressesIds,
+            functions.getSpecificFunctions(),
+            functions.getNamespaceFunctions());
+
     return new StatefulFunctionEgressStreams(sideOutputs);
   }
 

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ExternalTypeConverter.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ExternalTypeConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream.types;
+
+import java.util.Optional;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.Types;
+
+@Internal
+public class ExternalTypeConverter {
+
+  @SuppressWarnings("unchecked")
+  public static <T> Optional<Type<T>> fromTypeInformation(TypeInformation<T> typeInfo) {
+    if (BasicTypeInfo.BOOLEAN_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.booleanType());
+    } else if (BasicTypeInfo.INT_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.integerType());
+    } else if (BasicTypeInfo.LONG_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.longType());
+    } else if (BasicTypeInfo.FLOAT_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.floatType());
+    } else if (BasicTypeInfo.DOUBLE_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.doubleType());
+    } else if (BasicTypeInfo.STRING_TYPE_INFO.equals(typeInfo)) {
+      return Optional.of((Type<T>) Types.stringType());
+    }
+
+    return Optional.empty();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/FromInternalType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/FromInternalType.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream.types;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.TypeSerializer;
+
+@Internal
+public class FromInternalType<T> extends RichMapFunction<TypedValue, T> {
+
+  private final Type<T> type;
+
+  public FromInternalType(Type<T> type) {
+    this.type = type;
+  }
+
+  @Override
+  public T map(TypedValue typedValue) throws Exception {
+    TypeSerializer<T> typeSerializer = type.typeSerializer();
+    Slice input = SliceProtobufUtil.asSlice(typedValue.getValue());
+    return typeSerializer.deserialize(input);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ToInternalType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ToInternalType.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream.types;
+
+import com.google.protobuf.ByteString;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.core.message.RoutableMessageBuilder;
+import org.apache.flink.statefun.flink.datastream.Router;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.TypeSerializer;
+
+/** Converts each message to a {@link RoutableMessage}. */
+@Internal
+public class ToInternalType<T> extends RichMapFunction<T, RoutableMessage> {
+
+  private final Router<T> router;
+
+  private final Type<T> type;
+
+  private transient TypeSerializer<T> typeSerializer;
+
+  private transient ByteString typeNameByteString;
+
+  public ToInternalType(Type<T> type, Router<T> router) {
+    this.type = type;
+    this.router = router;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    typeSerializer = type.typeSerializer();
+    typeNameByteString = ByteString.copyFromUtf8(type.typeName().canonicalTypenameString());
+  }
+
+  @Override
+  public RoutableMessage map(T message) {
+    TypedValue typedValue =
+        TypedValue.newBuilder()
+            .setTypenameBytes(typeNameByteString)
+            .setHasValue(true)
+            .setValue(SliceProtobufUtil.asByteString(typeSerializer.serialize(message)))
+            .build();
+
+    return RoutableMessageBuilder.builder()
+        .withTargetAddress(router.route(message))
+        .withMessageBody(typedValue)
+        .build();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ToPublicTypedValue.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/ToPublicTypedValue.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream.types;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.TypedValue;
+
+/**
+ * Converts internal {@link org.apache.flink.statefun.sdk.reqreply.generated.TypedValue} to public
+ * {@link TypedValue}.
+ */
+@Internal
+public class ToPublicTypedValue
+    implements MapFunction<
+        org.apache.flink.statefun.sdk.reqreply.generated.TypedValue, TypedValue> {
+
+  @Override
+  public TypedValue map(org.apache.flink.statefun.sdk.reqreply.generated.TypedValue value)
+      throws Exception {
+    return new TypedValue(TypeName.parseFrom(value.getTypename()), value.toByteArray());
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/TypeConverterFactory.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/types/TypeConverterFactory.java
@@ -1,0 +1,31 @@
+package org.apache.flink.statefun.flink.datastream.types;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.datastream.GenericEgress;
+import org.apache.flink.statefun.flink.datastream.Router;
+import org.apache.flink.statefun.sdk.TypedValue;
+import org.apache.flink.statefun.sdk.types.Type;
+
+@Internal
+public class TypeConverterFactory {
+  private TypeConverterFactory() {}
+
+  public static <T> MapFunction<T, RoutableMessage> toInternalType(
+      Type<T> statefunType, Router<T> router) {
+    return new ToInternalType<>(statefunType, router);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T>
+      MapFunction<org.apache.flink.statefun.sdk.reqreply.generated.TypedValue, T> fromInternalType(
+          GenericEgress<T> egress) {
+    if (egress.getTypeInfo().getTypeClass().equals(TypedValue.class)) {
+      return (MapFunction<org.apache.flink.statefun.sdk.reqreply.generated.TypedValue, T>)
+          new ToPublicTypedValue();
+    }
+
+    return new FromInternalType<>(egress.getType());
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/TypedValue.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/TypedValue.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.statefun.sdk.types.TypedValueTypeInfoFactory;
+
+/** A typed value containing a {@link TypeName} and serialized bytes. */
+@TypeInfo(TypedValueTypeInfoFactory.class)
+@SuppressWarnings("unused")
+public class TypedValue {
+  private TypeName typeName;
+
+  private byte[] value;
+
+  public TypedValue() {}
+
+  public TypedValue(TypeName typeName, byte[] value) {
+    this.typeName = Objects.requireNonNull(typeName);
+    this.value = Objects.requireNonNull(value);
+  }
+
+  public void setTypeName(TypeName typeName) {
+    this.typeName = typeName;
+  }
+
+  public void setValue(byte[] value) {
+    this.value = value;
+  }
+
+  public TypeName getTypeName() {
+    return this.typeName;
+  }
+
+  public byte[] getValue() {
+    return this.value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TypedValue typedValue = (TypedValue) o;
+    return Objects.equals(typeName, typedValue.typeName) && Arrays.equals(value, typedValue.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(typeName);
+    result = 31 * result + Arrays.hashCode(value);
+    return result;
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/ByteStringSlice.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/ByteStringSlice.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+final class ByteStringSlice implements Slice {
+  private final ByteString byteString;
+
+  public ByteStringSlice(ByteString bytes) {
+    this.byteString = Objects.requireNonNull(bytes);
+  }
+
+  public ByteString byteString() {
+    return byteString;
+  }
+
+  @Override
+  public ByteBuffer asReadOnlyByteBuffer() {
+    return byteString.asReadOnlyByteBuffer();
+  }
+
+  @Override
+  public int readableBytes() {
+    return byteString.size();
+  }
+
+  @Override
+  public void copyTo(byte[] target) {
+    copyTo(target, 0);
+  }
+
+  @Override
+  public void copyTo(byte[] target, int targetOffset) {
+    byteString.copyTo(target, targetOffset);
+  }
+
+  @Override
+  public void copyTo(OutputStream outputStream) {
+    try {
+      byteString.writeTo(outputStream);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public byte byteAt(int position) {
+    return byteString.byteAt(position);
+  }
+
+  @Override
+  public void copyTo(ByteBuffer buffer) {
+    byteString.copyTo(buffer);
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    return byteString.toByteArray();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slice.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slice.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+public interface Slice {
+
+  int readableBytes();
+
+  void copyTo(ByteBuffer target);
+
+  void copyTo(byte[] target);
+
+  void copyTo(byte[] target, int targetOffset);
+
+  void copyTo(OutputStream outputStream);
+
+  byte byteAt(int position);
+
+  ByteBuffer asReadOnlyByteBuffer();
+
+  byte[] toByteArray();
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceOutput.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceOutput.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.slice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class SliceOutput {
+  private byte[] buf;
+  private int position;
+
+  public static SliceOutput sliceOutput(int initialSize) {
+    return new SliceOutput(initialSize);
+  }
+
+  private SliceOutput(int initialSize) {
+    if (initialSize < 0) {
+      throw new IllegalArgumentException("initial size has to be non negative");
+    }
+    this.buf = new byte[initialSize];
+    this.position = 0;
+  }
+
+  public void write(byte b) {
+    ensureCapacity(1);
+    buf[position] = b;
+    position++;
+  }
+
+  public void write(byte[] buffer) {
+    write(buffer, 0, buffer.length);
+  }
+
+  public void write(byte[] buffer, int offset, int len) {
+    Objects.requireNonNull(buffer);
+    if (offset < 0 || offset > buffer.length) {
+      throw new IllegalArgumentException("Offset out of range " + offset);
+    }
+    if (len < 0) {
+      throw new IllegalArgumentException("Negative length " + len);
+    }
+    ensureCapacity(len);
+    System.arraycopy(buffer, offset, buf, position, len);
+    position += len;
+  }
+
+  public void write(ByteBuffer buffer) {
+    int n = buffer.remaining();
+    ensureCapacity(n);
+    buffer.get(buf, position, n);
+    position += n;
+  }
+
+  public void write(Slice slice) {
+    write(slice.asReadOnlyByteBuffer());
+  }
+
+  public void writeFully(InputStream input) {
+    try {
+      int bytesRead;
+      do {
+        ensureCapacity(256);
+        bytesRead = input.read(buf, position, remaining());
+        position += bytesRead;
+      } while (bytesRead != -1);
+      position++; // compensate for the latest -1 addition.
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public Slice copyOf() {
+    return Slices.copyOf(buf, 0, position);
+  }
+
+  public Slice view() {
+    return Slices.wrap(buf, 0, position);
+  }
+
+  private int remaining() {
+    return buf.length - position;
+  }
+
+  private void ensureCapacity(final int bytesNeeded) {
+    final int requiredNewLength = position + bytesNeeded;
+    if (requiredNewLength >= buf.length) {
+      this.buf = Arrays.copyOf(buf, 2 * requiredNewLength);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceProtobufUtil.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceProtobufUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MoreByteStrings;
+import com.google.protobuf.Parser;
+import org.apache.flink.annotation.Internal;
+
+@Internal
+public final class SliceProtobufUtil {
+  private SliceProtobufUtil() {}
+
+  public static <T> T parseFrom(Parser<T> parser, Slice slice)
+      throws InvalidProtocolBufferException {
+    if (slice instanceof ByteStringSlice) {
+      ByteString byteString = ((ByteStringSlice) slice).byteString();
+      return parser.parseFrom(byteString);
+    }
+    return parser.parseFrom(slice.asReadOnlyByteBuffer());
+  }
+
+  public static Slice toSlice(Message message) {
+    return Slices.wrap(message.toByteArray());
+  }
+
+  public static ByteString asByteString(Slice slice) {
+    if (slice instanceof ByteStringSlice) {
+      ByteStringSlice byteStringSlice = (ByteStringSlice) slice;
+      return byteStringSlice.byteString();
+    }
+    return MoreByteStrings.wrap(slice.asReadOnlyByteBuffer());
+  }
+
+  public static Slice asSlice(ByteString byteString) {
+    return new ByteStringSlice(byteString);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slices.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slices.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public final class Slices {
+  private Slices() {}
+
+  public static Slice wrap(ByteBuffer buffer) {
+    return wrap(MoreByteStrings.wrap(buffer));
+  }
+
+  public static Slice wrap(byte[] bytes) {
+    return wrap(MoreByteStrings.wrap(bytes));
+  }
+
+  private static Slice wrap(ByteString bytes) {
+    return new ByteStringSlice(bytes);
+  }
+
+  public static Slice wrap(byte[] bytes, int offset, int len) {
+    return wrap(MoreByteStrings.wrap(bytes, offset, len));
+  }
+
+  public static Slice copyOf(byte[] bytes) {
+    return wrap(ByteString.copyFrom(bytes));
+  }
+
+  public static Slice copyOf(byte[] bytes, int offset, int len) {
+    return wrap(ByteString.copyFrom(bytes, offset, len));
+  }
+
+  public static Slice copyOf(InputStream inputStream, int expectedStreamSize) {
+    SliceOutput out = SliceOutput.sliceOutput(expectedStreamSize);
+    out.writeFully(inputStream);
+    return out.view();
+  }
+
+  public static Slice copyFromUtf8(String input) {
+    return wrap(ByteString.copyFromUtf8(input));
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SimpleType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SimpleType.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.Slices;
+
+/**
+ * A utility to create simple {@link Type} implementations.
+ *
+ * @param <T> the Java type handled by this {@link Type}.
+ */
+public final class SimpleType<T> implements Type<T> {
+
+  @FunctionalInterface
+  public interface Fn<I, O> {
+    O apply(I input) throws Throwable;
+  }
+
+  public static <T> Type<T> simpleTypeFrom(
+      TypeName typeName, Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+    return new SimpleType<>(typeName, serialize, deserialize, Collections.emptySet());
+  }
+
+  public static <T> Type<T> simpleImmutableTypeFrom(
+      TypeName typeName, Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+    return new SimpleType<>(
+        typeName, serialize, deserialize, EnumSet.of(TypeCharacteristics.IMMUTABLE_VALUES));
+  }
+
+  private final TypeName typeName;
+  private final TypeSerializer<T> serializer;
+  private final Set<TypeCharacteristics> typeCharacteristics;
+
+  private SimpleType(
+      TypeName typeName,
+      Fn<T, byte[]> serialize,
+      Fn<byte[], T> deserialize,
+      Set<TypeCharacteristics> typeCharacteristics) {
+    this.typeName = Objects.requireNonNull(typeName);
+    this.serializer = new Serializer<>(serialize, deserialize);
+    this.typeCharacteristics = Collections.unmodifiableSet(typeCharacteristics);
+  }
+
+  @Override
+  public TypeName typeName() {
+    return typeName;
+  }
+
+  @Override
+  public TypeSerializer<T> typeSerializer() {
+    return serializer;
+  }
+
+  @Override
+  public Set<TypeCharacteristics> typeCharacteristics() {
+    return typeCharacteristics;
+  }
+
+  private static final class Serializer<T> implements TypeSerializer<T> {
+    private final Fn<T, byte[]> serialize;
+    private final Fn<byte[], T> deserialize;
+
+    private Serializer(Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+      this.serialize = Objects.requireNonNull(serialize);
+      this.deserialize = Objects.requireNonNull(deserialize);
+    }
+
+    @Override
+    public Slice serialize(T value) {
+      try {
+        byte[] bytes = serialize.apply(value);
+        return Slices.wrap(bytes);
+      } catch (Throwable throwable) {
+        throw new IllegalStateException(throwable);
+      }
+    }
+
+    @Override
+    public T deserialize(Slice input) {
+      try {
+        byte[] bytes = input.toByteArray();
+        return deserialize.apply(bytes);
+      } catch (Throwable throwable) {
+        throw new IllegalStateException(throwable);
+      }
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SliceType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SliceType.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+
+public final class SliceType implements Type<Slice> {
+
+  private static final Set<TypeCharacteristics> IMMUTABLE_TYPE_CHARS =
+      Collections.unmodifiableSet(EnumSet.of(TypeCharacteristics.IMMUTABLE_VALUES));
+
+  private final TypeName typename;
+  private final Serializer serializer = new Serializer();
+
+  public SliceType(TypeName typename) {
+    this.typename = Objects.requireNonNull(typename);
+  }
+
+  @Override
+  public TypeName typeName() {
+    return typename;
+  }
+
+  @Override
+  public TypeSerializer<Slice> typeSerializer() {
+    return serializer;
+  }
+
+  @Override
+  public Set<TypeCharacteristics> typeCharacteristics() {
+    return IMMUTABLE_TYPE_CHARS;
+  }
+
+  private static final class Serializer implements TypeSerializer<Slice> {
+    @Override
+    public Slice serialize(Slice slice) {
+      return slice;
+    }
+
+    @Override
+    public Slice deserialize(Slice slice) {
+      return slice;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Type.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Type.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.flink.statefun.sdk.TypeName;
+
+/**
+ * This class is the core abstraction used by Stateful Functions's type system, and consists of a
+ * few things that StateFun uses to handle {@code Message}s and {@code ValueSpec}s:
+ *
+ * <ul>
+ *   <li>A {@link TypeName} to identify the type.
+ *   <li>A {@link TypeSerializer} for serializing and deserializing instances of the type.
+ * </ul>
+ *
+ * <h2>Cross-language primitive types</h2>
+ *
+ * <p>StateFun's type system has cross-language support for common primitive types, such as boolean,
+ * integer, long, etc. These primitive types have built-in {@link Type}s implemented for them
+ * already, with predefined {@link TypeName}s.
+ *
+ * <p>This is of course all transparent for the user, so you don't need to worry about it. Functions
+ * implemented in various languages (e.g. Java or Python) can message each other by directly sending
+ * supported primitive values as message arguments.
+ *
+ * <h2>Common custom types (e.g. JSON or Protobuf)</h2>
+ *
+ * <p>The type system is also very easily extensible to support custom message types, such as JSON
+ * or Protobuf messages. This is just a matter of implementing your own {@link Type} with a custom
+ * typename and serializer. Alternatively, you can also use the {@link SimpleType} class to do this
+ * easily.
+ *
+ * @param <T> the Java type of serialized / deserialized instances.
+ */
+public interface Type<T> extends Serializable {
+
+  /** @return The unique {@link TypeName} of this type. */
+  TypeName typeName();
+
+  /** @return A {@link TypeSerializer} that can serialize and deserialize this type. */
+  TypeSerializer<T> typeSerializer();
+
+  default Set<TypeCharacteristics> typeCharacteristics() {
+    return Collections.emptySet();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeCharacteristics.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeCharacteristics.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+public enum TypeCharacteristics {
+  IMMUTABLE_VALUES
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeNameSerializer.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeNameSerializer.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import java.io.IOException;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.statefun.sdk.TypeName;
+
+@Internal
+public class TypeNameSerializer extends TypeSerializerSingleton<TypeName> {
+
+  public static final TypeNameSerializer INSTANCE = new TypeNameSerializer();
+
+  @Override
+  public boolean isImmutableType() {
+    return true;
+  }
+
+  @Override
+  public TypeName createInstance() {
+    return new TypeName("", "");
+  }
+
+  @Override
+  public TypeName copy(TypeName from) {
+    return from;
+  }
+
+  @Override
+  public TypeName copy(TypeName from, TypeName reuse) {
+    return from;
+  }
+
+  @Override
+  public int getLength() {
+    return -1;
+  }
+
+  @Override
+  public void serialize(TypeName record, DataOutputView target) throws IOException {
+    StringSerializer.INSTANCE.serialize(record.canonicalTypenameString(), target);
+  }
+
+  @Override
+  public TypeName deserialize(DataInputView source) throws IOException {
+    return TypeName.parseFrom(StringSerializer.INSTANCE.deserialize(source));
+  }
+
+  @Override
+  public TypeName deserialize(TypeName reuse, DataInputView source) throws IOException {
+    return deserialize(source);
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    StringSerializer.INSTANCE.copy(source, target);
+  }
+
+  @Override
+  public TypeSerializerSnapshot<TypeName> snapshotConfiguration() {
+    return new TypeNameSerializerSnapshot();
+  }
+
+  /** Serializer configuration snapshot for compatibility and format evolution. */
+  @SuppressWarnings("WeakerAccess")
+  public static final class TypeNameSerializerSnapshot
+      extends SimpleTypeSerializerSnapshot<TypeName> {
+
+    public TypeNameSerializerSnapshot() {
+      super(() -> INSTANCE);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeNameTypeInfo.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeNameTypeInfo.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.TypeName;
+
+public class TypeNameTypeInfo extends TypeInformation<TypeName> {
+  @Override
+  public boolean isBasicType() {
+    return false;
+  }
+
+  @Override
+  public boolean isTupleType() {
+    return false;
+  }
+
+  @Override
+  public int getArity() {
+    return 2;
+  }
+
+  @Override
+  public int getTotalFields() {
+    return 2;
+  }
+
+  @Override
+  public Class<TypeName> getTypeClass() {
+    return TypeName.class;
+  }
+
+  @Override
+  public boolean isKeyType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<TypeName> createSerializer(ExecutionConfig config) {
+    return new TypeNameSerializer();
+  }
+
+  @Override
+  public String toString() {
+    return "TypeNameSerializer";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TypeNameTypeInfo;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 >> TypeNameTypeInfo.class.hashCode();
+  }
+
+  @Override
+  public boolean canEqual(Object obj) {
+    return equals(obj);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeSerializer.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeSerializer.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import org.apache.flink.statefun.sdk.slice.Slice;
+
+public interface TypeSerializer<T> {
+
+  Slice serialize(T value);
+
+  T deserialize(Slice bytes);
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypedValueTypeInfoFactory.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypedValueTypeInfoFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.statefun.sdk.TypedValue;
+
+@Internal
+public class TypedValueTypeInfoFactory extends TypeInfoFactory<TypedValue> {
+
+  @Override
+  public TypeInformation<TypedValue> createTypeInfo(
+      Type t, Map<String, TypeInformation<?>> genericParameters) {
+    return Types.POJO(
+        TypedValue.class,
+        new HashMap<String, TypeInformation<?>>() {
+          {
+            put("typeName", new TypeNameTypeInfo());
+            put("value", Types.PRIMITIVE_ARRAY(Types.BYTE));
+          }
+        });
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Types.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Types.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import static org.apache.flink.statefun.sdk.slice.SliceProtobufUtil.parseFrom;
+import static org.apache.flink.statefun.sdk.slice.SliceProtobufUtil.toSlice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MoreByteStrings;
+import com.google.protobuf.WireFormat;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.slice.Slices;
+import org.apache.flink.statefun.sdk.types.generated.BooleanWrapper;
+import org.apache.flink.statefun.sdk.types.generated.DoubleWrapper;
+import org.apache.flink.statefun.sdk.types.generated.FloatWrapper;
+import org.apache.flink.statefun.sdk.types.generated.IntWrapper;
+import org.apache.flink.statefun.sdk.types.generated.LongWrapper;
+import org.apache.flink.statefun.sdk.types.generated.StringWrapper;
+
+public final class Types {
+  private Types() {}
+
+  // primitives
+  public static final TypeName BOOLEAN_TYPENAME = TypeName.parseFrom("io.statefun.types/bool");
+  public static final TypeName INTEGER_TYPENAME = TypeName.parseFrom("io.statefun.types/int");
+  public static final TypeName FLOAT_TYPENAME = TypeName.parseFrom("io.statefun.types/float");
+  public static final TypeName LONG_TYPENAME = TypeName.parseFrom("io.statefun.types/long");
+  public static final TypeName DOUBLE_TYPENAME = TypeName.parseFrom("io.statefun.types/double");
+  public static final TypeName STRING_TYPENAME = TypeName.parseFrom("io.statefun.types/string");
+
+  // common characteristics
+  private static final Set<TypeCharacteristics> IMMUTABLE_TYPE_CHARS =
+      Collections.unmodifiableSet(EnumSet.of(TypeCharacteristics.IMMUTABLE_VALUES));
+
+  public static Type<Long> longType() {
+    return LongType.INSTANCE;
+  }
+
+  public static Type<String> stringType() {
+    return StringType.INSTANCE;
+  }
+
+  public static Type<Integer> integerType() {
+    return IntegerType.INSTANCE;
+  }
+
+  public static Type<Boolean> booleanType() {
+    return BooleanType.INSTANCE;
+  }
+
+  public static Type<Float> floatType() {
+    return FloatType.INSTANCE;
+  }
+
+  public static Type<Double> doubleType() {
+    return DoubleType.INSTANCE;
+  }
+
+  /**
+   * Compute the Protobuf field tag, as specified by the Protobuf wire format. See {@code
+   * WireFormat#makeTag(int, int)}}. NOTE: that, currently, for all StateFun provided wire types the
+   * tags should be 1 byte.
+   *
+   * @param fieldNumber the field number as specified in the message definition.
+   * @param wireType the field type as specified in the message definition.
+   * @return the field tag as a single byte.
+   */
+  private static byte protobufTagAsSingleByte(int fieldNumber, int wireType) {
+    int fieldTag = fieldNumber << 3 | wireType;
+    if (fieldTag < -127 || fieldTag > 127) {
+      throw new IllegalStateException(
+          "Protobuf Wrapper type compatibility is bigger than one byte.");
+    }
+    return (byte) fieldTag;
+  }
+
+  private static final Slice EMPTY_SLICE = Slices.wrap(new byte[] {});
+
+  private static final class LongType implements Type<Long> {
+
+    static final Type<Long> INSTANCE = new LongType();
+
+    private static final TypeSerializer<Long> serializer = new LongTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return LONG_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Long> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class LongTypeSerializer implements TypeSerializer<Long> {
+
+    @Override
+    public Slice serialize(Long element) {
+      return serializeLongWrapperCompatibleLong(element);
+    }
+
+    @Override
+    public Long deserialize(Slice input) {
+      return deserializeLongWrapperCompatibleLong(input);
+    }
+
+    private static final byte WRAPPER_TYPE_FIELD_TAG =
+        protobufTagAsSingleByte(LongWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_FIXED64);
+
+    private static Slice serializeLongWrapperCompatibleLong(long n) {
+      if (n == 0) {
+        return EMPTY_SLICE;
+      }
+      byte[] out = new byte[9];
+      out[0] = WRAPPER_TYPE_FIELD_TAG;
+      out[1] = (byte) (n & 0xFF);
+      out[2] = (byte) ((n >> 8) & 0xFF);
+      out[3] = (byte) ((n >> 16) & 0xFF);
+      out[4] = (byte) ((n >> 24) & 0xFF);
+      out[5] = (byte) ((n >> 32) & 0xFF);
+      out[6] = (byte) ((n >> 40) & 0xFF);
+      out[7] = (byte) ((n >> 48) & 0xFF);
+      out[8] = (byte) ((n >> 56) & 0xFF);
+      return Slices.wrap(out);
+    }
+
+    private static long deserializeLongWrapperCompatibleLong(Slice slice) {
+      if (slice.readableBytes() == 0) {
+        return 0;
+      }
+      if (slice.byteAt(0) != WRAPPER_TYPE_FIELD_TAG) {
+        throw new IllegalStateException("Not a LongWrapper");
+      }
+      return slice.byteAt(1) & 0xFFL
+          | (slice.byteAt(2) & 0xFFL) << 8
+          | (slice.byteAt(3) & 0xFFL) << 16
+          | (slice.byteAt(4) & 0xFFL) << 24
+          | (slice.byteAt(5) & 0xFFL) << 32
+          | (slice.byteAt(6) & 0xFFL) << 40
+          | (slice.byteAt(7) & 0xFFL) << 48
+          | (slice.byteAt(8) & 0xFFL) << 56;
+    }
+  }
+
+  private static final class StringType implements Type<String> {
+
+    static final Type<String> INSTANCE = new StringType();
+
+    private static final TypeSerializer<String> serializer = new StringTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return STRING_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<String> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class StringTypeSerializer implements TypeSerializer<String> {
+
+    private static final byte STRING_WRAPPER_FIELD_TYPE =
+        protobufTagAsSingleByte(
+            StringWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+
+    @Override
+    public Slice serialize(String element) {
+      return serializeStringWrapperCompatibleString(element);
+    }
+
+    @Override
+    public String deserialize(Slice input) {
+      return deserializeStringWrapperCompatibleString(input);
+    }
+
+    private static Slice serializeStringWrapperCompatibleString(String element) {
+      if (element.isEmpty()) {
+        return EMPTY_SLICE;
+      }
+      ByteString utf8 = ByteString.copyFromUtf8(element);
+      byte[] header = new byte[1 + 5 + utf8.size()];
+      int position = 0;
+      // write the field tag
+      header[position++] = STRING_WRAPPER_FIELD_TYPE;
+      // write utf8 bytes.length as a VarInt.
+      int varIntLen = utf8.size();
+      while ((varIntLen & -128) != 0) {
+        header[position++] = ((byte) (varIntLen & 127 | 128));
+        varIntLen >>>= 7;
+      }
+      header[position++] = ((byte) varIntLen);
+      // concat header and the utf8 string bytes
+      ByteString headerBuf = MoreByteStrings.wrap(header, 0, position);
+      ByteString result = MoreByteStrings.concat(headerBuf, utf8);
+      return SliceProtobufUtil.asSlice(result);
+    }
+
+    private static String deserializeStringWrapperCompatibleString(Slice input) {
+      if (input.readableBytes() == 0) {
+        return "";
+      }
+      ByteString buf = SliceProtobufUtil.asByteString(input);
+      int position = 0;
+      // read field tag
+      if (buf.byteAt(position++) != STRING_WRAPPER_FIELD_TYPE) {
+        throw new IllegalStateException("Not a StringWrapper");
+      }
+      // read VarInt32 length
+      int shift = 0;
+      long varIntSize = 0;
+      while (shift < 32) {
+        final byte b = buf.byteAt(position++);
+        varIntSize |= (long) (b & 0x7F) << shift;
+        if ((b & 0x80) == 0) {
+          break;
+        }
+        shift += 7;
+      }
+      // sanity checks
+      if (varIntSize < 0 || varIntSize > Integer.MAX_VALUE) {
+        throw new IllegalStateException("Malformed VarInt");
+      }
+      final int endIndex = position + (int) varIntSize;
+      ByteString utf8Bytes = buf.substring(position, endIndex);
+      return utf8Bytes.toStringUtf8();
+    }
+  }
+
+  private static final class IntegerType implements Type<Integer> {
+
+    static final Type<Integer> INSTANCE = new IntegerType();
+
+    private static final TypeSerializer<Integer> serializer = new IntegerTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return INTEGER_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Integer> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class IntegerTypeSerializer implements TypeSerializer<Integer> {
+    private static final byte WRAPPER_TYPE_FIELD_TYPE =
+        protobufTagAsSingleByte(IntWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_FIXED32);
+
+    @Override
+    public Slice serialize(Integer element) {
+      return serializeIntegerWrapperCompatibleInt(element);
+    }
+
+    @Override
+    public Integer deserialize(Slice input) {
+      return deserializeIntegerWrapperCompatibleInt(input);
+    }
+
+    private static Slice serializeIntegerWrapperCompatibleInt(int n) {
+      if (n == 0) {
+        return EMPTY_SLICE;
+      }
+      byte[] out = new byte[5];
+      out[0] = WRAPPER_TYPE_FIELD_TYPE;
+      out[1] = (byte) (n & 0xFF);
+      out[2] = (byte) ((n >> 8) & 0xFF);
+      out[3] = (byte) ((n >> 16) & 0xFF);
+      out[4] = (byte) ((n >> 24) & 0xFF);
+      return Slices.wrap(out);
+    }
+
+    private static int deserializeIntegerWrapperCompatibleInt(Slice slice) {
+      if (slice.readableBytes() == 0) {
+        return 0;
+      }
+      if (slice.byteAt(0) != WRAPPER_TYPE_FIELD_TYPE) {
+        throw new IllegalStateException("Not an IntWrapper");
+      }
+      return slice.byteAt(1) & 0xFF
+          | (slice.byteAt(2) & 0xFF) << 8
+          | (slice.byteAt(3) & 0xFF) << 16
+          | (slice.byteAt(4) & 0xFF) << 24;
+    }
+  }
+
+  private static final class BooleanType implements Type<Boolean> {
+
+    static final Type<Boolean> INSTANCE = new BooleanType();
+
+    private static final TypeSerializer<Boolean> serializer = new BooleanTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return BOOLEAN_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Boolean> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class BooleanTypeSerializer implements TypeSerializer<Boolean> {
+    private static final Slice TRUE_SLICE =
+        toSlice(BooleanWrapper.newBuilder().setValue(true).build());
+    private static final Slice FALSE_SLICE =
+        toSlice(BooleanWrapper.newBuilder().setValue(false).build());
+    private static final byte WRAPPER_TYPE_TAG =
+        protobufTagAsSingleByte(BooleanWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_VARINT);
+
+    @Override
+    public Slice serialize(Boolean element) {
+      return element ? TRUE_SLICE : FALSE_SLICE;
+    }
+
+    @Override
+    public Boolean deserialize(Slice input) {
+      if (input.readableBytes() == 0) {
+        return false;
+      }
+      final byte tag = input.byteAt(0);
+      final byte value = input.byteAt(1);
+      if (tag != WRAPPER_TYPE_TAG || value != (byte) 1) {
+        throw new IllegalStateException("Not a BooleanWrapper value.");
+      }
+      return true;
+    }
+  }
+
+  private static final class FloatType implements Type<Float> {
+
+    static final Type<Float> INSTANCE = new FloatType();
+
+    private static final TypeSerializer<Float> serializer = new FloatTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return FLOAT_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Float> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class FloatTypeSerializer implements TypeSerializer<Float> {
+
+    @Override
+    public Slice serialize(Float element) {
+      FloatWrapper wrapper = FloatWrapper.newBuilder().setValue(element).build();
+      return toSlice(wrapper);
+    }
+
+    @Override
+    public Float deserialize(Slice input) {
+      try {
+        FloatWrapper wrapper = parseFrom(FloatWrapper.parser(), input);
+        return wrapper.getValue();
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+
+  private static final class DoubleType implements Type<Double> {
+
+    static final Type<Double> INSTANCE = new DoubleType();
+
+    private static final TypeSerializer<Double> serializer = new DoubleTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return DOUBLE_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Double> typeSerializer() {
+      return serializer;
+    }
+
+    public Set<TypeCharacteristics> typeCharacteristics() {
+      return IMMUTABLE_TYPE_CHARS;
+    }
+  }
+
+  private static final class DoubleTypeSerializer implements TypeSerializer<Double> {
+
+    @Override
+    public Slice serialize(Double element) {
+      DoubleWrapper wrapper = DoubleWrapper.newBuilder().setValue(element).build();
+      return toSlice(wrapper);
+    }
+
+    @Override
+    public Double deserialize(Slice input) {
+      try {
+        DoubleWrapper wrapper = parseFrom(DoubleWrapper.parser(), input);
+        return wrapper.getValue();
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/EndpointTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/EndpointTest.java
@@ -1,0 +1,23 @@
+package org.apache.flink.statefun.flink.datastream;
+
+import org.junit.Test;
+
+/** Test validation of {@link Endpoint} specification. */
+public class EndpointTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWildcardNamespaceValidation() {
+    Endpoint.withSpec("*/name", "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWildcardNameValidation() {
+    Endpoint.withSpec("namespace/na*e", "");
+  }
+
+  @Test
+  public void testValidFunctions() {
+    Endpoint.withSpec("namespace/name", "");
+    Endpoint.withSpec("namespace/*", "");
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionsDataStreamInteropITCase.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionsDataStreamInteropITCase.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Types;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.StreamCollector;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** IT Case for Stateful Function interop. */
+public class StatefulFunctionsDataStreamInteropITCase {
+
+  private static final FunctionType TYPE = new FunctionType("example", "test");
+
+  private static final GenericEgress<String> greetings =
+      GenericEgress.named(TypeName.parseFrom("example/egress")).withUtf8StringType();
+
+  @ClassRule
+  public static MiniClusterWithClientResource flinkCluster =
+      new MiniClusterWithClientResource(
+          new MiniClusterResourceConfiguration.Builder()
+              .setNumberSlotsPerTaskManager(2)
+              .setNumberTaskManagers(1)
+              .build());
+
+  @Rule public StreamCollector collector = new StreamCollector();
+
+  @Test
+  public void testDataStreamInterop() throws Exception {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.getConfig().enableObjectReuse();
+
+    DataStream<String> stream = env.fromElements("John", "Sally");
+
+    StatefulFunctionDataStreamBuilder builder =
+        StatefulFunctionDataStreamBuilder.builder("datastream-interop")
+            .withDataStreamIngress(stream, name -> new Address(TYPE, name))
+            .withEndpoint(Endpoint.withSpec("remote/specific", "http://endpoint"))
+            .withEndpoint(Endpoint.withSpec("remote/*", "http://endpoint/{function.name}"))
+            .withFunctionProvider(
+                TYPE, (SerializableStatefulFunctionProvider) type -> new TestFunction())
+            .withGenericEgress(greetings);
+
+    StatefulFunctionEgressStreams egressStreams = builder.build(env);
+
+    DataStream<String> egress = egressStreams.getDataStream(greetings);
+    CompletableFuture<Collection<String>> results = collector.collect(egress);
+
+    env.execute();
+
+    Assert.assertThat(
+        "unexpected output from Stateful Functions environment",
+        results.get(),
+        Matchers.hasItems("John", "Sally"));
+  }
+
+  public static class TestFunction implements StatefulFunction {
+
+    @Override
+    public void invoke(Context context, Object input) {
+      Assert.assertThat("unexpected input data type", input, Matchers.instanceOf(TypedValue.class));
+      TypedValue typedValue = (TypedValue) input;
+      String message =
+          Types.stringType()
+              .typeSerializer()
+              .deserialize(SliceProtobufUtil.asSlice(typedValue.getValue()));
+      Assert.assertEquals("unexpected address id for record", context.self().id(), message);
+      context.send(StatefulFunctionsDataStreamInteropITCase.greetings.getId(), typedValue);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SanityPrimitiveTypeTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SanityPrimitiveTypeTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.Slices;
+import org.apache.flink.statefun.sdk.types.generated.BooleanWrapper;
+import org.apache.flink.statefun.sdk.types.generated.IntWrapper;
+import org.apache.flink.statefun.sdk.types.generated.LongWrapper;
+import org.apache.flink.statefun.sdk.types.generated.StringWrapper;
+import org.junit.Test;
+
+public class SanityPrimitiveTypeTest {
+
+  @Test
+  public void testBoolean() {
+    assertRoundTrip(Types.booleanType(), Boolean.TRUE);
+    assertRoundTrip(Types.booleanType(), Boolean.FALSE);
+  }
+
+  @Test
+  public void testInt() {
+    assertRoundTrip(Types.integerType(), 1);
+    assertRoundTrip(Types.integerType(), 1048576);
+    assertRoundTrip(Types.integerType(), Integer.MIN_VALUE);
+    assertRoundTrip(Types.integerType(), Integer.MAX_VALUE);
+    assertRoundTrip(Types.integerType(), -1);
+  }
+
+  @Test
+  public void testLong() {
+    assertRoundTrip(Types.longType(), -1L);
+    assertRoundTrip(Types.longType(), 0L);
+    assertRoundTrip(Types.longType(), Long.MIN_VALUE);
+    assertRoundTrip(Types.longType(), Long.MAX_VALUE);
+  }
+
+  @Test
+  public void testFloat() {
+    assertRoundTrip(Types.floatType(), Float.MIN_VALUE);
+    assertRoundTrip(Types.floatType(), Float.MAX_VALUE);
+    assertRoundTrip(Types.floatType(), 2.1459f);
+    assertRoundTrip(Types.floatType(), -1e-4f);
+  }
+
+  @Test
+  public void testDouble() {
+    assertRoundTrip(Types.doubleType(), Double.MIN_VALUE);
+    assertRoundTrip(Types.doubleType(), Double.MAX_VALUE);
+    assertRoundTrip(Types.doubleType(), 2.1459d);
+    assertRoundTrip(Types.doubleType(), -1e-4d);
+  }
+
+  @Test
+  public void testString() {
+    assertRoundTrip(Types.stringType(), "");
+    assertRoundTrip(Types.stringType(), "This is a string");
+  }
+
+  @Test
+  public void testSlice() {
+    final TypeName typename = new TypeName("test.namespace", "test.name");
+    assertRoundTrip(
+        new SliceType(typename), Slices.wrap("payload-foobar".getBytes(StandardCharsets.UTF_8)));
+    assertRoundTrip(new SliceType(typename), Slices.wrap(new byte[] {}));
+  }
+
+  @Test
+  public void testRandomCompatibilityWithAnIntegerWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Integer> serializer = Types.integerType().typeSerializer();
+    for (int i = 0; i < 1_000_000; i++) {
+      testCompatibilityWithWrapper(
+          serializer, IntWrapper::parseFrom, IntWrapper::getValue, IntWrapper::toByteArray, i);
+    }
+  }
+
+  @Test
+  public void testCompatibilityWithABooleanWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Boolean> serializer = Types.booleanType().typeSerializer();
+    testCompatibilityWithWrapper(
+        serializer,
+        BooleanWrapper::parseFrom,
+        BooleanWrapper::getValue,
+        BooleanWrapper::toByteArray,
+        true);
+
+    testCompatibilityWithWrapper(
+        serializer,
+        BooleanWrapper::parseFrom,
+        BooleanWrapper::getValue,
+        BooleanWrapper::toByteArray,
+        false);
+  }
+
+  @Test
+  public void testRandomCompatibilityWithALongWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Long> serializer = Types.longType().typeSerializer();
+    for (long i = 0; i < 1_000_000; i++) {
+      testCompatibilityWithWrapper(
+          serializer, LongWrapper::parseFrom, LongWrapper::getValue, LongWrapper::toByteArray, i);
+    }
+  }
+
+  @Test
+  public void testRandomCompatibilityWithStringWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<String> serializer = Types.stringType().typeSerializer();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = 0; i < 1_000; i++) {
+      int n = random.nextInt(4096);
+      byte[] buf = new byte[n];
+      random.nextBytes(buf);
+      String expected = new String(buf, StandardCharsets.UTF_8);
+
+      testCompatibilityWithWrapper(
+          serializer,
+          StringWrapper::parseFrom,
+          StringWrapper::getValue,
+          StringWrapper::toByteArray,
+          expected);
+    }
+  }
+
+  @FunctionalInterface
+  interface Fn<I, O> {
+    O apply(I input) throws InvalidProtocolBufferException;
+  }
+
+  private static <T, W> void testCompatibilityWithWrapper(
+      TypeSerializer<T> serializer,
+      Fn<ByteBuffer, W> parseFrom,
+      Fn<W, T> getValue,
+      Fn<W, byte[]> toByteArray,
+      T expected)
+      throws InvalidProtocolBufferException {
+    //
+    // test round trip with ourself.
+    //
+    final Slice serialized = serializer.serialize(expected);
+    final T got = serializer.deserialize(serialized);
+    assertEquals(expected, got);
+    //
+    // test that protobuf can parse what we wrote:
+    //
+    final W wrapper = parseFrom.apply(serialized.asReadOnlyByteBuffer());
+    assertEquals(expected, getValue.apply(wrapper));
+    //
+    // test that we can parse what protobuf wrote:
+    //
+    final Slice serializedByPb = Slices.wrap(toByteArray.apply(wrapper));
+    final T gotPb = serializer.deserialize(serializedByPb);
+    assertEquals(gotPb, expected);
+    // test that pb byte representation is equal to ours:
+    assertEquals(serializedByPb.asReadOnlyByteBuffer(), serialized.asReadOnlyByteBuffer());
+  }
+
+  public <T> void assertRoundTrip(Type<T> type, T element) {
+    final Slice slice;
+    {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      slice = serializer.serialize(element);
+    }
+    TypeSerializer<T> serializer = type.typeSerializer();
+    T got = serializer.deserialize(slice);
+    assertEquals(element, got);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SimpleTypeTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SimpleTypeTest.java
@@ -1,0 +1,48 @@
+package org.apache.flink.statefun.sdk.types;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.junit.Test;
+
+public class SimpleTypeTest {
+
+  @Test
+  public void mutableType() {
+    final Type<String> type =
+        SimpleType.simpleTypeFrom(
+            TypeName.parseFrom("test/simple-mutable-type"),
+            val -> val.getBytes(StandardCharsets.UTF_8),
+            bytes -> new String(bytes, StandardCharsets.UTF_8));
+
+    assertThat(type.typeName(), is(TypeName.parseFrom("test/simple-mutable-type")));
+    assertRoundTrip(type, "hello world!");
+  }
+
+  @Test
+  public void immutableType() {
+    final Type<String> type =
+        SimpleType.simpleImmutableTypeFrom(
+            TypeName.parseFrom("test/simple-immutable-type"),
+            val -> val.getBytes(StandardCharsets.UTF_8),
+            bytes -> new String(bytes, StandardCharsets.UTF_8));
+
+    assertThat(type.typeName(), is(TypeName.parseFrom("test/simple-immutable-type")));
+    assertRoundTrip(type, "hello world!");
+  }
+
+  public <T> void assertRoundTrip(Type<T> type, T element) {
+    final Slice slice;
+    {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      slice = serializer.serialize(element);
+    }
+    TypeSerializer<T> serializer = type.typeSerializer();
+    T deserialized = serializer.deserialize(slice);
+    assertEquals(element, deserialized);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/TypeNameSerializerTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/TypeNameSerializerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.TypeName;
+
+public class TypeNameSerializerTest extends SerializerTestBase<TypeName> {
+
+  @Override
+  protected TypeSerializer<TypeName> createSerializer() {
+    return new TypeNameSerializer();
+  }
+
+  @Override
+  protected int getLength() {
+    return -1;
+  }
+
+  @Override
+  protected Class<TypeName> getTypeClass() {
+    return TypeName.class;
+  }
+
+  @Override
+  protected TypeName[] getTestData() {
+    return new TypeName[] {new TypeName("namespace", "name")};
+  }
+}


### PR DESCRIPTION
Improve Stateful Functions <-> DataStream interop to improve usable with remote functions based on best practices / lessons learned from DataStream / Table interop. In particular: 

- Automatic type conversion between JVM primitives and remote type system
- Plugable types for use with complex class
- Hide internal classes like TypedValue
- Support all endpoint configuration including wildcards and URL path templating

Please see the docs and `ITCase` for full working examples. 

Unfortunately, I had to copy the `Type` and `TypeSerializer` classes from `statefun-sdk-java` because on the DataStream side we need them working against unshaded protobuf. As I don't imagine these classes will often (if ever) change I think this is alright but I wanted to point it out. 