### PR TITLE
[FLINK-25197] Fix serialization issue in RequestReplyFunctionBuilder

### DIFF
--- a/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/StateFunObjectMapper.java
+++ b/statefun-flink/statefun-flink-common/src/main/java/org/apache/flink/statefun/flink/common/json/StateFunObjectMapper.java
@@ -20,11 +20,9 @@ package org.apache.flink.statefun.flink.common.json;
 
 import java.io.IOException;
 import java.time.Duration;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.*;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.flink.statefun.sdk.TypeName;
 import org.apache.flink.util.TimeUtils;
@@ -36,6 +34,7 @@ public final class StateFunObjectMapper {
         new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     final SimpleModule module = new SimpleModule("statefun");
+    module.addSerializer(Duration.class, new DurationJsonSerializer());
     module.addDeserializer(Duration.class, new DurationJsonDeserializer());
     module.addDeserializer(TypeName.class, new TypeNameJsonDeserializer());
 
@@ -48,6 +47,16 @@ public final class StateFunObjectMapper {
     public Duration deserialize(
         JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
       return TimeUtils.parseDuration(jsonParser.getText());
+    }
+  }
+
+  private static final class DurationJsonSerializer extends JsonSerializer<Duration> {
+    @Override
+    public void serialize(
+        Duration duration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+        throws IOException {
+      String formattedDuration = TimeUtils.formatWithHighestUnit(duration);
+      jsonGenerator.writeString(formattedDuration);
     }
   }
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -53,7 +53,7 @@ under the License.
         </dependency>
   
         <!-- The following dependencies are here with scope provided, because: 
-             a) they are transitively required by the statefun-flink-* depencies
+             a) they are transitively required by the statefun-flink-* dependencies
              b) they are provided at runtime, by the embedding application. 
              
              Also note that org.slf4j:slf4j-api is excluded from all the artifacts, since maven 
@@ -77,6 +77,20 @@ under the License.
             <version>${flink.version}</version>
             <scope>provided</scope>
        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
         
     </dependencies>
 

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -21,8 +21,10 @@ package org.apache.flink.statefun.flink.datastream;
 import java.net.URI;
 import java.time.Duration;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.common.json.StateFunObjectMapper;
 import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.httpfn.TargetFunctions;
@@ -33,6 +35,9 @@ import org.apache.flink.statefun.sdk.FunctionType;
 
 /** A Builder for RequestReply remote function type. */
 public class RequestReplyFunctionBuilder {
+
+  /** The object mapper used to serialize the client spec object. */
+  private static final ObjectMapper CLIENT_SPEC_OBJ_MAPPER = StateFunObjectMapper.create();
 
   private final DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec =
       new DefaultHttpRequestReplyClientSpec.Timeouts();
@@ -124,12 +129,13 @@ public class RequestReplyFunctionBuilder {
     return builder.build();
   }
 
-  private static ObjectNode transportClientPropertiesAsObjectNode(
+  @VisibleForTesting
+  static ObjectNode transportClientPropertiesAsObjectNode(
       DefaultHttpRequestReplyClientSpec.Timeouts transportClientTimeoutsSpec) {
     final DefaultHttpRequestReplyClientSpec transportClientSpecPojo =
         new DefaultHttpRequestReplyClientSpec();
     transportClientSpecPojo.setTimeouts(transportClientTimeoutsSpec);
 
-    return new ObjectMapper().valueToTree(transportClientSpecPojo);
+    return CLIENT_SPEC_OBJ_MAPPER.valueToTree(transportClientSpecPojo);
   }
 }

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
@@ -1,0 +1,66 @@
+package org.apache.flink.statefun.flink.datastream;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+import java.util.Random;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientSpec;
+import org.apache.flink.util.TimeUtils;
+import org.junit.Test;
+
+public class RequestReplyFunctionBuilderTest {
+
+  @Test
+  public void serializeClientSpec() {
+
+    final int seed = 27;
+    final int maxSeconds = 300;
+    final Random random = new Random(seed);
+    final Duration readTimeout = Duration.ofSeconds(random.nextInt(maxSeconds));
+    final Duration writeTimeout = Duration.ofSeconds(random.nextInt(maxSeconds));
+    final Duration connectTimeout = Duration.ofSeconds(random.nextInt(maxSeconds));
+    final Duration callTimeout = connectTimeout.plusSeconds(random.nextInt(maxSeconds));
+
+    final DefaultHttpRequestReplyClientSpec.Timeouts timeouts =
+        new DefaultHttpRequestReplyClientSpec.Timeouts();
+    timeouts.setCallTimeout(callTimeout);
+    timeouts.setReadTimeout(readTimeout);
+    timeouts.setWriteTimeout(writeTimeout);
+    timeouts.setConnectTimeout(connectTimeout);
+
+    final ObjectNode rootNode =
+        RequestReplyFunctionBuilder.transportClientPropertiesAsObjectNode(timeouts);
+    assertThat(rootNode, notNullValue());
+    final JsonNode timeoutsNode = rootNode.get("timeouts");
+    assertThat(timeoutsNode, notNullValue());
+
+    assertThat(timeoutsNode.size(), equalTo(4));
+    assertThat(TimeUtils.parseDuration(timeoutsNode.get("read").asText()), equalTo(readTimeout));
+    assertThat(TimeUtils.parseDuration(timeoutsNode.get("write").asText()), equalTo(writeTimeout));
+    assertThat(
+        TimeUtils.parseDuration(timeoutsNode.get("connect").asText()), equalTo(connectTimeout));
+    assertThat(TimeUtils.parseDuration(timeoutsNode.get("call").asText()), equalTo(callTimeout));
+  }
+}


### PR DESCRIPTION
This fixes the issue described in [FLINK-25197](https://issues.apache.org/jira/browse/FLINK-25197), where this error occurs when using RequestReplyFunctionBuilder to build Statefun jobs:

> Java 8 date/time type `java.time.Duration` not supported by default: add Module "org.apache.flink.shaded.jackson2.com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling 

The fix is to make RequestReplyFunctionBuilder use an instance of StatefunObjectMapper to serialize the client spec -- previously, it used a non-customized instance of ObjectMapper -- and to change StatefunObjectMapper to support serialization of java.time.Duration values.

