### PR TITLE
[FLINK-24110] Filter null ComponentJsonObjects

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RemoteModule.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/RemoteModule.java
@@ -48,6 +48,7 @@ public final class RemoteModule implements StatefulFunctionModule {
   private static List<ComponentJsonObject> parseComponentNodes(
       Iterable<? extends JsonNode> componentNodes) {
     return StreamSupport.stream(componentNodes.spliterator(), false)
+        .filter(node -> !node.isNull())
         .map(ComponentJsonObject::new)
         .collect(Collectors.toList());
   }

--- a/statefun-flink/statefun-flink-core/src/test/resources/remote-module/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/remote-module/module.yaml
@@ -24,3 +24,4 @@ spec:
 kind: com.foo.bar/test.component.3
 spec:
   nonsense: ignored
+---


### PR DESCRIPTION
Trailing `---` in the new module.yaml format are interpreted as null `JsonNode`'s. This change filter's them out to avoid confusing error messages. 

