### PR TITLE
Update apache-kafka.md

### DIFF
--- a/docs/content/docs/modules/io/apache-kafka.md
+++ b/docs/content/docs/modules/io/apache-kafka.md
@@ -108,7 +108,7 @@ Starts from offsets that have an ingestion time larger than or equal to a specif
 ```yaml
 startupPosition:
   type: date
-  date: 2020-02-01 04:15:00.00 Z
+  date: 2020-02-01 04:15:00.000 +0000
 ```
 
 On startup, if the specified startup offset for a partition is out-of-range or does not exist (which may be the case if the ingress is configured to start from group offsets, specific offsets, or from a date), then the ingress will fallback to using the position configured using ``ingress.spec.autoOffsetResetPosition`` which may be set to either `latest` or `earliest`.


### PR DESCRIPTION
Fixed the docs as the date startup position expects three digits for millisecond as well as the timezone offset formatted as e.g. `+0000`:

https://github.com/apache/flink-statefun/blob/f11b3f22b83b6683e67d129a76f02641120ec66c/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressSpec.java