### PR TITLE
[FLINK-26340][statefun-golang-sdk] Add ability in Golang SDK to create new statefun.Context from existing one, but with a new underlying context.Context

### DIFF
--- a/docs/content/docs/sdk/golang.md
+++ b/docs/content/docs/sdk/golang.md
@@ -323,6 +323,27 @@ func (g *Greeter) Invoke(ctx statefun.Context, message: statefun.Message) error 
 {{< /tab >}}
 {{< /tabs >}}
 
+## Context
+
+The `Context` interface exposed by the Golang SDK -- which is used above to access storage, egresses, and invoke other stateful functions -- embeds the standard Golang `Context` interface from the `context` package. You can further customize the wrapped `Context` using `DeriveContext`, for example:
+
+```
+import (
+    "github.com/apache/flink-statefun/statefun-sdk-go/v3/pkg/statefun"
+)
+
+func (g *Greeter) Invoke(ctx statefun.Context, message: statefun.Message) error {
+
+    ctx = statefun.DeriveContext(ctx, context.WithValue(ctx, "key", "value"))
+
+    // do something with ctx, which now holds key=value
+
+    return nil
+}
+```
+
+`DeriveContext` accepts a stateful-function `Context` and a standard `Context`; it returns a new stateful-function `Context` that is functionally equivalent to the original stateful-function `Context`, as far as stateful-function operations are concerned, but which wraps the supplied standard `Context` instead. 
+
 ## Serving Functions
 
 The Golang SDK ships with a ``RequestReplyHandler`` that is a standard http `Handler` and automatically dispatches function calls based on RESTful HTTP ``POSTS``.

--- a/statefun-sdk-go/v3/pkg/statefun/handler.go
+++ b/statefun-sdk-go/v3/pkg/statefun/handler.go
@@ -20,10 +20,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/apache/flink-statefun/statefun-sdk-go/v3/pkg/statefun/internal/protocol"
-	"google.golang.org/protobuf/proto"
 	"log"
 	"net/http"
+	"sync"
+
+	"github.com/apache/flink-statefun/statefun-sdk-go/v3/pkg/statefun/internal/protocol"
+	"google.golang.org/protobuf/proto"
 )
 
 // StatefulFunctions is a registry for multiple StatefulFunction's. A RequestReplyHandler
@@ -214,6 +216,7 @@ func (h *handler) invoke(ctx context.Context, toFunction *protocol.ToFunction) (
 			return nil, ctx.Err()
 		default:
 			sContext := statefunContext{
+				Mutex:    new(sync.Mutex),
 				self:     self,
 				storage:  storage,
 				response: response,


### PR DESCRIPTION
In the Golang SDK, `statefun.Context` embeds the `context.Context` interface and is implemented by the `statefunContext` struct, which embeds a `context.Context`. To support common patterns in Golang related to adding values to context, it would be useful to be able to create a derived `statefun.Context` that is equivalent to the original in terms of statefun functionality but which wraps a different `context.Context`.

This PR adds:

```
WithContext(ctx context.Context) statefun.Context
```

... to the `statefun.Context` interface and implements it on `statefunContext`. This method returns the derived statefun context.

This is technically a breaking change to `statefun.Context` (i.e. addition of new method), but, given its purpose, we do not expect there to be implementations of this interface outside the Golang SDK. 

The changes here include:
* Change `sync.Mutex` in `statefunContext` to be `*sync.Mutex` and update construction of statefunContext accordingly
* Add `WithContext` to `statefun.Context` interface and implement on `statefunContext`
* Add unit test