### PR TITLE
[FLINK-23853] Update Flink dependency to v1.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ under the License.
         <protobuf.version>3.7.1</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.13.0</flink.version>
+        <flink.version>1.13.2</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
         <root.dir>${rootDir}</root.dir>

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -39,6 +39,10 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -34,6 +34,12 @@ under the License.
             <artifactId>statefun-flink-harness</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Adds Driver module into classpath to be picked up by harness -->

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
@@ -18,3 +18,8 @@ This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.
 
 - com.google.protobuf:protobuf-java:3.7.1
+
+This project bundles the following dependencies under the MIT license.
+See bundled license files under "META-INF/licenses" for details.
+
+- org.slf4j:slf4j-api:1.7.7

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/licenses/LICENSE.slf4j-api
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/licenses/LICENSE.slf4j-api
@@ -1,0 +1,21 @@
+Copyright (c) 2004-2017 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -12,24 +12,36 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.13
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - com.google.auto.service:auto-service-annotations:1.0-rc6
-- com.google.guava:guava:18.0
+- com.google.guava:guava:29.0-jre
+- com.google.guava:failureaccess:1.0.1
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.errorprone:error_prone_annotations:2.3.4
+- com.google.j2objc:j2objc-annotations:1.3
+- org.checkerframework:checker-qual:2.11.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.kafka:kafka-clients:2.4.1
 - org.lz4:lz4-java:1.6.0
 - com.squareup.okhttp3:okhttp:3.14.6
 - com.squareup.okio:okio:1.17.2
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.12.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
 - joda-time:joda-time:2.5
 - software.amazon.ion:ion-java:1.0.2
 - io.dropwizard.metrics:metrics-core:jar:3.2.6
+- log4j:log4j:1.2.17
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.
 
 - com.github.luben:zstd-jni:1.4.3-1
 - com.google.protobuf:protobuf-java:3.7.1
+
+This project bundles the following dependencies under the MIT license.
+See bundled license files under "META-INF/licenses" for details.
+
+- org.slf4j:slf4j-log4j12:1.7.15
+- org.slf4j:slf4j-api:1.7.7

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/licenses/LICENSE.slf4j-api
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/licenses/LICENSE.slf4j-api
@@ -1,0 +1,21 @@
+Copyright (c) 2004-2017 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/flink:1.13.0-scala_2.12-java8
+FROM apache/flink:1.13.2-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
Updates Flink dependency to v1.13.2, as well as update all relevant `NOTICE` files as a result of this upgrade.

The change is verified by the E2E tests.