### PR TITLE
[hotfix] Add Java 11 profile to make StateFun work in IDEs (IntelliJ) that use JDK 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@ under the License.
         </dependency>
     </dependencies>
 
+
     <profiles>
         <!--
             We're reusing the apache-release build profile defined in the Apache Parent POM,
@@ -121,6 +122,30 @@ under the License.
                                 <phase>none</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>11</source>
+                            <target>11</target>
+                            <compilerArgs combine.children="append">
+                                <arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
+                                <arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
To run with Java 11 in the IDEs, we need to open some modules by default (that are otherwise closed). IN particular, we need to enable access to `sun.misc.Unsafe` for the generated protobuf sources.

This PR adds the necessary compiler flags, if the java version is >= 11.

The approach is adopted from the core flink repository.