### PR TITLE
[hotfix][build] Add version for build helper plugin in statefun-protobuf-shaded

### DIFF
--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -84,6 +84,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>


### PR DESCRIPTION
This PR adds a version for build helper plugin in statefun-protobuf-shaded.
The PR pins the version to what was effectively used by the build process.