### PR TITLE
[BP-3.2][FLINK-25829] Skip deployment of statefun-sdk-js

### DIFF
--- a/statefun-sdk-js/pom.xml
+++ b/statefun-sdk-js/pom.xml
@@ -32,23 +32,11 @@ under the License.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
-        <resources>
-            <resource>
-                <!-- include src/main/protobuf in the resulting artifact. -->
-                <directory>src/main/protobuf</directory>
-            </resource>
-        </resources>
     </build>
 </project>


### PR DESCRIPTION
This is a backport of #286 onto `release-3.2`.