### PR TITLE
[FLINK-26378][sdk][py] Set caller to None for ingress messages.

### DIFF
--- a/statefun-sdk-python/statefun/request_reply_v3.py
+++ b/statefun-sdk-python/statefun/request_reply_v3.py
@@ -113,7 +113,7 @@ class UserFacingContext(statefun.context.Context):
 # -------------------------------------------------------------------------------------------------------------------
 
 def sdk_address_from_pb(addr: Address) -> typing.Optional[SdkAddress]:
-    if not addr:
+    if not addr or (not addr.namespace and not addr.type and not addr.id):
         return None
     return SdkAddress(namespace=addr.namespace,
                       name=addr.type,

--- a/statefun-sdk-python/tests/request_reply_test.py
+++ b/statefun-sdk-python/tests/request_reply_test.py
@@ -229,3 +229,16 @@ class RequestReplyTestCase(unittest.TestCase):
         self.assertEqual(missing_state_2_spec['state_name'], 'missing_state_2')
         self.assertEqual(missing_state_2_spec['expiration_spec']['mode'], 'AFTER_WRITE')
         self.assertEqual(missing_state_2_spec['expiration_spec']['expire_after_millis'], '2000')
+
+    def test_caller_not_set(self):
+        functions = StatefulFunctions()
+
+        @functions.bind(typename='org.foo/greeter')
+        def fun(context: Context, message: Message):
+            self.assertIsNone(context.caller)
+
+        builder = InvocationBuilder()
+        builder.with_target("org.foo", "greeter", "0")
+        builder.with_invocation("Hello", StringType)
+
+        round_trip(functions, builder)


### PR DESCRIPTION
This PR makes sure that the caller's address would be None for
messages that are coming from an ingress.

Previously, calling `context.caller`, for ingress messages would return an `SdkAdress` with all its fields set to the empty string.
After this PR, calling `context.caller` for message returns a proper `None`.
