### PR TITLE
Use JDK 8 Optional instead of shaded Optional class from Guava.

### DIFF
--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilder.java
@@ -24,10 +24,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.flink.shaded.guava18.com.google.common.base.Optional;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
@@ -144,7 +144,7 @@ public final class StatefulFunctionDataStreamBuilder {
    */
   public StatefulFunctionEgressStreams build(StreamExecutionEnvironment env) {
     final StatefulFunctionsConfig config =
-        Optional.fromNullable(this.config).or(() -> StatefulFunctionsConfig.fromEnvironment(env));
+        Optional.ofNullable(this.config).orElseGet(() -> StatefulFunctionsConfig.fromEnvironment(env));
 
     requestReplyFunctions.forEach(
         (type, spec) -> functionProviders.put(type, new SerializableHttpFunctionProvider(spec)));


### PR DESCRIPTION
I got this error on a sample project with Flink embedded using `org.apache.flink:statefun-flink-datastream:3.1.0` and `org.apache.flink:flink-clients_2.12:1.14.0`

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/flink/shaded/guava18/com/google/common/base/Optional
	at org.apache.flink.statefun.flink.datastream.StatefulFunctionDataStreamBuilder.build(StatefulFunctionDataStreamBuilder.java:147)
	at org.example.Main.main(Main.java:50)
Caused by: java.lang.ClassNotFoundException: org.apache.flink.shaded.guava18.com.google.common.base.Optional
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 2 more
```
I bump flink-clients version down to `org.apache.flink:flink-clients_2.12:1.13.2` and there is no error anymore.

I still think using the JDK `Optional` class is more straightforward and less error-prone than importing the shaded Guava class. 

So this is my small PR.