### PR TITLE
[FLINK-24464][core] Metrics sometimes report negative backlog

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
@@ -43,7 +43,7 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
     this.outgoingEgress = metered(typeGroup, "outEgress");
     this.blockedAddress = typeGroup.counter("numBlockedAddress");
     this.inflightAsyncOps = typeGroup.counter("inflightAsyncOps");
-    this.backlogMessage = typeGroup.counter("numBacklog");
+    this.backlogMessage = typeGroup.counter("numBacklog", new NonNegativeCounter());
     this.remoteInvocationFailures = metered(typeGroup, "remoteInvocationFailures");
     this.remoteInvocationLatency = typeGroup.histogram("remoteInvocationLatency", histogram());
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounter.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.metrics;
+
+import org.apache.flink.metrics.Counter;
+
+/**
+ * A simple counter that can never go below zero.
+ *
+ * <p>This class is used in a non-thread safe manner, so it is important all modifications are
+ * checked before updating the count. Otherwise, negative values might be reported.
+ */
+public class NonNegativeCounter implements Counter {
+
+  private long count;
+
+  @Override
+  public void inc() {
+    inc(1);
+  }
+
+  @Override
+  public void inc(long value) {
+    count += value;
+  }
+
+  @Override
+  public void dec() {
+    dec(1);
+  }
+
+  @Override
+  public void dec(long value) {
+    if (value > count) {
+      count = 0;
+    } else {
+      count -= value;
+    }
+  }
+
+  @Override
+  public long getCount() {
+    return count;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounterTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounterTest.java
@@ -1,0 +1,27 @@
+package org.apache.flink.statefun.flink.core.metrics;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.flink.metrics.Counter;
+import org.junit.Test;
+
+public class NonNegativeCounterTest {
+
+  @Test
+  public void testNonNegativeCounter() throws Exception {
+    Counter counter = new NonNegativeCounter();
+
+    counter.inc();
+    assertThat(counter.getCount(), is(1L));
+
+    counter.inc(2);
+    assertThat(counter.getCount(), is(3L));
+
+    counter.dec(4);
+    assertThat(counter.getCount(), is(0L));
+
+    counter.dec();
+    assertThat(counter.getCount(), is(0L));
+  }
+}


### PR DESCRIPTION
The backlog metric sometimes reports a negative value. This is because the current count is stored in an in-memory variable, while the value used to decrement the count as the backlog clears is stored in Flink state. In the case of a job restart, the in-memory variable is reset to zero (it is a new instance) while the numbers in state are retained. 

Reseting the count after a restore would require iterating over all keys, so instead we simply prevent negative backlogs from being reported to not publish non-sensical values to reporters. 