### PR TITLE
[hotfix] remove invalid link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ to get yourself started with Stateful Functions.
 
 For a fully detailed documentation, please visit the [official docs](https://ci.apache.org/projects/flink/flink-statefun-docs-master).
 
-For code examples, please take a look at the [examples](statefun-examples/).
-
 ![Java 8 Build](https://github.com/apache/flink-statefun/workflows/Java%208%20Build/badge.svg)
 
 ## Table of Contents

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,7 +6,7 @@ Stateful Functions 使我们能够将强大的状态管理与像 AWS Lambda 类�
 
 本文档旨在简要介绍 Stateful Functions 的核心概念以及如何开发一个 Stateful Functions 应用。
 
-更多详细信息，可以参考 [官方文档](https://ci.apache.org/projects/flink/flink-statefun-docs-master) ，相关代码示例，请查看[这里](statefun-examples/)  。
+更多详细信息，可以参考 [官方文档](https://ci.apache.org/projects/flink/flink-statefun-docs-master)。
 
 [![构建状态](https://travis-ci.org/apache/flink-statefun.svg?branch=master)](https://travis-ci.org/apache/flink-statefun)
 


### PR DESCRIPTION
`statefun-examples` is not there anymore, remove it from README.