### PR TITLE
[FLINK-25915][Docs] Implement Matomo on Statefun website

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -23,6 +23,25 @@ under the License.
   {{ hugo.Generator }}
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    /* We explicitly disable cookie tracking to avoid privacy issues */
+    _paq.push(['disableCookies']);
+    /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+    _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//matomo.privacy.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '1']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>
 
 <body dir={{ .Site.Language.LanguageDirection }}>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -65,17 +65,6 @@ under the License.
   </main>
 
   {{ partial "docs/inject/body" . }}
-
-  <!-- Google Analytics -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52545728-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Like https://github.com/apache/flink/pull/18577, this PR removes the current Google Analytics web analytics tracking from the Flink documentation and replaces it with the ASF hosted Matomo installation, as discussed on the Dev mailing list https://lists.apache.org/thread/kv0mf1y9cq4cdsf4jkq3gb6jo7b81cq3