### PR TITLE
[FLINK-24364][e2e] Add delayed message cancellation smoke test case

### DIFF
--- a/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/java/org/apache/flink/statefun/e2e/smoke/SmokeRunnerParameters.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/java/org/apache/flink/statefun/e2e/smoke/SmokeRunnerParameters.java
@@ -35,6 +35,7 @@ public final class SmokeRunnerParameters implements Serializable {
   private double stateModificationsPr = 0.4;
   private double sendPr = 0.9;
   private double sendAfterPr = 0.1;
+  private double sendAfterWithCancellationPr = 0.1;
   private double asyncSendPr = 0.1;
   private double noopPr = 0.2;
   private double sendEgressPr = 0.03;
@@ -42,6 +43,8 @@ public final class SmokeRunnerParameters implements Serializable {
   private String verificationServerHost = "localhost";
   private int verificationServerPort = 5050;
   private boolean isAsyncOpSupported = false;
+  private boolean isDelayCancellationOpSupported = false;
+
   private long randomGeneratorSeed = System.nanoTime();
 
   /** Creates an instance of ModuleParameters from a key-value map. */
@@ -108,6 +111,14 @@ public final class SmokeRunnerParameters implements Serializable {
     return sendAfterPr;
   }
 
+  public boolean isDelayCancellationOpSupported() {
+    return isDelayCancellationOpSupported;
+  }
+
+  public void setDelayCancellationOpSupported(boolean delayCancellationOpSupported) {
+    isDelayCancellationOpSupported = delayCancellationOpSupported;
+  }
+
   public void setSendAfterPr(double sendAfterPr) {
     this.sendAfterPr = sendAfterPr;
   }
@@ -158,6 +169,14 @@ public final class SmokeRunnerParameters implements Serializable {
 
   public void setVerificationServerPort(int verificationServerPort) {
     this.verificationServerPort = verificationServerPort;
+  }
+
+  public double getSendAfterWithCancellationPr() {
+    return sendAfterWithCancellationPr;
+  }
+
+  public void setSendAfterWithCancellationPr(double sendAfterWithCancellationPr) {
+    this.sendAfterWithCancellationPr = sendAfterWithCancellationPr;
   }
 
   public boolean isAsyncOpSupported() {

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/protobuf/commands.proto
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/protobuf/commands.proto
@@ -42,6 +42,11 @@ message Command {
   message SendAfter {
     int32 target = 1;
     Commands commands = 2;
+    string cancellation_token = 3;
+  }
+  message CancelSendAfter {
+     int32 target = 1;
+     string cancellation_token = 2;
   }
   message SendEgress {
   }
@@ -60,6 +65,7 @@ message Command {
     SendEgress send_egress = 4;
     AsyncOperation async_operation = 5;
     Verify verify = 6;
+    CancelSendAfter cancel_send_after = 7;
   }
 }
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
@@ -61,6 +61,7 @@ public class EmbeddedSmokeHarnessTest {
     parameters.setVerificationServerHost("localhost");
     parameters.setVerificationServerPort(started.port());
     parameters.setAsyncOpSupported(true);
+    parameters.setDelayCancellationOpSupported(true);
     parameters.asMap().forEach(harness::withGlobalConfiguration);
 
     // run the harness.

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/SmokeVerificationEmbeddedE2E.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/SmokeVerificationEmbeddedE2E.java
@@ -34,6 +34,7 @@ public class SmokeVerificationEmbeddedE2E {
     parameters.setMessageCount(100_000);
     parameters.setMaxFailures(1);
     parameters.setAsyncOpSupported(true);
+    parameters.setDelayCancellationOpSupported(true);
 
     StatefulFunctionsAppContainers.Builder builder =
         StatefulFunctionsAppContainers.builder("flink-statefun-cluster", NUM_WORKERS);


### PR DESCRIPTION
### Add delayed message cancellation e2e test case

Copied from the JIRA description:

> StateFun supports sending delayed messages with a user defined cancellation token, and in addition canceling delayed message by providing this token.
> This feature is based on best-effort and it is non-deterministic, therefore it is difficult to craft an e2e test to capture it (it is covered with a unit test, where the exact conditions can be fixed)
> I propose non the less, to add it to the smoke as a leaf command, meaning, a command that doesn't result in state increment). But nevertheless it basically simulates a user that is "clicking around".

A followup issue should be created to extend this to the remote SDKs. (cc: @evans-ye if you are interested)
