### PR TITLE
[FLINK-24132] Remove directory-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@ under the License.
         <flink.version>1.13.2</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
-        <root.dir>${rootDir}</root.dir>
     </properties>
 
     <dependencies>
@@ -316,24 +315,6 @@ under the License.
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.commonjava.maven.plugins</groupId>
-                <artifactId>directory-maven-plugin</artifactId>
-                <version>0.1</version>
-                <executions>
-                    <execution>
-                        <id>directories</id>
-                        <goals>
-                            <goal>highest-basedir</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                        <configuration>
-                            <property>rootDir</property>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -78,7 +78,7 @@ under the License.
                                 <inherited>false</inherited>
                                 <phase>pre-integration-test</phase>
                                 <configuration>
-                                    <executable>${root.dir}/tools/docker/build-stateful-functions.sh</executable>
+                                    <executable>../tools/docker/build-stateful-functions.sh</executable>
                                 </configuration>
                             </execution>
                             <execution>
@@ -89,7 +89,7 @@ under the License.
                                 <inherited>false</inherited>
                                 <phase>pre-integration-test</phase>
                                 <configuration>
-                                    <executable>${root.dir}/statefun-sdk-python/build-distribution.sh</executable>
+                                    <executable>../statefun-sdk-python/build-distribution.sh</executable>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
The only usage of that plugin is at `statefun-e2e-tests/pom.xml`
and to only invoke two shell script. We can simply use a relative path
Since the shell scripts resolve their basedirs anyways.