### PR TITLE
More retryable http status codes

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -42,8 +42,8 @@ import org.slf4j.LoggerFactory;
 final class RetryingCallback implements Callback {
   private static final Duration INITIAL_BACKOFF_DURATION = Duration.ofMillis(10);
 
-  private static final Set<Integer> RETRYABLE_HTTP_CODES =
-      new HashSet<>(Arrays.asList(409, 420, 408, 429, 499, 500));
+  private static final Set<Integer> RETRYABLE_HTTP_CODES = new HashSet<>(
+      Arrays.asList(400, 408, 409, 420, 429, 499, 500, 503, 504));
 
   private static final Logger LOG = LoggerFactory.getLogger(RetryingCallback.class);
 


### PR DESCRIPTION
This PR increases the list of status codes considered retryable.

* When Flink Statefun has high load, it can happen that the requests are sent too slowly and the server read timeout cuts off a request, in which case commonly a 400 error will be returned since the body was not parseable as a protobuf message.
* When using a load balancer like Envoy, 503 and 504 errors can occur frequently when the upstream service is unavailable or e.g. getting redeployed.
