### PR TITLE
Feature/tb

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ This section contains information for building this project.
   $ mvn clean install -Prun-e2e-tests
   ```
 
+I had to use the below to successfully build the project:
+
+`mvn clean package install -Denforcer.fail=false -Dos.arch=x86_64 -DskipTests`
+
 2. Build Stateful Functions Docker image: This step requires that you've already compiled artifacts from the source code.
   ```
   $ ./tools/docker/build-stateful-functions.sh
@@ -166,3 +170,26 @@ Apache Flink, Stateful Functions, and all its associated repositories follow the
 ## <a name="license"></a>License
 
 The code in this repository is licensed under the [Apache Software License 2.0](LICENSE).
+
+## TODO:
+
+- Fix the dependency convergence issues that arise from adding the PubSub connector as a dependency. When the install
+command is run the terminal is littered with:
+
+```text
+[WARNING] 
+Dependency convergence error for com.google.api:api-common:1.9.3 paths to dependency are:
++-org.apache.flink:statefun-smoke-e2e-js:3.4-SNAPSHOT
+  +-org.apache.flink:flink-connector-gcp-pubsub:1.16.0
+    +-com.google.cloud:google-cloud-core:1.93.7
+      +-com.google.api:gax:1.57.1
+        +-com.google.api:api-common:1.9.3
+and
++-org.apache.flink:statefun-smoke-e2e-js:3.4-SNAPSHOT
+  +-org.apache.flink:flink-connector-gcp-pubsub:1.16.0
+    +-com.google.cloud:google-cloud-core:1.93.7
+      +-com.google.api.grpc:proto-google-iam-v1:0.13.0
+        +-com.google.api:api-common:1.8.1
+```
+
+- Work out how to use the PubSub connector within our StateFun

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@ under the License.
         <module>statefun-sdk-js</module>
         <module>statefun-kafka-io</module>
         <module>statefun-kinesis-io</module>
+        <module>statefun-pubsub-io</module>
         <module>statefun-flink</module>
         <module>statefun-shaded</module>
         <module>statefun-testutil</module>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@ under the License.
             <artifactId>auto-service-annotations</artifactId>
             <version>${auto-service.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-gcp-pubsub</artifactId>
+            <version>1.16.0</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -78,32 +78,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- build uber jar for launching the remote function -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.apache.flink.statefun.e2e.smoke.java.CommandInterpreterAppServer</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/statefun-pubsub-io/pom.xml
+++ b/statefun-pubsub-io/pom.xml
@@ -19,48 +19,26 @@ under the License.
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>statefun-e2e-tests</artifactId>
+        <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>3.4-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>statefun-smoke-e2e-embedded</artifactId>
+    <artifactId>statefun-pubsub-io</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>statefun-flink-harness</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- conflicts with testcontainers -->
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- smoke end-to-end common -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>statefun-smoke-e2e-common</artifactId>
+            <artifactId>statefun-sdk-embedded</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Reusing some classes from the driver module, e.g. Ids and Types -->
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4-SNAPSHOT</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-    </build>
 </project>

--- a/statefun-pubsub-io/src/main/java/org/apache/flink/statefun/sdk/pubsub/PubsubIOTypes.java
+++ b/statefun-pubsub-io/src/main/java/org/apache/flink/statefun/sdk/pubsub/PubsubIOTypes.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.sdk.pubsub;
+
+// import stuff here
+
+public final class PubsubIOTypes {
+
+    private PubsubIOTypes() {}
+
+    public static final IngressType UNIVERSAL_INGRESS_TYPE =
+            new IngressType("statefun.pubsub.io", "universal-ingress");
+    public static final EgressType UNIVERSAL_EGRESS_TYPE =
+            new EgressType("statefun.pubsub.io", "universal-egress");
+}

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <properties>
         <protocol-messages.dir>${generated-sources.basedir}/protocol-messages/</protocol-messages.dir>
         <proto-sources.dir>target/proto-sources</proto-sources.dir>
-        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
this fixes the error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade (default) on project statefun-smoke-e2e-embedded: Error creating shaded jar: Invalid signature file digest for Manifest main attributes -> [Help 1]
```

by removing the shaded jar plugin for 2 of the modules where this error occurred

downside:
- rather than 1 large jar, you get lots of little jars for these 2 modules

upside:
- we can do modifications to the modules without test failures