### PR TITLE
[FLINK-23520][datastream] improve statefun <-> datastream interop

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/SdkMessage.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/message/SdkMessage.java
@@ -22,13 +22,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.statefun.flink.core.generated.Envelope;
 import org.apache.flink.statefun.flink.core.generated.Envelope.Builder;
 import org.apache.flink.statefun.flink.core.generated.EnvelopeAddress;
 import org.apache.flink.statefun.sdk.Address;
 
-final class SdkMessage implements Message {
+@Internal
+public final class SdkMessage implements Message {
 
   private final Address target;
 
@@ -38,7 +40,7 @@ final class SdkMessage implements Message {
 
   private Object payload;
 
-  SdkMessage(@Nullable Address source, Address target, Object payload) {
+  public SdkMessage(@Nullable Address source, Address target, Object payload) {
     this(source, target, payload, null);
   }
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -29,10 +29,21 @@ under the License.
 
     <artifactId>statefun-flink-datastream</artifactId>
 
+    <properties>
+        <protocol-messages.dir>${basedir}/target/generated-sources/protocol-messages/</protocol-messages.dir>
+        <proto-sources.dir>target/proto-sources</proto-sources.dir>
+        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-sdk-embedded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>statefun-sdk-protos</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -77,11 +88,121 @@ under the License.
             <version>${flink.version}</version>
             <scope>provided</scope>
        </dependency>
-        
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Step 1: (generate-sources) unpack protocol source proto files -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-protobuf</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.flink</groupId>
+                                    <artifactId>statefun-sdk-protos</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${proto-sources.dir}</outputDirectory>
+                                    <includes>types/*.proto</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Step 2: (generate-sources) generate protocol java messages with protoc -->
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>${protoc-jar-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-protobuf-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <includeStdTypes>true</includeStdTypes>
+                            <protocVersion>${protobuf.version}</protocVersion>
+                            <cleanOutputFolder>true</cleanOutputFolder>
+                            <inputDirectories>
+                                <inputDirectory>src/main/protobuf</inputDirectory>
+                                <inputDirectory>${proto-sources.dir}</inputDirectory>
+                            </inputDirectories>
+                            <outputDirectory>${protocol-messages.dir}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${protocol-messages.dir}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -78,12 +78,6 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-java</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/Endpoint.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/Endpoint.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.common.json.StateFunObjectMapper;
+import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
+import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
+import org.apache.flink.statefun.flink.core.httpfn.TargetFunctions;
+import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
+import org.apache.flink.statefun.flink.core.httpfn.TransportClientSpec;
+import org.apache.flink.statefun.flink.core.httpfn.UrlPathTemplate;
+import org.apache.flink.statefun.sdk.TypeName;
+
+/**
+ * Specifies an endpoint for connecting to a remote function. This spec corresponds to the {@code
+ * endpoints} section of the {@code module.yaml} configuration file.The specification correlates the
+ * logical typename of a function to a physical endpoints.
+ *
+ * <p>The {@code functions} parameter of the Endpoint is the {@link TypeName} of the logical
+ * Stateful Functions. This parameter can points towards a fully qualified typename - {@literal
+ * '<namespace>/<name>'} or contain a wildcard in the name position - {@literal '<namespace>/*'}.
+ * Wildcard endpoints will match all functions under the given namespace.
+ *
+ * <p>The {@code urlPathTemplate} parameter is the physical URL under which the functions are
+ * available. Path templates may contain template parameters that are filled in based on the
+ * functions specific type. Template parameterization works well with load balancers and service
+ * gateways.
+ *
+ * <p>For example, a message sent to the typename {@literal 'com.example/greeter'} will be routed to
+ * {@literal 'http://bar.foo.com/greeter'}.
+ *
+ * <p>{@code Endpoint.http("example/*", "https://endpoints/{function.name}"}</pre>
+ */
+public abstract class Endpoint {
+
+  private final TargetFunctions targetFunctions;
+
+  private Endpoint(TargetFunctions targetFunctions) {
+    this.targetFunctions = targetFunctions;
+  }
+
+  /** Creates a new http endpoint based on the given specification. */
+  public static HttpEndpoint http(String functions, String urlPathTemplate) {
+    Objects.requireNonNull(functions, "functions cannot be null");
+    Objects.requireNonNull(urlPathTemplate, "urlPathTemplate cannot be null");
+    TargetFunctions targetFunctions = TargetFunctions.fromPatternString(functions);
+
+    return new HttpEndpoint(targetFunctions, new UrlPathTemplate(urlPathTemplate));
+  }
+
+  @Internal
+  abstract SerializableStatefulFunctionProvider getFunctionProvider();
+
+  @Internal
+  final TargetFunctions targetFunctions() {
+    return targetFunctions;
+  }
+
+  public static class HttpEndpoint extends Endpoint {
+
+    private final DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec =
+        new DefaultHttpRequestReplyClientSpec.Timeouts();
+
+    private final HttpFunctionEndpointSpec.Builder builder;
+
+    private HttpEndpoint(TargetFunctions functions, UrlPathTemplate urlPathTemplate) {
+      super(functions);
+      this.builder = HttpFunctionEndpointSpec.builder(functions, urlPathTemplate);
+    }
+
+    /**
+     * Set a maximum request duration. This duration spans the complete call, including connecting
+     * to the function endpoint, writing the request, function processing, and reading the response.
+     *
+     * @param duration the duration after which the request is considered failed.
+     * @return this builder.
+     */
+    public HttpEndpoint withMaxRequestDuration(Duration duration) {
+      transportClientTimeoutsSpec.setCallTimeout(duration);
+      return this;
+    }
+
+    /**
+     * Set a timeout for connecting to function endpoints.
+     *
+     * @param duration the duration after which a connect attempt is considered failed.
+     * @return this builder.
+     */
+    public HttpEndpoint withConnectTimeout(Duration duration) {
+      transportClientTimeoutsSpec.setConnectTimeout(duration);
+      return this;
+    }
+
+    /**
+     * Set a timeout for individual read IO operations during a function invocation request.
+     *
+     * @param duration the duration after which a read IO operation is considered failed.
+     * @return this builder.
+     */
+    public HttpEndpoint withReadTimeout(Duration duration) {
+      transportClientTimeoutsSpec.setReadTimeout(duration);
+      return this;
+    }
+
+    /**
+     * Set a timeout for individual write IO operations during a function invocation request.
+     *
+     * @param duration the duration after which a write IO operation is considered failed.
+     * @return this builder.
+     */
+    public HttpEndpoint withWriteTimeout(Duration duration) {
+      transportClientTimeoutsSpec.setWriteTimeout(duration);
+      return this;
+    }
+
+    /**
+     * Sets the max messages to batch together for a specific address.
+     *
+     * @param maxNumBatchRequests the maximum number of requests to batch for an address.
+     * @return this builder.
+     */
+    public HttpEndpoint withMaxNumBatchRequests(int maxNumBatchRequests) {
+      builder.withMaxNumBatchRequests(maxNumBatchRequests);
+      return this;
+    }
+
+    @Override
+    SerializableStatefulFunctionProvider getFunctionProvider() {
+      final TransportClientSpec transportClientSpec =
+          new TransportClientSpec(
+              TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE,
+              transportClientPropertiesAsObjectNode(transportClientTimeoutsSpec));
+      builder.withTransport(transportClientSpec);
+      return new SerializableHttpFunctionProvider(builder.build());
+    }
+
+    private static ObjectNode transportClientPropertiesAsObjectNode(
+        DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec) {
+      final DefaultHttpRequestReplyClientSpec transportClientSpecPojo =
+          new DefaultHttpRequestReplyClientSpec();
+      transportClientSpecPojo.setTimeouts(transportClientTimeoutsSpec);
+
+      return StateFunObjectMapper.create().valueToTree(transportClientSpecPojo);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/GenericEgress.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/GenericEgress.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+
+/** Identifies a generic egress. */
+public class GenericEgress {
+  private final EgressIdentifier<TypedValue> id;
+
+  private GenericEgress(TypeName typeName) {
+    this.id = new EgressIdentifier<>(typeName.name(), typeName.name(), TypedValue.class);
+  }
+
+  @Override
+  public String toString() {
+    return "GenericEgress{" + "typeName=" + id.namespace() + "/" + id.name() + '}';
+  }
+
+  @Internal
+  EgressIdentifier<TypedValue> getId() {
+    return this.id;
+  }
+
+  /**
+   * Creates a generic egress with the given name.
+   *
+   * <pre>{@code
+   * final GenericEgress egress =
+   *    GenericEgress.named(TypeName.parseFrom("example/egress"));
+   * }</pre>
+   *
+   * @param typeName unique name for the GenericEgress.
+   * @return a {@link GenericEgress} spec.
+   */
+  public static GenericEgress named(TypeName typeName) {
+    return new GenericEgress(typeName);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -31,7 +31,12 @@ import org.apache.flink.statefun.flink.core.httpfn.TransportClientSpec;
 import org.apache.flink.statefun.flink.core.httpfn.UrlPathTemplate;
 import org.apache.flink.statefun.sdk.FunctionType;
 
-/** A Builder for RequestReply remote function type. */
+/**
+ * A Builder for RequestReply remote function type.
+ *
+ * @deprecated see {@link Endpoint}.
+ */
+@Deprecated
 public class RequestReplyFunctionBuilder {
 
   private final DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec =

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -21,8 +21,8 @@ package org.apache.flink.statefun.flink.datastream;
 import java.net.URI;
 import java.time.Duration;
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.common.json.StateFunObjectMapper;
 import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.httpfn.TargetFunctions;
@@ -130,6 +130,6 @@ public class RequestReplyFunctionBuilder {
         new DefaultHttpRequestReplyClientSpec();
     transportClientSpecPojo.setTimeouts(transportClientTimeoutsSpec);
 
-    return new ObjectMapper().valueToTree(transportClientSpecPojo);
+    return StateFunObjectMapper.create().valueToTree(transportClientSpecPojo);
   }
 }

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
@@ -24,10 +24,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.flink.shaded.guava18.com.google.common.base.Optional;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
@@ -35,6 +35,7 @@ import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.RoutableMessage;
 import org.apache.flink.statefun.flink.core.translation.EmbeddedTranslator;
 import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -42,8 +43,73 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 /**
  * Builder for a Stateful Function Application.
  *
- * <p>This builder allows defining all the aspects of a stateful function application. define input
- * streams as ingresses, define function providers and egress ids.
+ * <p>This builder is the entry point and central context for creating Stateful Functions' programs
+ * that integrate with the Java-specific {@link DataStream} API.
+ *
+ * <p>A builder is responsible for:
+ *
+ * <ul>
+ *   <li>Convert a {@link DataStream} into an ingress.
+ *   <li>Convert messages targeting an egress into a {@link DataStream}
+ *   <li>Connect to {@link Endpoint}'s and manage all communication with remote function instances.
+ *   <li>Offering further configuration options.
+ * </ul>
+ *
+ * <h1>Example</h1>
+ *
+ *<p>Suppose the following Python Stateful Function:
+ *
+ *<pre>{@code
+ * from statefun import *
+ *
+ * functions = StatefulFunctions()
+ *
+ * @functions.bind("example/greeter", [ValueSpec("count", IntType)])
+ * async def greeter(context: Context, message: Message):
+ *    visits = ctx.storage.count or 0
+ *    visits += 1
+ *    ctx.storage.count = visits
+ *
+ *    templates = ["", "Welcome %s", "Nice to see you again %s", "Third time is a charm %s"]
+ *    if seen < len(templates):
+ *         greeting = templates[seen] % name
+ *    else:
+ *         greeting = f"Nice to see you at the {seen}-nth time {name}!"
+ *
+ *     context.send_egress(egress_message_builder(
+ *         typename='com.example/datastream-egress',
+ *         value=greeting,
+ *         value_type=StringType))
+ * }</pre>
+ *
+ * You can interoperate with this function from a {@code DataStream} application.
+ *
+ * <pre>{@code
+ *    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+ *    DataStream<String> names = env.fromElements("John", "Sally", "John", "John");
+ *
+ *    GenericEgress greetings = GenericEgress
+ *        .named(TypeName.parseFrom("com.example/datastream-egress"));
+ *
+ *    DataStream<RoutableMessage> messages = names.map(name ->
+ *        MessageBuilder.forAddress(new FunctionType("example", "greeter"), name)
+ *            .withValue(name));
+ *
+ *        StatefulFunctionEgressStreams egressStreams = StatefulFunctionDataStreamBuilder
+ *             .builder("datastream-interop")
+ *             .withDataStreamAsIngress(messages)
+ *             .withEndpoint(Endpoint.http("example/*", "https://endpoint/{function.name}"))
+ *             .withGenericEgress(greetings)
+ *             .build(env);
+ *
+ *    DataStream<EgressMessage> greetings = egressStreams.getDataStream(greetings);
+ *    greetings.map(EgressMessage::asUtf8String).print();
+ *
+ *    env.execute();
+ * }</pre>
+ *
+ * <p>Note: If you don't intend to use the {@link DataStream} API, image based deployment with
+ * {@code module.yaml} configuration files are preferred.
  */
 public final class StatefulFunctionDataStreamBuilder {
 
@@ -60,9 +126,10 @@ public final class StatefulFunctionDataStreamBuilder {
 
   private final String pipelineName;
   private final List<DataStream<RoutableMessage>> definedIngresses = new ArrayList<>();
-  private final Map<FunctionType, SerializableStatefulFunctionProvider> functionProviders =
+  private final Map<FunctionType, SerializableStatefulFunctionProvider> specificTypeProviders =
       new HashMap<>();
-  private final Map<FunctionType, HttpFunctionEndpointSpec> requestReplyFunctions = new HashMap<>();
+  private final Map<FunctionTypeNamespaceMatcher, SerializableStatefulFunctionProvider>
+      perNamespaceEndpointSpecs = new HashMap<>();
   private final Set<EgressIdentifier<?>> egressesIds = new LinkedHashSet<>();
 
   @Nullable private StatefulFunctionsConfig config;
@@ -70,6 +137,7 @@ public final class StatefulFunctionDataStreamBuilder {
   /**
    * Adds an ingress of incoming messages.
    *
+   * @see org.apache.flink.statefun.sdk.messages.MessageBuilder
    * @param ingress an incoming stream of messages.
    * @return this builder.
    */
@@ -91,7 +159,29 @@ public final class StatefulFunctionDataStreamBuilder {
       FunctionType functionType, SerializableStatefulFunctionProvider provider) {
     Objects.requireNonNull(functionType);
     Objects.requireNonNull(provider);
-    putAndThrowIfPresent(functionProviders, functionType, provider);
+    putAndThrowIfPresent(specificTypeProviders, functionType, provider);
+    return this;
+  }
+
+  /**
+   * Adds an {@link Endpoint} for connecting to remote functions.
+   *
+   * @param endpoint A configured {@link Endpoint}.
+   * @return this builder.
+   */
+  public StatefulFunctionDataStreamBuilder withEndpoint(Endpoint endpoint) {
+    Objects.requireNonNull(endpoint);
+    if (endpoint.targetFunctions().isSpecificFunctionType()) {
+      putAndThrowIfPresent(
+          specificTypeProviders,
+          endpoint.targetFunctions().asSpecificFunctionType(),
+          endpoint.getFunctionProvider());
+    } else {
+      putAndThrowIfPresent(
+          perNamespaceEndpointSpecs,
+          endpoint.targetFunctions().asNamespace(),
+          endpoint.getFunctionProvider());
+    }
     return this;
   }
 
@@ -100,13 +190,33 @@ public final class StatefulFunctionDataStreamBuilder {
    *
    * @param builder an already configured {@code RequestReplyFunctionBuilder}.
    * @return this builder.
+   * @deprecated see {@link #withEndpoint(Endpoint)}.
    */
+  @Deprecated
   public StatefulFunctionDataStreamBuilder withRequestReplyRemoteFunction(
       RequestReplyFunctionBuilder builder) {
     Objects.requireNonNull(builder);
     HttpFunctionEndpointSpec spec = builder.spec();
     putAndThrowIfPresent(
-        requestReplyFunctions, spec.targetFunctions().asSpecificFunctionType(), spec);
+        specificTypeProviders,
+        spec.targetFunctions().asSpecificFunctionType(),
+        new SerializableHttpFunctionProvider(spec));
+    return this;
+  }
+
+  /**
+   * Registers a {@link GenericEgress} to create an output stream. Generic egresses automatically
+   * handle type conversions between the Stateful Functions ecosystem and Flink's {@link
+   * org.apache.flink.api.common.typeinfo.TypeInformation}.
+   *
+   * <p>Generic egresses must be eagerly registered with the environment.
+   *
+   * @param egressId The typed identifier
+   * @return this builder
+   */
+  public StatefulFunctionDataStreamBuilder withGenericEgress(GenericEgress egressId) {
+    Objects.requireNonNull(egressId);
+    putAndThrowIfPresent(egressesIds, egressId.getId());
     return this;
   }
 
@@ -144,16 +254,17 @@ public final class StatefulFunctionDataStreamBuilder {
    */
   public StatefulFunctionEgressStreams build(StreamExecutionEnvironment env) {
     final StatefulFunctionsConfig config =
-        Optional.fromNullable(this.config).or(() -> StatefulFunctionsConfig.fromEnvironment(env));
-
-    requestReplyFunctions.forEach(
-        (type, spec) -> functionProviders.put(type, new SerializableHttpFunctionProvider(spec)));
+        Optional.ofNullable(this.config)
+            .orElseGet(() -> StatefulFunctionsConfig.fromEnvironment(env));
 
     FeedbackKey<Message> key =
         new FeedbackKey<>(pipelineName, FEEDBACK_INVOCATION_ID_SEQ.incrementAndGet());
     EmbeddedTranslator embeddedTranslator = new EmbeddedTranslator(config, key);
+
     Map<EgressIdentifier<?>, DataStream<?>> sideOutputs =
-        embeddedTranslator.translate(definedIngresses, egressesIds, functionProviders);
+        embeddedTranslator.translate(
+            definedIngresses, egressesIds, specificTypeProviders, perNamespaceEndpointSpecs);
+
     return new StatefulFunctionEgressStreams(sideOutputs);
   }
 

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionEgressStreams.java
@@ -22,12 +22,15 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
  * StatefulFunctionEgressStreams - this class holds a handle for every egress stream defined via
- * {@link StatefulFunctionDataStreamBuilder#withEgressId(EgressIdentifier)}. see {@link
- * #getDataStreamForEgressId(EgressIdentifier)}.
+ * {@link StatefulFunctionDataStreamBuilder#withGenericEgress(GenericEgress)} and {@link
+ * StatefulFunctionDataStreamBuilder#withEgressId(EgressIdentifier)}. see {@link
+ * #getDataStream(GenericEgress)} {@link #getDataStreamForEgressId(EgressIdentifier)}.
  */
 public final class StatefulFunctionEgressStreams {
   private final Map<EgressIdentifier<?>, DataStream<?>> egresses;
@@ -35,6 +38,47 @@ public final class StatefulFunctionEgressStreams {
   @Internal
   StatefulFunctionEgressStreams(Map<EgressIdentifier<?>, DataStream<?>> egresses) {
     this.egresses = Objects.requireNonNull(egresses);
+  }
+
+  /**
+   * Returns the {@link DataStream} that represents a stateful functions egress for a {@link
+   * GenericEgress}. Messages sent to an egress with the supplied id will result in the {@link
+   * DataStream} returned from this method. The messages will be automatically converted from the
+   * stateful functions {@link org.apache.flink.statefun.sdk.types.Type} to DataStream {@link
+   * org.apache.flink.api.common.typeinfo.TypeInformation}.
+   *
+   * <pre>{@code
+   * context.send_egress(egress_message_builder(
+   *          typename='com.example/datastream-egress',
+   *          value=greeting,
+   *          value_type=StringType))
+   * }</pre>
+   *
+   * <p>Note that the type system of the stateful functions ecosystem is richer than the one of the
+   * DataStream API. The stateful functions runtime will make sure to properly serialize the output
+   * records to the first operator of the DataStream API. Afterwards, the {@link
+   * org.apache.flink.api.common.typeinfo.TypeInformation} semantics of the DataStream API need to
+   * be considered.
+   *
+   * @param egress The identifier registered with {@link
+   *     StatefulFunctionDataStreamBuilder#withGenericEgress(GenericEgress)}.
+   * @return The materialized DataStream.
+   */
+  @SuppressWarnings("unchecked")
+  public DataStream<EgressMessage> getDataStream(GenericEgress egress) {
+    Objects.requireNonNull(egress);
+    DataStream<TypedValue> dataStream = (DataStream<TypedValue>) egresses.get(egress.getId());
+    if (dataStream == null) {
+      throw new IllegalArgumentException(
+          "Unknown data stream for egress "
+              + egress
+              + ". Ensure the egress was pre-registered with StatefulFunctionDataStreamBuilder#withGenericEgress(GenericEgress)");
+    }
+
+    return dataStream
+        .map(EgressMessage::new)
+        .returns(EgressMessage.class)
+        .name("from-internal-type");
   }
 
   /**

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/EgressMessage.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/EgressMessage.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.messages.serializer.EgressMessageTypeInfoFactory;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.TypeSerializer;
+import org.apache.flink.statefun.sdk.types.Types;
+
+/** A message sent to a generic egress by a remote stateful function instance. */
+@TypeInfo(EgressMessageTypeInfoFactory.class)
+public final class EgressMessage {
+  private final TypedValue typedValue;
+
+  @Internal
+  public EgressMessage(TypedValue typedValue) {
+    this.typedValue = typedValue;
+  }
+
+  public boolean isLong() {
+    return is(Types.longType());
+  }
+
+  public long asLong() {
+    return as(Types.longType());
+  }
+
+  public boolean isUtf8String() {
+    return is(Types.stringType());
+  }
+
+  public String asUtf8String() {
+    return as(Types.stringType());
+  }
+
+  public boolean isInt() {
+    return is(Types.integerType());
+  }
+
+  public int asInt() {
+    return as(Types.integerType());
+  }
+
+  public boolean isBoolean() {
+    return is(Types.booleanType());
+  }
+
+  public boolean asBoolean() {
+    return as(Types.booleanType());
+  }
+
+  public boolean isFloat() {
+    return is(Types.floatType());
+  }
+
+  public float asFloat() {
+    return as(Types.floatType());
+  }
+
+  public boolean isDouble() {
+    return is(Types.doubleType());
+  }
+
+  public double asDouble() {
+    return as(Types.doubleType());
+  }
+
+  public <T> boolean is(Type<T> type) {
+    String thisTypeNameString = typedValue.getTypename();
+    String thatTypeNameString = type.typeName().canonicalTypenameString();
+    return thisTypeNameString.equals(thatTypeNameString);
+  }
+
+  public <T> T as(Type<T> type) {
+    TypeSerializer<T> typeSerializer = type.typeSerializer();
+    Slice input = SliceProtobufUtil.asSlice(typedValue.getValue());
+    return typeSerializer.deserialize(input);
+  }
+
+  public TypeName valueTypeName() {
+    return TypeName.parseFrom(typedValue.getTypename());
+  }
+
+  public Slice rawValue() {
+    return SliceProtobufUtil.asSlice(typedValue.getValue());
+  }
+
+  public TypedValue typedValue() {
+    return typedValue;
+  }
+
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EgressMessage that = (EgressMessage) o;
+    return Objects.equals(typedValue.getTypename(), that.typedValue.getTypename())
+        && Arrays.equals(typedValue.toByteArray(), typedValue.toByteArray());
+  }
+
+  public int hashCode() {
+    return 32 >> Objects.hash(typedValue);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/MessageBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/MessageBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages;
+
+import com.google.protobuf.ByteString;
+import java.util.Objects;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.flink.core.message.SdkMessage;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.TypeSerializer;
+import org.apache.flink.statefun.sdk.types.Types;
+
+/**
+ * {@link MessageBuilder} creates messages that can be sent to stateful functions, routed to the
+ * target address. The {@code #withValue} methods will automatically convert elements into the
+ * StateFun type system. These messages are then automatically consumable by any remote langauge SDK
+ * - Python, Java, etc.
+ *
+ * <p>{@code MessageBuilder.forAddress(new FunctionType("example", "python-function"),
+ * "id").withValue("hello")}
+ */
+public final class MessageBuilder {
+  private final Address targetAddress;
+
+  private MessageBuilder(FunctionType functionType, String id) {
+    this.targetAddress = new Address(functionType, id);
+  }
+
+  public static MessageBuilder forAddress(FunctionType functionType, String id) {
+    return new MessageBuilder(functionType, id);
+  }
+
+  public static MessageBuilder forAddress(TypeName functionType, String id) {
+    return new MessageBuilder(new FunctionType(functionType.namespace(), functionType.name()), id);
+  }
+
+  public static MessageBuilder forAddress(Address address) {
+    Objects.requireNonNull(address);
+    return new MessageBuilder(address.type(), address.id());
+  }
+
+  public RoutableMessage withValue(boolean value) {
+    return withCustomType(Types.booleanType(), value);
+  }
+
+  public RoutableMessage withValue(int value) {
+    return withCustomType(Types.integerType(), value);
+  }
+
+  public RoutableMessage withValue(long value) {
+    return withCustomType(Types.longType(), value);
+  }
+
+  public RoutableMessage withValue(String value) {
+    return withCustomType(Types.stringType(), value);
+  }
+
+  public RoutableMessage withValue(float value) {
+    return withCustomType(Types.floatType(), value);
+  }
+
+  public RoutableMessage withValue(double value) {
+    return withCustomType(Types.doubleType(), value);
+  }
+
+  public <T> RoutableMessage withCustomType(Type<T> customType, T element) {
+    Objects.requireNonNull(customType);
+    Objects.requireNonNull(element);
+    TypeSerializer<T> typeSerializer = customType.typeSerializer();
+    TypedValue.Builder builder = TypedValue.newBuilder();
+    builder.setTypename(customType.typeName().canonicalTypenameString());
+    Slice serialized = typeSerializer.serialize(element);
+    ByteString serializedByteString = SliceProtobufUtil.asByteString(serialized);
+    builder.setValue(serializedByteString);
+    builder.setHasValue(true);
+    return new SdkMessage(null, targetAddress, builder.build());
+  }
+
+  /**
+   * A special utility method that does not convert the target element into the stateful functions
+   * type system. These objects are only consumable by embedded {@link
+   * org.apache.flink.statefun.sdk.StatefulFunction} instances.
+   */
+  public RoutableMessage withJavaObject(Object element) {
+    return new SdkMessage(null, targetAddress, element);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageSerializer.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageSerializer.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages.serializer;
+
+import com.google.protobuf.MoreByteStrings;
+import java.io.IOException;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+
+public class EgressMessageSerializer extends TypeSerializerSingleton<EgressMessage> {
+
+  public static final EgressMessageSerializer INSTANCE = new EgressMessageSerializer();
+
+  @Override
+  public boolean isImmutableType() {
+    return true;
+  }
+
+  @Override
+  public EgressMessage createInstance() {
+    return new EgressMessage(TypedValue.newBuilder().build());
+  }
+
+  @Override
+  public EgressMessage copy(EgressMessage from) {
+    return from;
+  }
+
+  @Override
+  public EgressMessage copy(EgressMessage from, EgressMessage reuse) {
+    return from;
+  }
+
+  @Override
+  public int getLength() {
+    return -1;
+  }
+
+  @Override
+  public void serialize(EgressMessage record, DataOutputView target) throws IOException {
+    target.writeUTF(record.typedValue().getTypename());
+    target.writeBoolean(record.typedValue().getHasValue());
+    target.writeInt(record.typedValue().getValue().size());
+    target.write(record.typedValue().getValue().toByteArray());
+  }
+
+  @Override
+  public EgressMessage deserialize(DataInputView source) throws IOException {
+    TypedValue.Builder builder = TypedValue.newBuilder();
+    builder.setTypename(source.readUTF());
+    builder.setHasValue(source.readBoolean());
+    int len = source.readInt();
+    byte[] data = new byte[len];
+    source.read(data);
+    builder.setValue(MoreByteStrings.wrap(data));
+    return new EgressMessage(builder.build());
+  }
+
+  @Override
+  public EgressMessage deserialize(EgressMessage reuse, DataInputView source) throws IOException {
+    return deserialize(source);
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    target.writeUTF(source.readUTF());
+    target.writeBoolean(source.readBoolean());
+    int len = source.readInt();
+    target.writeInt(len);
+    target.write(source, len);
+  }
+
+  @Override
+  public TypeSerializerSnapshot<EgressMessage> snapshotConfiguration() {
+    return new EgressMessageTypeSerializer();
+  }
+
+  public static class EgressMessageTypeSerializer
+      extends SimpleTypeSerializerSnapshot<EgressMessage> {
+
+    public EgressMessageTypeSerializer() {
+      super(() -> INSTANCE);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageTypeInfo.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageTypeInfo.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages.serializer;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+
+public class EgressMessageTypeInfo extends TypeInformation<EgressMessage> {
+
+  public static final EgressMessageTypeInfo INSTANCE = new EgressMessageTypeInfo();
+
+  @Override
+  public boolean isBasicType() {
+    return false;
+  }
+
+  @Override
+  public boolean isTupleType() {
+    return false;
+  }
+
+  @Override
+  public int getArity() {
+    return 1;
+  }
+
+  @Override
+  public int getTotalFields() {
+    return 1;
+  }
+
+  @Override
+  public Class<EgressMessage> getTypeClass() {
+    return EgressMessage.class;
+  }
+
+  @Override
+  public boolean isKeyType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<EgressMessage> createSerializer(ExecutionConfig config) {
+    return EgressMessageSerializer.INSTANCE;
+  }
+
+  @Override
+  public String toString() {
+    return "EgressMessageTypeInfo";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof EgressMessageTypeInfo;
+  }
+
+  @Override
+  public int hashCode() {
+    return 32 >> getClass().hashCode();
+  }
+
+  @Override
+  public boolean canEqual(Object obj) {
+    return equals(obj);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageTypeInfoFactory.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageTypeInfoFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages.serializer;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+
+public class EgressMessageTypeInfoFactory extends TypeInfoFactory<EgressMessage> {
+  @Override
+  public TypeInformation<EgressMessage> createTypeInfo(
+      Type t, Map<String, TypeInformation<?>> genericParameters) {
+    return EgressMessageTypeInfo.INSTANCE;
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/ByteStringSlice.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/ByteStringSlice.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+final class ByteStringSlice implements Slice {
+  private final ByteString byteString;
+
+  public ByteStringSlice(ByteString bytes) {
+    this.byteString = Objects.requireNonNull(bytes);
+  }
+
+  public ByteString byteString() {
+    return byteString;
+  }
+
+  @Override
+  public ByteBuffer asReadOnlyByteBuffer() {
+    return byteString.asReadOnlyByteBuffer();
+  }
+
+  @Override
+  public int readableBytes() {
+    return byteString.size();
+  }
+
+  @Override
+  public void copyTo(byte[] target) {
+    copyTo(target, 0);
+  }
+
+  @Override
+  public void copyTo(byte[] target, int targetOffset) {
+    byteString.copyTo(target, targetOffset);
+  }
+
+  @Override
+  public void copyTo(OutputStream outputStream) {
+    try {
+      byteString.writeTo(outputStream);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public byte byteAt(int position) {
+    return byteString.byteAt(position);
+  }
+
+  @Override
+  public void copyTo(ByteBuffer buffer) {
+    byteString.copyTo(buffer);
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    return byteString.toByteArray();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slice.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slice.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+public interface Slice {
+
+  int readableBytes();
+
+  void copyTo(ByteBuffer target);
+
+  void copyTo(byte[] target);
+
+  void copyTo(byte[] target, int targetOffset);
+
+  void copyTo(OutputStream outputStream);
+
+  byte byteAt(int position);
+
+  ByteBuffer asReadOnlyByteBuffer();
+
+  byte[] toByteArray();
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceOutput.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceOutput.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.slice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class SliceOutput {
+  private byte[] buf;
+  private int position;
+
+  public static SliceOutput sliceOutput(int initialSize) {
+    return new SliceOutput(initialSize);
+  }
+
+  private SliceOutput(int initialSize) {
+    if (initialSize < 0) {
+      throw new IllegalArgumentException("initial size has to be non negative");
+    }
+    this.buf = new byte[initialSize];
+    this.position = 0;
+  }
+
+  public void write(byte b) {
+    ensureCapacity(1);
+    buf[position] = b;
+    position++;
+  }
+
+  public void write(byte[] buffer) {
+    write(buffer, 0, buffer.length);
+  }
+
+  public void write(byte[] buffer, int offset, int len) {
+    Objects.requireNonNull(buffer);
+    if (offset < 0 || offset > buffer.length) {
+      throw new IllegalArgumentException("Offset out of range " + offset);
+    }
+    if (len < 0) {
+      throw new IllegalArgumentException("Negative length " + len);
+    }
+    ensureCapacity(len);
+    System.arraycopy(buffer, offset, buf, position, len);
+    position += len;
+  }
+
+  public void write(ByteBuffer buffer) {
+    int n = buffer.remaining();
+    ensureCapacity(n);
+    buffer.get(buf, position, n);
+    position += n;
+  }
+
+  public void write(Slice slice) {
+    write(slice.asReadOnlyByteBuffer());
+  }
+
+  public void writeFully(InputStream input) {
+    try {
+      int bytesRead;
+      do {
+        ensureCapacity(256);
+        bytesRead = input.read(buf, position, remaining());
+        position += bytesRead;
+      } while (bytesRead != -1);
+      position++; // compensate for the latest -1 addition.
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public Slice copyOf() {
+    return Slices.copyOf(buf, 0, position);
+  }
+
+  public Slice view() {
+    return Slices.wrap(buf, 0, position);
+  }
+
+  private int remaining() {
+    return buf.length - position;
+  }
+
+  private void ensureCapacity(final int bytesNeeded) {
+    final int requiredNewLength = position + bytesNeeded;
+    if (requiredNewLength >= buf.length) {
+      this.buf = Arrays.copyOf(buf, 2 * requiredNewLength);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceProtobufUtil.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/SliceProtobufUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MoreByteStrings;
+import com.google.protobuf.Parser;
+import org.apache.flink.annotation.Internal;
+
+@Internal
+public final class SliceProtobufUtil {
+  private SliceProtobufUtil() {}
+
+  public static <T> T parseFrom(Parser<T> parser, Slice slice)
+      throws InvalidProtocolBufferException {
+    if (slice instanceof ByteStringSlice) {
+      ByteString byteString = ((ByteStringSlice) slice).byteString();
+      return parser.parseFrom(byteString);
+    }
+    return parser.parseFrom(slice.asReadOnlyByteBuffer());
+  }
+
+  public static Slice toSlice(Message message) {
+    return Slices.wrap(message.toByteArray());
+  }
+
+  public static ByteString asByteString(Slice slice) {
+    if (slice instanceof ByteStringSlice) {
+      ByteStringSlice byteStringSlice = (ByteStringSlice) slice;
+      return byteStringSlice.byteString();
+    }
+    return MoreByteStrings.wrap(slice.asReadOnlyByteBuffer());
+  }
+
+  public static Slice asSlice(ByteString byteString) {
+    return new ByteStringSlice(byteString);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slices.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/slice/Slices.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.slice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.MoreByteStrings;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public final class Slices {
+  private Slices() {}
+
+  public static Slice wrap(ByteBuffer buffer) {
+    return wrap(MoreByteStrings.wrap(buffer));
+  }
+
+  public static Slice wrap(byte[] bytes) {
+    return wrap(MoreByteStrings.wrap(bytes));
+  }
+
+  private static Slice wrap(ByteString bytes) {
+    return new ByteStringSlice(bytes);
+  }
+
+  public static Slice wrap(byte[] bytes, int offset, int len) {
+    return wrap(MoreByteStrings.wrap(bytes, offset, len));
+  }
+
+  public static Slice copyOf(byte[] bytes) {
+    return wrap(ByteString.copyFrom(bytes));
+  }
+
+  public static Slice copyOf(byte[] bytes, int offset, int len) {
+    return wrap(ByteString.copyFrom(bytes, offset, len));
+  }
+
+  public static Slice copyOf(InputStream inputStream, int expectedStreamSize) {
+    SliceOutput out = SliceOutput.sliceOutput(expectedStreamSize);
+    out.writeFully(inputStream);
+    return out.view();
+  }
+
+  public static Slice copyFromUtf8(String input) {
+    return wrap(ByteString.copyFromUtf8(input));
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SimpleType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SimpleType.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.Slices;
+
+/**
+ * A utility to create simple {@link Type} implementations.
+ *
+ * @param <T> the Java type handled by this {@link Type}.
+ */
+public final class SimpleType<T> implements Type<T> {
+
+  @FunctionalInterface
+  public interface Fn<I, O> {
+    O apply(I input) throws Throwable;
+  }
+
+  public static <T> Type<T> simpleTypeFrom(
+      TypeName typeName, Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+    return new SimpleType<>(typeName, serialize, deserialize);
+  }
+
+  private final TypeName typeName;
+  private final TypeSerializer<T> serializer;
+
+  private SimpleType(TypeName typeName, Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+    this.typeName = Objects.requireNonNull(typeName);
+    this.serializer = new Serializer<>(serialize, deserialize);
+  }
+
+  @Override
+  public TypeName typeName() {
+    return typeName;
+  }
+
+  @Override
+  public TypeSerializer<T> typeSerializer() {
+    return serializer;
+  }
+
+  private static final class Serializer<T> implements TypeSerializer<T> {
+    private final Fn<T, byte[]> serialize;
+    private final Fn<byte[], T> deserialize;
+
+    private Serializer(Fn<T, byte[]> serialize, Fn<byte[], T> deserialize) {
+      this.serialize = Objects.requireNonNull(serialize);
+      this.deserialize = Objects.requireNonNull(deserialize);
+    }
+
+    @Override
+    public Slice serialize(T value) {
+      try {
+        byte[] bytes = serialize.apply(value);
+        return Slices.wrap(bytes);
+      } catch (Throwable throwable) {
+        throw new IllegalStateException(throwable);
+      }
+    }
+
+    @Override
+    public T deserialize(Slice input) {
+      try {
+        byte[] bytes = input.toByteArray();
+        return deserialize.apply(bytes);
+      } catch (Throwable throwable) {
+        throw new IllegalStateException(throwable);
+      }
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SliceType.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/SliceType.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+
+public final class SliceType implements Type<Slice> {
+
+  private final TypeName typename;
+  private final Serializer serializer = new Serializer();
+
+  public SliceType(TypeName typename) {
+    this.typename = Objects.requireNonNull(typename);
+  }
+
+  @Override
+  public TypeName typeName() {
+    return typename;
+  }
+
+  @Override
+  public TypeSerializer<Slice> typeSerializer() {
+    return serializer;
+  }
+
+  private static final class Serializer implements TypeSerializer<Slice> {
+    @Override
+    public Slice serialize(Slice slice) {
+      return slice;
+    }
+
+    @Override
+    public Slice deserialize(Slice slice) {
+      return slice;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Type.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Type.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import java.io.Serializable;
+import org.apache.flink.statefun.sdk.TypeName;
+
+/**
+ * This class is the core abstraction used by Stateful Functions's type system, and consists of a
+ * few things that StateFun uses to handle {@code Message}s and {@code ValueSpec}s:
+ *
+ * <ul>
+ *   <li>A {@link TypeName} to identify the type.
+ *   <li>A {@link TypeSerializer} for serializing and deserializing instances of the type.
+ * </ul>
+ *
+ * <h2>Cross-language primitive types</h2>
+ *
+ * <p>StateFun's type system has cross-language support for common primitive types, such as boolean,
+ * integer, long, etc. These primitive types have built-in {@link Type}s implemented for them
+ * already, with predefined {@link TypeName}s.
+ *
+ * <p>This is of course all transparent for the user, so you don't need to worry about it. Functions
+ * implemented in various languages (e.g. Java or Python) can message each other by directly sending
+ * supported primitive values as message arguments.
+ *
+ * <h2>Common custom types (e.g. JSON or Protobuf)</h2>
+ *
+ * <p>The type system is also very easily extensible to support custom message types, such as JSON
+ * or Protobuf messages. This is just a matter of implementing your own {@link Type} with a custom
+ * typename and serializer. Alternatively, you can also use the {@link SimpleType} class to do this
+ * easily.
+ *
+ * @param <T> the Java type of serialized / deserialized instances.
+ */
+public interface Type<T> extends Serializable {
+
+  /** @return The unique {@link TypeName} of this type. */
+  TypeName typeName();
+
+  /** @return A {@link TypeSerializer} that can serialize and deserialize this type. */
+  TypeSerializer<T> typeSerializer();
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeSerializer.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/TypeSerializer.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.types;
+
+import org.apache.flink.statefun.sdk.slice.Slice;
+
+public interface TypeSerializer<T> {
+
+  Slice serialize(T value);
+
+  T deserialize(Slice bytes);
+}

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Types.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/sdk/types/Types.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import static org.apache.flink.statefun.sdk.slice.SliceProtobufUtil.parseFrom;
+import static org.apache.flink.statefun.sdk.slice.SliceProtobufUtil.toSlice;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MoreByteStrings;
+import com.google.protobuf.WireFormat;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.slice.Slices;
+import org.apache.flink.statefun.sdk.types.generated.BooleanWrapper;
+import org.apache.flink.statefun.sdk.types.generated.DoubleWrapper;
+import org.apache.flink.statefun.sdk.types.generated.FloatWrapper;
+import org.apache.flink.statefun.sdk.types.generated.IntWrapper;
+import org.apache.flink.statefun.sdk.types.generated.LongWrapper;
+import org.apache.flink.statefun.sdk.types.generated.StringWrapper;
+
+public final class Types {
+  private Types() {}
+
+  // primitives
+  public static final TypeName BOOLEAN_TYPENAME = TypeName.parseFrom("io.statefun.types/bool");
+  public static final TypeName INTEGER_TYPENAME = TypeName.parseFrom("io.statefun.types/int");
+  public static final TypeName FLOAT_TYPENAME = TypeName.parseFrom("io.statefun.types/float");
+  public static final TypeName LONG_TYPENAME = TypeName.parseFrom("io.statefun.types/long");
+  public static final TypeName DOUBLE_TYPENAME = TypeName.parseFrom("io.statefun.types/double");
+  public static final TypeName STRING_TYPENAME = TypeName.parseFrom("io.statefun.types/string");
+
+  public static Type<Long> longType() {
+    return LongType.INSTANCE;
+  }
+
+  public static Type<String> stringType() {
+    return StringType.INSTANCE;
+  }
+
+  public static Type<Integer> integerType() {
+    return IntegerType.INSTANCE;
+  }
+
+  public static Type<Boolean> booleanType() {
+    return BooleanType.INSTANCE;
+  }
+
+  public static Type<Float> floatType() {
+    return FloatType.INSTANCE;
+  }
+
+  public static Type<Double> doubleType() {
+    return DoubleType.INSTANCE;
+  }
+
+  /**
+   * Compute the Protobuf field tag, as specified by the Protobuf wire format. See {@code
+   * WireFormat#makeTag(int, int)}}. NOTE: that, currently, for all StateFun provided wire types the
+   * tags should be 1 byte.
+   *
+   * @param fieldNumber the field number as specified in the message definition.
+   * @param wireType the field type as specified in the message definition.
+   * @return the field tag as a single byte.
+   */
+  private static byte protobufTagAsSingleByte(int fieldNumber, int wireType) {
+    int fieldTag = fieldNumber << 3 | wireType;
+    if (fieldTag < -127 || fieldTag > 127) {
+      throw new IllegalStateException(
+          "Protobuf Wrapper type compatibility is bigger than one byte.");
+    }
+    return (byte) fieldTag;
+  }
+
+  private static final Slice EMPTY_SLICE = Slices.wrap(new byte[] {});
+
+  private static final class LongType implements Type<Long> {
+
+    static final Type<Long> INSTANCE = new LongType();
+
+    private static final TypeSerializer<Long> serializer = new LongTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return LONG_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Long> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class LongTypeSerializer implements TypeSerializer<Long> {
+
+    @Override
+    public Slice serialize(Long element) {
+      return serializeLongWrapperCompatibleLong(element);
+    }
+
+    @Override
+    public Long deserialize(Slice input) {
+      return deserializeLongWrapperCompatibleLong(input);
+    }
+
+    private static final byte WRAPPER_TYPE_FIELD_TAG =
+        protobufTagAsSingleByte(LongWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_FIXED64);
+
+    private static Slice serializeLongWrapperCompatibleLong(long n) {
+      if (n == 0) {
+        return EMPTY_SLICE;
+      }
+      byte[] out = new byte[9];
+      out[0] = WRAPPER_TYPE_FIELD_TAG;
+      out[1] = (byte) (n & 0xFF);
+      out[2] = (byte) ((n >> 8) & 0xFF);
+      out[3] = (byte) ((n >> 16) & 0xFF);
+      out[4] = (byte) ((n >> 24) & 0xFF);
+      out[5] = (byte) ((n >> 32) & 0xFF);
+      out[6] = (byte) ((n >> 40) & 0xFF);
+      out[7] = (byte) ((n >> 48) & 0xFF);
+      out[8] = (byte) ((n >> 56) & 0xFF);
+      return Slices.wrap(out);
+    }
+
+    private static long deserializeLongWrapperCompatibleLong(Slice slice) {
+      if (slice.readableBytes() == 0) {
+        return 0;
+      }
+      if (slice.byteAt(0) != WRAPPER_TYPE_FIELD_TAG) {
+        throw new IllegalStateException("Not a LongWrapper");
+      }
+      return slice.byteAt(1) & 0xFFL
+          | (slice.byteAt(2) & 0xFFL) << 8
+          | (slice.byteAt(3) & 0xFFL) << 16
+          | (slice.byteAt(4) & 0xFFL) << 24
+          | (slice.byteAt(5) & 0xFFL) << 32
+          | (slice.byteAt(6) & 0xFFL) << 40
+          | (slice.byteAt(7) & 0xFFL) << 48
+          | (slice.byteAt(8) & 0xFFL) << 56;
+    }
+  }
+
+  private static final class StringType implements Type<String> {
+
+    static final Type<String> INSTANCE = new StringType();
+
+    private static final TypeSerializer<String> serializer = new StringTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return STRING_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<String> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class StringTypeSerializer implements TypeSerializer<String> {
+
+    private static final byte STRING_WRAPPER_FIELD_TYPE =
+        protobufTagAsSingleByte(
+            StringWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+
+    @Override
+    public Slice serialize(String element) {
+      return serializeStringWrapperCompatibleString(element);
+    }
+
+    @Override
+    public String deserialize(Slice input) {
+      return deserializeStringWrapperCompatibleString(input);
+    }
+
+    private static Slice serializeStringWrapperCompatibleString(String element) {
+      if (element.isEmpty()) {
+        return EMPTY_SLICE;
+      }
+      ByteString utf8 = ByteString.copyFromUtf8(element);
+      byte[] header = new byte[1 + 5 + utf8.size()];
+      int position = 0;
+      // write the field tag
+      header[position++] = STRING_WRAPPER_FIELD_TYPE;
+      // write utf8 bytes.length as a VarInt.
+      int varIntLen = utf8.size();
+      while ((varIntLen & -128) != 0) {
+        header[position++] = ((byte) (varIntLen & 127 | 128));
+        varIntLen >>>= 7;
+      }
+      header[position++] = ((byte) varIntLen);
+      // concat header and the utf8 string bytes
+      ByteString headerBuf = MoreByteStrings.wrap(header, 0, position);
+      ByteString result = MoreByteStrings.concat(headerBuf, utf8);
+      return SliceProtobufUtil.asSlice(result);
+    }
+
+    private static String deserializeStringWrapperCompatibleString(Slice input) {
+      if (input.readableBytes() == 0) {
+        return "";
+      }
+      ByteString buf = SliceProtobufUtil.asByteString(input);
+      int position = 0;
+      // read field tag
+      if (buf.byteAt(position++) != STRING_WRAPPER_FIELD_TYPE) {
+        throw new IllegalStateException("Not a StringWrapper");
+      }
+      // read VarInt32 length
+      int shift = 0;
+      long varIntSize = 0;
+      while (shift < 32) {
+        final byte b = buf.byteAt(position++);
+        varIntSize |= (long) (b & 0x7F) << shift;
+        if ((b & 0x80) == 0) {
+          break;
+        }
+        shift += 7;
+      }
+      // sanity checks
+      if (varIntSize < 0 || varIntSize > Integer.MAX_VALUE) {
+        throw new IllegalStateException("Malformed VarInt");
+      }
+      final int endIndex = position + (int) varIntSize;
+      ByteString utf8Bytes = buf.substring(position, endIndex);
+      return utf8Bytes.toStringUtf8();
+    }
+  }
+
+  private static final class IntegerType implements Type<Integer> {
+
+    static final Type<Integer> INSTANCE = new IntegerType();
+
+    private static final TypeSerializer<Integer> serializer = new IntegerTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return INTEGER_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Integer> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class IntegerTypeSerializer implements TypeSerializer<Integer> {
+    private static final byte WRAPPER_TYPE_FIELD_TYPE =
+        protobufTagAsSingleByte(IntWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_FIXED32);
+
+    @Override
+    public Slice serialize(Integer element) {
+      return serializeIntegerWrapperCompatibleInt(element);
+    }
+
+    @Override
+    public Integer deserialize(Slice input) {
+      return deserializeIntegerWrapperCompatibleInt(input);
+    }
+
+    private static Slice serializeIntegerWrapperCompatibleInt(int n) {
+      if (n == 0) {
+        return EMPTY_SLICE;
+      }
+      byte[] out = new byte[5];
+      out[0] = WRAPPER_TYPE_FIELD_TYPE;
+      out[1] = (byte) (n & 0xFF);
+      out[2] = (byte) ((n >> 8) & 0xFF);
+      out[3] = (byte) ((n >> 16) & 0xFF);
+      out[4] = (byte) ((n >> 24) & 0xFF);
+      return Slices.wrap(out);
+    }
+
+    private static int deserializeIntegerWrapperCompatibleInt(Slice slice) {
+      if (slice.readableBytes() == 0) {
+        return 0;
+      }
+      if (slice.byteAt(0) != WRAPPER_TYPE_FIELD_TYPE) {
+        throw new IllegalStateException("Not an IntWrapper");
+      }
+      return slice.byteAt(1) & 0xFF
+          | (slice.byteAt(2) & 0xFF) << 8
+          | (slice.byteAt(3) & 0xFF) << 16
+          | (slice.byteAt(4) & 0xFF) << 24;
+    }
+  }
+
+  private static final class BooleanType implements Type<Boolean> {
+
+    static final Type<Boolean> INSTANCE = new BooleanType();
+
+    private static final TypeSerializer<Boolean> serializer = new BooleanTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return BOOLEAN_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Boolean> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class BooleanTypeSerializer implements TypeSerializer<Boolean> {
+    private static final Slice TRUE_SLICE =
+        toSlice(BooleanWrapper.newBuilder().setValue(true).build());
+    private static final Slice FALSE_SLICE =
+        toSlice(BooleanWrapper.newBuilder().setValue(false).build());
+    private static final byte WRAPPER_TYPE_TAG =
+        protobufTagAsSingleByte(BooleanWrapper.VALUE_FIELD_NUMBER, WireFormat.WIRETYPE_VARINT);
+
+    @Override
+    public Slice serialize(Boolean element) {
+      return element ? TRUE_SLICE : FALSE_SLICE;
+    }
+
+    @Override
+    public Boolean deserialize(Slice input) {
+      if (input.readableBytes() == 0) {
+        return false;
+      }
+      final byte tag = input.byteAt(0);
+      final byte value = input.byteAt(1);
+      if (tag != WRAPPER_TYPE_TAG || value != (byte) 1) {
+        throw new IllegalStateException("Not a BooleanWrapper value.");
+      }
+      return true;
+    }
+  }
+
+  private static final class FloatType implements Type<Float> {
+
+    static final Type<Float> INSTANCE = new FloatType();
+
+    private static final TypeSerializer<Float> serializer = new FloatTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return FLOAT_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Float> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class FloatTypeSerializer implements TypeSerializer<Float> {
+
+    @Override
+    public Slice serialize(Float element) {
+      FloatWrapper wrapper = FloatWrapper.newBuilder().setValue(element).build();
+      return toSlice(wrapper);
+    }
+
+    @Override
+    public Float deserialize(Slice input) {
+      try {
+        FloatWrapper wrapper = parseFrom(FloatWrapper.parser(), input);
+        return wrapper.getValue();
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+
+  private static final class DoubleType implements Type<Double> {
+
+    static final Type<Double> INSTANCE = new DoubleType();
+
+    private static final TypeSerializer<Double> serializer = new DoubleTypeSerializer();
+
+    @Override
+    public TypeName typeName() {
+      return DOUBLE_TYPENAME;
+    }
+
+    @Override
+    public TypeSerializer<Double> typeSerializer() {
+      return serializer;
+    }
+  }
+
+  private static final class DoubleTypeSerializer implements TypeSerializer<Double> {
+
+    @Override
+    public Slice serialize(Double element) {
+      DoubleWrapper wrapper = DoubleWrapper.newBuilder().setValue(element).build();
+      return toSlice(wrapper);
+    }
+
+    @Override
+    public Double deserialize(Slice input) {
+      try {
+        DoubleWrapper wrapper = parseFrom(DoubleWrapper.parser(), input);
+        return wrapper.getValue();
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/EndpointTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/EndpointTest.java
@@ -1,0 +1,23 @@
+package org.apache.flink.statefun.flink.datastream;
+
+import org.junit.Test;
+
+/** Test validation of {@link Endpoint} specification. */
+public class EndpointTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWildcardNamespaceValidation() {
+    Endpoint.http("*/name", "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWildcardNameValidation() {
+    Endpoint.http("namespace/na*e", "");
+  }
+
+  @Test
+  public void testValidFunctions() {
+    Endpoint.http("namespace/name", "https://endpoint");
+    Endpoint.http("namespace/*", "https://endpoint/{function.name}");
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionsDataStreamInteropITCase.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionsDataStreamInteropITCase.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.flink.datastream;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+import org.apache.flink.statefun.sdk.messages.MessageBuilder;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Types;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.StreamCollector;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** IT Case for Stateful Function interop. */
+public class StatefulFunctionsDataStreamInteropITCase {
+
+  private static final FunctionType TYPE = new FunctionType("example", "test");
+
+  private static final GenericEgress greetings =
+      GenericEgress.named(TypeName.parseFrom("example/egress"));
+
+  @ClassRule
+  public static MiniClusterWithClientResource flinkCluster =
+      new MiniClusterWithClientResource(
+          new MiniClusterResourceConfiguration.Builder()
+              .setNumberSlotsPerTaskManager(2)
+              .setNumberTaskManagers(1)
+              .build());
+
+  @Rule public StreamCollector collector = new StreamCollector();
+
+  @Test
+  public void testDataStreamInterop() throws Exception {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.getConfig().enableObjectReuse();
+
+    DataStream<RoutableMessage> stream =
+        env.fromElements("John", "Sally")
+            .map(name -> MessageBuilder.forAddress(TYPE, name).withValue(name));
+
+    StatefulFunctionDataStreamBuilder builder =
+        StatefulFunctionDataStreamBuilder.builder("datastream-interop")
+            .withDataStreamAsIngress(stream)
+            .withEndpoint(Endpoint.http("remote/specific", "http://endpoint"))
+            .withEndpoint(Endpoint.http("remote/*", "http://endpoint/{function.name}"))
+            .withFunctionProvider(
+                TYPE, (SerializableStatefulFunctionProvider) type -> new TestFunction())
+            .withGenericEgress(greetings);
+
+    StatefulFunctionEgressStreams egressStreams = builder.build(env);
+
+    DataStream<String> egress =
+        egressStreams.getDataStream(greetings).map(EgressMessage::asUtf8String);
+
+    CompletableFuture<Collection<String>> results = collector.collect(egress);
+
+    env.execute();
+
+    Assert.assertThat(
+        "unexpected output from Stateful Functions environment",
+        results.get(),
+        Matchers.hasItems("John", "Sally"));
+  }
+
+  public static class TestFunction implements StatefulFunction {
+
+    @Override
+    public void invoke(Context context, Object input) {
+      Assert.assertThat("unexpected input data type", input, Matchers.instanceOf(TypedValue.class));
+      TypedValue typedValue = (TypedValue) input;
+      String message =
+          Types.stringType()
+              .typeSerializer()
+              .deserialize(SliceProtobufUtil.asSlice(typedValue.getValue()));
+      Assert.assertEquals("unexpected address id for record", context.self().id(), message);
+      context.send(StatefulFunctionsDataStreamInteropITCase.greetings.getId(), typedValue);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageSerializerTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/messages/serializer/EgressMessageSerializerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.messages.serializer;
+
+import com.google.protobuf.ByteString;
+import java.util.Objects;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.messages.EgressMessage;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.types.Type;
+import org.apache.flink.statefun.sdk.types.Types;
+
+public class EgressMessageSerializerTest extends SerializerTestBase<EgressMessage> {
+
+  @Override
+  protected TypeSerializer<EgressMessage> createSerializer() {
+    return EgressMessageSerializer.INSTANCE;
+  }
+
+  @Override
+  protected int getLength() {
+    return -1;
+  }
+
+  @Override
+  protected Class<EgressMessage> getTypeClass() {
+    return EgressMessage.class;
+  }
+
+  @Override
+  protected EgressMessage[] getTestData() {
+    return new EgressMessage[] {
+      egressMessage(Types.integerType(), 1),
+      egressMessage(Types.booleanType(), true),
+      egressMessage(Types.longType(), 100L),
+      egressMessage(Types.floatType(), 0.5f),
+      egressMessage(Types.doubleType(), 12.2d),
+      egressMessage(Types.stringType(), "hello")
+    };
+  }
+
+  public static <T> EgressMessage egressMessage(Type<T> customType, T element) {
+    Objects.requireNonNull(customType);
+    Objects.requireNonNull(element);
+    org.apache.flink.statefun.sdk.types.TypeSerializer<T> typeSerializer =
+        customType.typeSerializer();
+    TypedValue.Builder builder = TypedValue.newBuilder();
+    builder.setTypename(customType.typeName().canonicalTypenameString());
+    Slice serialized = typeSerializer.serialize(element);
+    ByteString serializedByteString = SliceProtobufUtil.asByteString(serialized);
+    builder.setValue(serializedByteString);
+    builder.setHasValue(true);
+    return new EgressMessage(builder.build());
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SanityPrimitiveTypeTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SanityPrimitiveTypeTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.statefun.sdk.types;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.apache.flink.statefun.sdk.slice.Slices;
+import org.apache.flink.statefun.sdk.types.generated.BooleanWrapper;
+import org.apache.flink.statefun.sdk.types.generated.IntWrapper;
+import org.apache.flink.statefun.sdk.types.generated.LongWrapper;
+import org.apache.flink.statefun.sdk.types.generated.StringWrapper;
+import org.junit.Test;
+
+public class SanityPrimitiveTypeTest {
+
+  @Test
+  public void testBoolean() {
+    assertRoundTrip(Types.booleanType(), Boolean.TRUE);
+    assertRoundTrip(Types.booleanType(), Boolean.FALSE);
+  }
+
+  @Test
+  public void testInt() {
+    assertRoundTrip(Types.integerType(), 1);
+    assertRoundTrip(Types.integerType(), 1048576);
+    assertRoundTrip(Types.integerType(), Integer.MIN_VALUE);
+    assertRoundTrip(Types.integerType(), Integer.MAX_VALUE);
+    assertRoundTrip(Types.integerType(), -1);
+  }
+
+  @Test
+  public void testLong() {
+    assertRoundTrip(Types.longType(), -1L);
+    assertRoundTrip(Types.longType(), 0L);
+    assertRoundTrip(Types.longType(), Long.MIN_VALUE);
+    assertRoundTrip(Types.longType(), Long.MAX_VALUE);
+  }
+
+  @Test
+  public void testFloat() {
+    assertRoundTrip(Types.floatType(), Float.MIN_VALUE);
+    assertRoundTrip(Types.floatType(), Float.MAX_VALUE);
+    assertRoundTrip(Types.floatType(), 2.1459f);
+    assertRoundTrip(Types.floatType(), -1e-4f);
+  }
+
+  @Test
+  public void testDouble() {
+    assertRoundTrip(Types.doubleType(), Double.MIN_VALUE);
+    assertRoundTrip(Types.doubleType(), Double.MAX_VALUE);
+    assertRoundTrip(Types.doubleType(), 2.1459d);
+    assertRoundTrip(Types.doubleType(), -1e-4d);
+  }
+
+  @Test
+  public void testString() {
+    assertRoundTrip(Types.stringType(), "");
+    assertRoundTrip(Types.stringType(), "This is a string");
+  }
+
+  @Test
+  public void testSlice() {
+    final TypeName typename = new TypeName("test.namespace", "test.name");
+    assertRoundTrip(
+        new SliceType(typename), Slices.wrap("payload-foobar".getBytes(StandardCharsets.UTF_8)));
+    assertRoundTrip(new SliceType(typename), Slices.wrap(new byte[] {}));
+  }
+
+  @Test
+  public void testRandomCompatibilityWithAnIntegerWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Integer> serializer = Types.integerType().typeSerializer();
+    for (int i = 0; i < 1_000_000; i++) {
+      testCompatibilityWithWrapper(
+          serializer, IntWrapper::parseFrom, IntWrapper::getValue, IntWrapper::toByteArray, i);
+    }
+  }
+
+  @Test
+  public void testCompatibilityWithABooleanWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Boolean> serializer = Types.booleanType().typeSerializer();
+    testCompatibilityWithWrapper(
+        serializer,
+        BooleanWrapper::parseFrom,
+        BooleanWrapper::getValue,
+        BooleanWrapper::toByteArray,
+        true);
+
+    testCompatibilityWithWrapper(
+        serializer,
+        BooleanWrapper::parseFrom,
+        BooleanWrapper::getValue,
+        BooleanWrapper::toByteArray,
+        false);
+  }
+
+  @Test
+  public void testRandomCompatibilityWithALongWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<Long> serializer = Types.longType().typeSerializer();
+    for (long i = 0; i < 1_000_000; i++) {
+      testCompatibilityWithWrapper(
+          serializer, LongWrapper::parseFrom, LongWrapper::getValue, LongWrapper::toByteArray, i);
+    }
+  }
+
+  @Test
+  public void testRandomCompatibilityWithStringWrapper() throws InvalidProtocolBufferException {
+    TypeSerializer<String> serializer = Types.stringType().typeSerializer();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = 0; i < 1_000; i++) {
+      int n = random.nextInt(4096);
+      byte[] buf = new byte[n];
+      random.nextBytes(buf);
+      String expected = new String(buf, StandardCharsets.UTF_8);
+
+      testCompatibilityWithWrapper(
+          serializer,
+          StringWrapper::parseFrom,
+          StringWrapper::getValue,
+          StringWrapper::toByteArray,
+          expected);
+    }
+  }
+
+  @FunctionalInterface
+  interface Fn<I, O> {
+    O apply(I input) throws InvalidProtocolBufferException;
+  }
+
+  private static <T, W> void testCompatibilityWithWrapper(
+      TypeSerializer<T> serializer,
+      Fn<ByteBuffer, W> parseFrom,
+      Fn<W, T> getValue,
+      Fn<W, byte[]> toByteArray,
+      T expected)
+      throws InvalidProtocolBufferException {
+    //
+    // test round trip with ourself.
+    //
+    final Slice serialized = serializer.serialize(expected);
+    final T got = serializer.deserialize(serialized);
+    assertEquals(expected, got);
+    //
+    // test that protobuf can parse what we wrote:
+    //
+    final W wrapper = parseFrom.apply(serialized.asReadOnlyByteBuffer());
+    assertEquals(expected, getValue.apply(wrapper));
+    //
+    // test that we can parse what protobuf wrote:
+    //
+    final Slice serializedByPb = Slices.wrap(toByteArray.apply(wrapper));
+    final T gotPb = serializer.deserialize(serializedByPb);
+    assertEquals(gotPb, expected);
+    // test that pb byte representation is equal to ours:
+    assertEquals(serializedByPb.asReadOnlyByteBuffer(), serialized.asReadOnlyByteBuffer());
+  }
+
+  public <T> void assertRoundTrip(Type<T> type, T element) {
+    final Slice slice;
+    {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      slice = serializer.serialize(element);
+    }
+    TypeSerializer<T> serializer = type.typeSerializer();
+    T got = serializer.deserialize(slice);
+    assertEquals(element, got);
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SimpleTypeTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/sdk/types/SimpleTypeTest.java
@@ -1,0 +1,36 @@
+package org.apache.flink.statefun.sdk.types;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.slice.Slice;
+import org.junit.Test;
+
+public class SimpleTypeTest {
+
+  @Test
+  public void mutableType() {
+    final Type<String> type =
+        SimpleType.simpleTypeFrom(
+            TypeName.parseFrom("test/simple-mutable-type"),
+            val -> val.getBytes(StandardCharsets.UTF_8),
+            bytes -> new String(bytes, StandardCharsets.UTF_8));
+
+    assertThat(type.typeName(), is(TypeName.parseFrom("test/simple-mutable-type")));
+    assertRoundTrip(type, "hello world!");
+  }
+
+  public <T> void assertRoundTrip(Type<T> type, T element) {
+    final Slice slice;
+    {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      slice = serializer.serialize(element);
+    }
+    TypeSerializer<T> serializer = type.typeSerializer();
+    T deserialized = serializer.deserialize(slice);
+    assertEquals(element, deserialized);
+  }
+}


### PR DESCRIPTION
Improve Stateful Functions <-> DataStream interop to improve usability with remote functions based on best practices / lessons learned from DataStream / Table interop. In particular:

- Automatic type conversion between JVM primitives and remote type system
- Plugable types for use with complex class
- Hide internal classes like TypedValue
- Support all endpoint configuration including wildcards and URL path templating

Please see the docs and ITCase for full working examples.

Unfortunately, I had to copy the Type and TypeSerializer classes from `statefun-sdk-java` because on the DataStream side we need them working against unshaded protobuf. As I don't imagine these classes will often (if ever) change I think this is alright but I wanted to point it out.