### PR TITLE
[FLINK-25936][java-sdk] Set value type name correctly in a MutableTypeCell.

### DIFF
--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorage.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import org.apache.flink.statefun.sdk.java.AddressScopedStorage;
+import org.apache.flink.statefun.sdk.java.ApiExtension;
 import org.apache.flink.statefun.sdk.java.ValueSpec;
 import org.apache.flink.statefun.sdk.java.annotations.Internal;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
@@ -269,13 +270,13 @@ public final class ConcurrentAddressScopedStorage implements AddressScopedStorag
       }
       lock.lock();
       try {
-        final TypedValue newTypedValue =
-            this.typedValue
-                .toBuilder()
+        ByteString typenameBytes = ApiExtension.typeNameByteString(spec.typeName());
+        this.typedValue =
+            TypedValue.newBuilder()
+                .setTypenameBytes(typenameBytes)
                 .setHasValue(true)
                 .setValue(serialize(serializer, value))
                 .build();
-        this.typedValue = newTypedValue;
         this.status = CellStatus.MODIFIED;
       } finally {
         lock.unlock();

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorageTest.java
@@ -189,7 +189,7 @@ public class ConcurrentAddressScopedStorageTest {
             .setStateName(spec.name())
             .setStateValue(
                 TypedValue.newBuilder()
-                    .setTypename(spec.type().typeName().asTypeNameString())
+                    .setTypename(value == null ? "" : spec.type().typeName().asTypeNameString())
                     .setHasValue(value != null)
                     .setValue(toByteString(spec.type(), value)))
             .build();


### PR DESCRIPTION
This PR fixes a bug in the remote java SDK that affects types without an `IMMUTABLE_VALUE` type characteristics.
(this Is only affect custom implementations of the `Type` interface)

`MutableTypeCell` was assuming incorrectly that the backend will send a `TypedValue` with a `type_name` field set even if the value is missing (`TypedValue.has_value = false`). This is not the case, and hence the `type_name` needs to be set explicitly.