### PR TITLE
[FLINK-25367] Upgrade to Flink 1.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ under the License.
         <protobuf.version>3.7.1</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
-        <flink.version>1.13.3</flink.version>
+        <flink.version>1.13.5</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
         <root.dir>${rootDir}</root.dir>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/flink:1.13.3-scala_2.12-java8
+FROM apache/flink:1.13.5-scala_2.12-java8
 
 ENV ROLE worker
 ENV MASTER_HOST localhost


### PR DESCRIPTION
This PR upgrades the Flink dependency to 1.13.5 for the 3.1 release series.

note: this might not build since the 1.13.5 artefacts are not yet present at maven central.