### PR TITLE
[FLINK-23964] Use shaded tcnative in dev docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -42,6 +42,9 @@ RUN mkdir -p $FLINK_HOME/plugins/oss-fs-hadoop && \
 RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \
     mv $FLINK_HOME/opt/flink-azure-fs-hadoop-*.jar $FLINK_HOME/plugins/azure-fs-hadoop
 
+# add tcnative
+RUN mv $FLINK_HOME/opt/flink-shaded-netty-tcnative-dynamic-*.jar  $FLINK_HOME/lib/
+
 # entry point 
 ADD docker-entry-point.sh /docker-entry-point.sh
 


### PR DESCRIPTION
This PR adds Netty's shaded tcnative artifact and thus makes openssl available for Netty.
It is a back port of https://github.com/apache/flink-statefun-docker/pull/16