### PR TITLE
Clarify error message for ValueSpec names

### DIFF
--- a/statefun-sdk-js/src/core.ts
+++ b/statefun-sdk-js/src/core.ts
@@ -158,7 +158,7 @@ export class ValueSpec implements ValueSpecOpts {
             throw new Error("missing name");
         }
         if (!/^[_a-z]+$/.test(name)) {
-            throw new Error(`a name can only contain lower or upper case letters`);
+            throw new Error("a name can only contain lowercase letters and underscores");
         }
         if (type === undefined || type === null) {
             throw new Error("missing type");


### PR DESCRIPTION
Update an error message in the JavaScript SDK to indicate that ValueSpec names can contain only lowercase letters and underscores rather than lower and uppercase letters.