### PR TITLE
[statefun-sdk-js] Fix value spec's name error message

### DIFF
--- a/statefun-sdk-js/src/core.ts
+++ b/statefun-sdk-js/src/core.ts
@@ -158,7 +158,7 @@ export class ValueSpec implements ValueSpecOpts {
             throw new Error("missing name");
         }
         if (!/^[_a-z]+$/.test(name)) {
-            throw new Error(`a name can only contain lower or upper case letters`);
+            throw new Error(`a name can only contain lower letters or _`);
         }
         if (type === undefined || type === null) {
             throw new Error("missing type");


### PR DESCRIPTION
The error message doesn't match the regex or JSDoc comments. This commit corrects the error message.