### PR TITLE
Fix unclosed requests

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsJob.java
@@ -21,6 +21,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okhttp3.OkHttpClient;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
@@ -67,6 +70,10 @@ public class StatefulFunctionsJob {
     setDefaultContextClassLoaderIfAbsent();
 
     env.getConfig().enableObjectReuse();
+
+    // Enable fine-grained logging for OkHttp to get details about unclosed connections when they
+    // occur
+    Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
 
     final StatefulFunctionsUniverse statefulFunctionsUniverse =
         StatefulFunctionsUniverses.get(

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
@@ -71,11 +71,15 @@ final class DefaultHttpRequestReplyClient implements RequestReplyClient {
   }
 
   private static FromFunction parseResponse(Response response) {
-    final InputStream httpResponseBody = responseBody(response);
     try {
-      return parseProtobufOrThrow(FromFunction.parser(), httpResponseBody);
+      final InputStream httpResponseBody = responseBody(response);
+      try {
+        return parseProtobufOrThrow(FromFunction.parser(), httpResponseBody);
+      } finally {
+        IOUtils.closeQuietly(httpResponseBody);
+      }
     } finally {
-      IOUtils.closeQuietly(httpResponseBody);
+      response.close();
     }
   }
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallback.java
@@ -90,6 +90,7 @@ final class RetryingCallback implements Callback {
     if (isShutdown.getAsBoolean()) {
       throw new IllegalStateException("An exception caught during shutdown.", cause);
     }
+
     LOG.warn(
         "Retriable exception caught while trying to deliver a message: " + requestSummary, cause);
     metrics.remoteInvocationFailures();
@@ -105,9 +106,48 @@ final class RetryingCallback implements Callback {
       resultFuture.complete(response);
       return;
     }
-    if (!RETRYABLE_HTTP_CODES.contains(response.code()) && response.code() < 500) {
+
+    boolean isRetryable = RETRYABLE_HTTP_CODES.contains(response.code());
+
+    String prefixString =
+        isRetryable
+            ? "Non-successful, retryable HTTP response code " + response.code() + " received"
+            : "Non-successful, non-retryable HTTP response code " + response.code() + " received";
+
+    try {
+      ResponseBody body = response.body();
+      if (body == null) {
+        String errorMessage = prefixString + " and the response body is null.";
+        if (isRetryable) {
+          LOG.warn(errorMessage);
+        } else {
+          LOG.error(errorMessage);
+        }
+      } else {
+        String bodyText = body.string();
+        String errorMessage = prefixString + " with body \"" + bodyText + "\".";
+        if (isRetryable) {
+          LOG.warn(errorMessage);
+        } else {
+          LOG.error(errorMessage);
+        }
+      }
+    } catch (IOException exception) {
+      String errorMessage =
+          prefixString + " and encountered an IOException while reading the body.";
+      if (isRetryable) {
+        LOG.warn(errorMessage);
+      } else {
+        LOG.error(errorMessage);
+      }
+    }
+
+    response.close();
+
+    if (!isRetryable && response.code() < 500) {
       throw new IllegalStateException("Non successful HTTP response code " + response.code());
     }
+
     if (!retryAfterApplyingBackoff(call)) {
       throw new IllegalStateException(
           "Maximal request time has elapsed. Last known error is: invalid HTTP response code "


### PR DESCRIPTION
This PR fixes the unclosed response warnings that Statefun reports when an HTTP request by Flink fails.

The PR also sets the recommended logger setting to get more details about the issue when it occurs.

Example:

```
Aug 09, 2023 9:28:57 AM okhttp3.internal.platform.Platform log
Aug 9 10:28:57 <POD> taskmanager WARNING WARNING: A connection to http://worker:9090/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```