### PR TITLE
[hotfix][statefun][function-type] Updated parameter description

### DIFF
--- a/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/FunctionType.java
+++ b/statefun-sdk-embedded/src/main/java/org/apache/flink/statefun/sdk/FunctionType.java
@@ -39,7 +39,7 @@ public final class FunctionType implements Serializable {
   /**
    * Creates a {@link FunctionType}.
    *
-   * @param namespace the function type's namepsace.
+   * @param namespace the function type's namespace.
    * @param type the function type's name.
    */
   public FunctionType(String namespace, String type) {


### PR DESCRIPTION
The javadoc param description is <code>...namespace the function type's **namepsace**..</code>.  Changed it to <code>...namespace the function type's **namespace**...</code>