### PR TITLE
[FLINK-22752] More robust state configurations in base flink-conf.yaml

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/src/main/resources/flink-conf.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 # This file is the base for the Apache Flink configuration
 
+statefun.flink-job-name: Statefun Application
+
 #==============================================================================
 # Configurations strictly required by Stateful Functions. Do not change.
 #==============================================================================
@@ -32,10 +34,17 @@ restart-strategy: fixed-delay
 restart-strategy.fixed-delay.attempts: 2147483647
 restart-strategy.fixed-delay.delay: 1sec
 
+state.backend.local-recovery: true
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
+state.backend.rocksdb.localdir: /local/state/rocksdb
+state.backend.rocksdb.memory.partitioned-index-filters: true
+state.backend.rocksdb.checkpoint.transfer.thread.num: 8
+state.backend.rocksdb.thread.num: 4
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+taskmanager.state.local.root-dirs: file:///local/state/recovery
 
 #==============================================================================
 # Recommended memory configurations. Users may change according to their needs.

--- a/tools/docker/flink-distribution-template/conf/flink-conf.yaml
+++ b/tools/docker/flink-distribution-template/conf/flink-conf.yaml
@@ -35,10 +35,17 @@ restart-strategy: fixed-delay
 restart-strategy.fixed-delay.attempts: 2147483647
 restart-strategy.fixed-delay.delay: 1sec
 
+state.backend.local-recovery: true
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
+state.backend.rocksdb.localdir: /local/state/rocksdb
+state.backend.rocksdb.memory.partitioned-index-filters: true
+state.backend.rocksdb.checkpoint.transfer.thread.num: 8
+state.backend.rocksdb.thread.num: 4
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+taskmanager.state.local.root-dirs: file:///local/state/recovery
 
 #==============================================================================
 # Recommended memory configurations. Users may change according to their needs.


### PR DESCRIPTION
This PR intends to add a few configurations to the base `flink-conf.yaml`:
- Activate local recovery. This includes setting a local directory for RocksDB to flush its sst / metadata files, as well as setting a local directory for recovery.
- Activate partitioned indexes by default
- Use more threads for transferring checkpoint files from DFS
- Increase RocksDB compaction threads

---

## MIrroring changes to official released Docker images

The changes here will be mirrored to our official released Docker images via this PR on `apache/flink-statefun-docker`: https://github.com/apache/flink-statefun-docker/pull/14

---

## Verifying the changes

The new configuration has been set in the `flink-conf.yaml` we use in the E2E tests as well. After doing that, I can see logs such as:

`
13:23:41,274 INFO  org.apache.flink.statefun.e2e.smoke.SmokeRunner               - 2021-08-16 05:23:41,278 INFO  org.apache.flink.contrib.streaming.state.restore.RocksDBIncrementalRestoreOperation [] - Finished restoring from state handle: IncrementalLocalKeyedStateHandle{metaDataState=File State: file:/local/state/recovery/ ......
`

and

`
13:23:41,198 INFO  org.apache.flink.statefun.e2e.smoke.SmokeRunner               - 2021-08-16 05:23:41,202 INFO  org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder [] - Finished building RocksDB keyed state-backend at /local/state/rocksdb/ ......
`

which confirms that local recovery is working.

Also, other configurations have been picked up as well as confirmed by the logs.