### PR TITLE
[FLINK-23718] [build, sdk] Manage Python SDK as a Maven module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ under the License.
         <module>statefun-sdk-embedded</module>
         <module>statefun-sdk-protos</module>
         <module>statefun-sdk-java</module>
+        <module>statefun-sdk-python</module>
         <module>statefun-kafka-io</module>
         <module>statefun-kinesis-io</module>
         <module>statefun-flink</module>

--- a/statefun-sdk-python/pom.xml
+++ b/statefun-sdk-python/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-sdk-python</artifactId>
+
+    <build>
+        <plugins>
+            <!-- No need to publish this artifact to Maven -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Previously, the StateFun Python SDK lives as a "dangling" directory in the repository that is not managed by Maven.

We'd like include the directory as a Maven module. To start things simple, we can have the Maven POM do nothing at all - the sole purpose is just so that the directory is included in the build process so we can take advantage of existing checks in the build process, e.g. for ASF license checks on the source files.

We can start extending on this in the future, e.g. build the SDK or run the Python unit tests using the Docker Maven plugin.