### PR TITLE
enhance exponential backoff

### DIFF
--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/BoundedExponentialBackoffTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/BoundedExponentialBackoffTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class BoundedExponentialBackoffTest {
   private final FakeNanoClock fakeTime = new FakeNanoClock();
   private final BoundedExponentialBackoff backoffUnderTest =
-      new BoundedExponentialBackoff(fakeTime, Duration.ofSeconds(1), Duration.ofMinutes(1));
+      new BoundedExponentialBackoff(fakeTime, Duration.ofSeconds(1), 2, 0.1, Duration.ofMinutes(1));
 
   @Test
   public void simpleUsage() {


### PR DESCRIPTION
This PR enhances the exponential backoff by adding jitter to prevent a thundering herd of requests.

The base backoff is increased to 1s, because 10ms can still create significant load on a service that might already be overwhelmed.

Finally, log messages are added or updated to provide useful diagnostic information in failure scenarios.