### PR TITLE
[hotfix] Add configuration for reproducible smoke tests

### DIFF
--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/src/main/java/org/apache/flink/statefun/e2e/smoke/common/ModuleParameters.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/src/main/java/org/apache/flink/statefun/e2e/smoke/common/ModuleParameters.java
@@ -42,6 +42,7 @@ public final class ModuleParameters implements Serializable {
   private String verificationServerHost = "localhost";
   private int verificationServerPort = 5050;
   private boolean isAsyncOpSupported = false;
+  private long randomGeneratorSeed = System.nanoTime();
 
   /** Creates an instance of ModuleParameters from a key-value map. */
   public static ModuleParameters from(Map<String, String> globalConfiguration) {
@@ -167,6 +168,14 @@ public final class ModuleParameters implements Serializable {
     isAsyncOpSupported = asyncOpSupported;
   }
 
+  public long getRandomGeneratorSeed() {
+    return randomGeneratorSeed;
+  }
+
+  public void setRandomGeneratorSeed(long randomGeneratorSeed) {
+    this.randomGeneratorSeed = randomGeneratorSeed;
+  }
+
   @Override
   public String toString() {
     return "ModuleParameters{"
@@ -199,6 +208,8 @@ public final class ModuleParameters implements Serializable {
         + verificationServerPort
         + ", isAsyncOpSupported="
         + isAsyncOpSupported
+        + ", randomGeneratorSeed="
+        + randomGeneratorSeed
         + '}';
   }
 }

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/src/main/java/org/apache/flink/statefun/e2e/smoke/driver/CommandFlinkSource.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/src/main/java/org/apache/flink/statefun/e2e/smoke/driver/CommandFlinkSource.java
@@ -27,11 +27,12 @@ import java.util.OptionalInt;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import org.apache.commons.math3.random.JDKRandomGenerator;
+import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.statefun.e2e.smoke.common.ModuleParameters;
@@ -159,8 +160,15 @@ final class CommandFlinkSource extends RichSourceFunction<TypedValue>
         startPosition,
         kaboomIndex,
         moduleParameters.getMessageCount());
-    Supplier<SourceCommand> generator =
-        new CommandGenerator(new JDKRandomGenerator(), moduleParameters);
+
+    LOG.info(
+        "creating random message generator with seed {}",
+        moduleParameters.getRandomGeneratorSeed());
+
+    RandomGenerator random = new JDKRandomGenerator();
+    random.setSeed(moduleParameters.getRandomGeneratorSeed());
+    Supplier<SourceCommand> generator = new CommandGenerator(random, moduleParameters);
+
     FunctionStateTracker functionStateTracker = this.functionStateTracker;
     for (int i = startPosition; i < moduleParameters.getMessageCount(); i++) {
       if (atLeastOneCheckpointCompleted && kaboomIndex.isPresent() && i >= kaboomIndex.getAsInt()) {

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/testutils/SmokeRunnerParameters.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/testutils/SmokeRunnerParameters.java
@@ -41,6 +41,7 @@ public final class SmokeRunnerParameters implements Serializable {
   private String verificationServerHost = "localhost";
   private int verificationServerPort = 5050;
   private boolean isAsyncOpSupported = false;
+  private long randomGeneratorSeed = System.nanoTime();
 
   public Map<String, String> asMap() {
     ObjectMapper mapper = new ObjectMapper();
@@ -159,9 +160,17 @@ public final class SmokeRunnerParameters implements Serializable {
     isAsyncOpSupported = asyncOpSupported;
   }
 
+  public long getRandomGeneratorSeed() {
+    return randomGeneratorSeed;
+  }
+
+  public void setRandomGeneratorSeed(long randomGeneratorSeed) {
+    this.randomGeneratorSeed = randomGeneratorSeed;
+  }
+
   @Override
   public String toString() {
-    return "ModuleParameters{"
+    return "SmokeRunnerParameters{"
         + "numberOfFunctionInstances="
         + numberOfFunctionInstances
         + ", commandDepth="
@@ -191,6 +200,8 @@ public final class SmokeRunnerParameters implements Serializable {
         + verificationServerPort
         + ", isAsyncOpSupported="
         + isAsyncOpSupported
+        + ", randomGeneratorSeed="
+        + randomGeneratorSeed
         + '}';
   }
 }


### PR DESCRIPTION
While debugging the go SDK, I found it convenient to reproduce smoke tests that found issues, for more straightforward debugging. I also cleaned up a deprecation warning on the source. 