### PR TITLE
[FLINK-25308] Provide a custom remote module name

### DIFF
--- a/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/ResourceLocator.java
+++ b/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/ResourceLocator.java
@@ -21,12 +21,22 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import javax.annotation.Nullable;
 
 public final class ResourceLocator {
   private ResourceLocator() {}
+
+  public static Iterable<URL> findResources(String namedResource) {
+    if (namedResource.startsWith("classpath:")) {
+      return findNamedResources(namedResource);
+    } else {
+      URL u = findNamedResource(namedResource);
+      return Collections.singletonList(u);
+    }
+  }
 
   /** Locates a resource with a given name in the classpath or url path. */
   public static Iterable<URL> findNamedResources(String name) {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -100,6 +100,13 @@ public class StatefulFunctionsConfig implements Serializable {
           .withDescription(
               "The max number of async operations per task before backpressure is applied.");
 
+  public static final ConfigOption<String> REMOTE_MODULE_NAME =
+      ConfigOptions.key("statefun.remote.module-name")
+          .stringType()
+          .defaultValue("classpath:module.yaml")
+          .withDescription(
+              "The name of the remote module entity to look for. Also supported, file:///...");
+
   /**
    * Creates a new {@link StatefulFunctionsConfig} based on the default configurations in the
    * current environment set via the {@code flink-conf.yaml}.
@@ -125,6 +132,8 @@ public class StatefulFunctionsConfig implements Serializable {
 
   private int maxAsyncOperationsPerTask;
 
+  private String remoteModuleName;
+
   private Map<String, String> globalConfigurations = new HashMap<>();
 
   /**
@@ -139,6 +148,7 @@ public class StatefulFunctionsConfig implements Serializable {
     this.flinkJobName = configuration.get(FLINK_JOB_NAME);
     this.feedbackBufferSize = configuration.get(TOTAL_MEMORY_USED_FOR_FEEDBACK_CHECKPOINTING);
     this.maxAsyncOperationsPerTask = configuration.get(ASYNC_MAX_OPERATIONS_PER_TASK);
+    this.remoteModuleName = configuration.get(REMOTE_MODULE_NAME);
 
     for (String key : configuration.keySet()) {
       if (key.startsWith(MODULE_CONFIG_PREFIX)) {
@@ -204,6 +214,24 @@ public class StatefulFunctionsConfig implements Serializable {
   /** Sets the max async operations allowed per task. */
   public void setMaxAsyncOperationsPerTask(int maxAsyncOperationsPerTask) {
     this.maxAsyncOperationsPerTask = maxAsyncOperationsPerTask;
+  }
+
+  /** Returns the remote module name. */
+  public String getRemoteModuleName() {
+    return remoteModuleName;
+  }
+
+  /**
+   * Sets a template for the remote module name.
+   *
+   * <p>By default the system will look for module.yaml in the classapth, to override that use
+   * either a configuration parameter (see {@linkplain #REMOTE_MODULE_NAME}) or this getter.
+   *
+   * <p>The supported formats are either a file path, a file path prefixed with a {@code file:}
+   * schema, or a name prefixed by {@code classpath:}
+   */
+  public void setRemoteModuleName(String remoteModuleName) {
+    this.remoteModuleName = Objects.requireNonNull(remoteModuleName);
   }
 
   /**

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverses.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverses.java
@@ -39,8 +39,8 @@ public final class StatefulFunctionsUniverses {
     @Override
     public StatefulFunctionsUniverse get(
         ClassLoader classLoader, StatefulFunctionsConfig configuration) {
-      Modules modules = Modules.loadFromClassPath();
-      return modules.createStatefulFunctionsUniverse(configuration);
+      Modules modules = Modules.loadFromClassPath(configuration);
+      return modules.createStatefulFunctionsUniverse();
     }
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoader.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoader.java
@@ -31,7 +31,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YA
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import org.apache.flink.statefun.flink.common.ResourceLocator;
 import org.apache.flink.statefun.flink.common.json.Selectors;
-import org.apache.flink.statefun.flink.core.spi.Constants;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
 
 public final class JsonServiceLoader {
@@ -43,11 +42,10 @@ public final class JsonServiceLoader {
   private static final JsonPointer MODULE_SPEC = JsonPointer.compile("/module/spec");
   private static final JsonPointer MODULE_META_TYPE = JsonPointer.compile("/module/meta/type");
 
-  public static Iterable<StatefulFunctionModule> load() {
+  public static Iterable<StatefulFunctionModule> load(String moduleName) {
     ObjectMapper mapper = mapper();
 
-    Iterable<URL> namedResources =
-        ResourceLocator.findNamedResources("classpath:" + Constants.STATEFUL_FUNCTIONS_MODULE_NAME);
+    Iterable<URL> namedResources = ResourceLocator.findResources(moduleName);
 
     return StreamSupport.stream(namedResources.spliterator(), false)
         .map(moduleUrl -> fromUrl(mapper, moduleUrl))

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/Modules.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/Modules.java
@@ -31,17 +31,20 @@ public final class Modules {
   private final List<ExtensionModule> extensionModules;
   private final List<FlinkIoModule> ioModules;
   private final List<StatefulFunctionModule> statefulFunctionModules;
+  private final StatefulFunctionsConfig configuration;
 
   private Modules(
-      List<ExtensionModule> extensionModules,
+      StatefulFunctionsConfig configuration,
       List<FlinkIoModule> ioModules,
-      List<StatefulFunctionModule> statefulFunctionModules) {
+      List<StatefulFunctionModule> statefulFunctionModules,
+      List<ExtensionModule> extensionModules) {
+    this.configuration = Objects.requireNonNull(configuration);
     this.extensionModules = extensionModules;
     this.ioModules = ioModules;
     this.statefulFunctionModules = statefulFunctionModules;
   }
 
-  public static Modules loadFromClassPath() {
+  public static Modules loadFromClassPath(StatefulFunctionsConfig configuration) {
     List<StatefulFunctionModule> statefulFunctionModules = new ArrayList<>();
     List<FlinkIoModule> ioModules = new ArrayList<>();
     List<ExtensionModule> extensionModules = new ArrayList<>();
@@ -52,17 +55,17 @@ public final class Modules {
     for (StatefulFunctionModule provider : ServiceLoader.load(StatefulFunctionModule.class)) {
       statefulFunctionModules.add(provider);
     }
-    for (StatefulFunctionModule provider : JsonServiceLoader.load()) {
+    String remoteModuleName = configuration.getRemoteModuleName();
+    for (StatefulFunctionModule provider : JsonServiceLoader.load(remoteModuleName)) {
       statefulFunctionModules.add(provider);
     }
     for (FlinkIoModule provider : ServiceLoader.load(FlinkIoModule.class)) {
       ioModules.add(provider);
     }
-    return new Modules(extensionModules, ioModules, statefulFunctionModules);
+    return new Modules(configuration, ioModules, statefulFunctionModules, extensionModules);
   }
 
-  public StatefulFunctionsUniverse createStatefulFunctionsUniverse(
-      StatefulFunctionsConfig configuration) {
+  public StatefulFunctionsUniverse createStatefulFunctionsUniverse() {
     MessageFactoryKey factoryKey = configuration.getFactoryKey();
 
     StatefulFunctionsUniverse universe = new StatefulFunctionsUniverse(factoryKey);

--- a/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
+++ b/statefun-flink/statefun-flink-harness/src/main/java/org/apache/flink/statefun/flink/harness/Harness.java
@@ -168,8 +168,8 @@ public class Harness {
     @Override
     public StatefulFunctionsUniverse get(
         ClassLoader classLoader, StatefulFunctionsConfig configuration) {
-      Modules modules = Modules.loadFromClassPath();
-      StatefulFunctionsUniverse universe = modules.createStatefulFunctionsUniverse(configuration);
+      Modules modules = Modules.loadFromClassPath(configuration);
+      StatefulFunctionsUniverse universe = modules.createStatefulFunctionsUniverse();
       ingressToReplace.forEach((id, spec) -> universe.ingress().put(id, spec));
       egressToReplace.forEach((id, spec) -> universe.egress().put(id, spec));
       return universe;


### PR DESCRIPTION
This PR adds a new `flink-conf` configuration key: `statefun.remote.module-name`.

With this configuration key it is possible to override the default remote module file name (`module.yaml`).
(See the following mailing list thread https://lists.apache.org/thread/dpp45wr81gsmnjcoqtotprnt6gx9comq).

To provide a different name, for example `prod.yaml` that is located at `/flink/usrlib/prod.yaml`
One can add the following to their `flink-conf.yaml`:

```
statefun.remote.module-name: /flink/usrlib/prod.yaml
```