### PR TITLE
Max Retries

### DIFF
--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/src/test/resources/remote-module/module.yaml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/src/test/resources/remote-module/module.yaml
@@ -18,3 +18,4 @@ spec:
   functions: statefun.smoke.e2e/command-interpreter-fn
   urlPathTemplate: https://remote-function-host
   maxNumBatchRequests: 10000
+  maxRetries: 5

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/src/test/resources/remote-module/module.yaml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/src/test/resources/remote-module/module.yaml
@@ -18,6 +18,7 @@ spec:
   functions: statefun.smoke.e2e/command-interpreter-fn
   urlPathTemplate: https://remote-function-host:8000
   maxNumBatchRequests: 10000
+  maxRetries: 5
   transport:
     type: io.statefun.transports.v1/async
     trust_cacerts: file:/opt/statefun/modules/statefun-smoke-e2e/certs/a_ca.pem

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/src/test/resources/remote-module/module.yaml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/src/test/resources/remote-module/module.yaml
@@ -18,3 +18,4 @@ spec:
   functions: statefun.smoke.e2e/command-interpreter-fn
   urlPathTemplate: http://remote-function-host:8000
   maxNumBatchRequests: 10000
+  maxRetries: 5

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/src/test/resources/module.yaml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/src/test/resources/module.yaml
@@ -18,3 +18,4 @@ spec:
   functions: statefun.smoke.e2e/command-interpreter-fn
   urlPathTemplate: http://localhost:8000
   maxNumBatchRequests: 10000
+  maxRetries: 5

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClient.java
@@ -56,7 +56,8 @@ final class DefaultHttpRequestReplyClient implements RequestReplyClient {
   public CompletableFuture<FromFunction> call(
       ToFunctionRequestSummary requestSummary,
       RemoteInvocationMetrics metrics,
-      ToFunction toFunction) {
+      ToFunction toFunction,
+      int maxRetries) {
     Request request =
         new Request.Builder()
             .url(url)
@@ -65,13 +66,17 @@ final class DefaultHttpRequestReplyClient implements RequestReplyClient {
 
     Call newCall = client.newCall(request);
     RetryingCallback callback =
-        new RetryingCallback(requestSummary, metrics, newCall.timeout(), isShutdown);
+        new RetryingCallback(requestSummary, metrics, newCall.timeout(), isShutdown, maxRetries);
     callback.attachToCall(newCall);
     return callback.future().thenApply(DefaultHttpRequestReplyClient::parseResponse);
   }
 
   private static FromFunction parseResponse(Response response) {
-    final InputStream httpResponseBody = responseBody(response);
+    if (response == null) {
+      return null;
+    }
+
+final InputStream httpResponseBody = responseBody(response);
     try {
       return parseProtobufOrThrow(FromFunction.parser(), httpResponseBody);
     } finally {

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpec.java
@@ -35,6 +35,9 @@ public final class HttpFunctionEndpointSpec implements Serializable {
   private static final long serialVersionUID = 1;
 
   private static final Integer DEFAULT_MAX_NUM_BATCH_REQUESTS = 1000;
+
+  private static final Integer DEFAULT_MAX_RETRIES = -1;
+
   private static final TransportClientSpec DEFAULT_TRANSPORT_CLIENT_SPEC =
       new TransportClientSpec(
           TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE,
@@ -47,6 +50,7 @@ public final class HttpFunctionEndpointSpec implements Serializable {
   private final TargetFunctions targetFunctions;
   private final UrlPathTemplate urlPathTemplate;
   private final int maxNumBatchRequests;
+  private final int maxRetries;
 
   // ============================================================
   //  HTTP transport related properties
@@ -63,11 +67,13 @@ public final class HttpFunctionEndpointSpec implements Serializable {
       TargetFunctions targetFunctions,
       UrlPathTemplate urlPathTemplate,
       int maxNumBatchRequests,
+      int maxRetries,
       TypeName transportClientFactoryType,
       ObjectNode transportClientProps) {
     this.targetFunctions = targetFunctions;
     this.urlPathTemplate = urlPathTemplate;
     this.maxNumBatchRequests = maxNumBatchRequests;
+    this.maxRetries = maxRetries;
     this.transportClientFactoryType = transportClientFactoryType;
     this.transportClientProps = transportClientProps;
   }
@@ -82,6 +88,10 @@ public final class HttpFunctionEndpointSpec implements Serializable {
 
   public int maxNumBatchRequests() {
     return maxNumBatchRequests;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
   }
 
   public TypeName transportClientFactoryType() {
@@ -99,6 +109,7 @@ public final class HttpFunctionEndpointSpec implements Serializable {
     private final UrlPathTemplate urlPathTemplate;
 
     private int maxNumBatchRequests = DEFAULT_MAX_NUM_BATCH_REQUESTS;
+    private int maxRetries = DEFAULT_MAX_RETRIES;
     private TransportClientSpec transportClientSpec = DEFAULT_TRANSPORT_CLIENT_SPEC;
 
     @JsonCreator
@@ -115,6 +126,12 @@ public final class HttpFunctionEndpointSpec implements Serializable {
     @JsonProperty("maxNumBatchRequests")
     public Builder withMaxNumBatchRequests(int maxNumBatchRequests) {
       this.maxNumBatchRequests = maxNumBatchRequests;
+      return this;
+    }
+
+    @JsonProperty("maxRetries")
+    public Builder withMaxRetries(int maxRetries) {
+      this.maxRetries = maxRetries;
       return this;
     }
 
@@ -138,6 +155,7 @@ public final class HttpFunctionEndpointSpec implements Serializable {
           targetFunctions,
           urlPathTemplate,
           maxNumBatchRequests,
+          maxRetries,
           transportClientSpec.factoryKind(),
           transportClientSpec.specNode());
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionProvider.java
@@ -46,6 +46,7 @@ public final class HttpFunctionProvider implements StatefulFunctionProvider, Man
     return new RequestReplyFunction(
         functionType,
         endpointSpec.maxNumBatchRequests(),
+        endpointSpec.maxRetries(),
         requestReplyClientFactory.createTransportClient(
             endpointSpec.transportClientProperties(), endpointUrl));
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/binders/v1/HttpEndpointBinderV1.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/httpfn/binders/v1/HttpEndpointBinderV1.java
@@ -48,6 +48,7 @@ import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
  *   functions: com.foo.bar/*                                         (typename)
  *   urlPathTemplate: https://bar.foo.com:8080/{function.name}        (string)
  *   maxNumBatchRequests: 10000                                       (int, optional)
+ *   maxRetries: 5                                                    (int, optional)
  *   timeouts:                                                        (object, optional)
  *     call: 1minute                                                  (duration, optional)
  *     connect: 20seconds                                             (duration, optional)
@@ -68,6 +69,7 @@ public final class HttpEndpointBinderV1 implements ComponentBinder {
   private static final JsonPointer URL_PATH_TEMPLATE = JsonPointer.compile("/urlPathTemplate");
   private static final JsonPointer MAX_NUM_BATCH_REQUESTS =
       JsonPointer.compile("/maxNumBatchRequests");
+  private static final JsonPointer MAX_RETRIES = JsonPointer.compile("/maxRetries");
 
   private HttpEndpointBinderV1() {}
 
@@ -105,6 +107,8 @@ public final class HttpEndpointBinderV1 implements ComponentBinder {
     optionalMaxNumBatchRequests(httpEndpointSpecNode)
         .ifPresent(specBuilder::withMaxNumBatchRequests);
 
+    optionalMaxRetries(httpEndpointSpecNode).ifPresent(specBuilder::withMaxRetries);
+
     final TransportClientSpec transportClientSpec =
         new TransportClientSpec(
             TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE, (ObjectNode) httpEndpointSpecNode);
@@ -125,5 +129,9 @@ public final class HttpEndpointBinderV1 implements ComponentBinder {
 
   private static OptionalInt optionalMaxNumBatchRequests(JsonNode functionNode) {
     return Selectors.optionalIntegerAt(functionNode, MAX_NUM_BATCH_REQUESTS);
+  }
+
+  private static OptionalInt optionalMaxRetries(JsonNode functionNode) {
+    return Selectors.optionalIntegerAt(functionNode, MAX_RETRIES);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/nettyclient/NettyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/nettyclient/NettyClient.java
@@ -127,7 +127,8 @@ final class NettyClient implements RequestReplyClient, NettyClientService {
   public CompletableFuture<FromFunction> call(
       ToFunctionRequestSummary requestSummary,
       RemoteInvocationMetrics metrics,
-      ToFunction toFunction) {
+      ToFunction toFunction,
+      int maxRetries) {
     NettyRequest request = new NettyRequest(this, metrics, requestSummary, toFunction);
     return request.start();
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ClassLoaderSafeRequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/ClassLoaderSafeRequestReplyClient.java
@@ -42,12 +42,13 @@ public final class ClassLoaderSafeRequestReplyClient implements RequestReplyClie
   public CompletableFuture<FromFunction> call(
       ToFunctionRequestSummary requestSummary,
       RemoteInvocationMetrics metrics,
-      ToFunction toFunction) {
+      ToFunction toFunction,
+      int maxRetries) {
     final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 
     try {
       Thread.currentThread().setContextClassLoader(delegateClassLoader);
-      return delegate.call(requestSummary, metrics, toFunction);
+      return delegate.call(requestSummary, metrics, toFunction, maxRetries);
     } finally {
       Thread.currentThread().setContextClassLoader(originalClassLoader);
     }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyClient.java
@@ -30,5 +30,6 @@ public interface RequestReplyClient {
   CompletableFuture<FromFunction> call(
       ToFunctionRequestSummary requestSummary,
       RemoteInvocationMetrics metrics,
-      ToFunction toFunction);
+      ToFunction toFunction,
+      int maxRetries);
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -70,7 +70,12 @@ public class RequestReplyFunctionTest {
 
   private final RequestReplyFunction functionUnderTest =
       new RequestReplyFunction(
-          FN_TYPE, testInitialRegisteredState("session", "com.foo.bar/myType"), 10, client, true);
+          FN_TYPE,
+          testInitialRegisteredState("session", "com.foo.bar/myType"),
+          10,
+          5,
+          client,
+          true);
 
   @Test
   public void example() {
@@ -121,7 +126,7 @@ public class RequestReplyFunctionTest {
 
   @Test
   public void reachingABatchLimitTriggersBackpressure() {
-    RequestReplyFunction functionUnderTest = new RequestReplyFunction(FN_TYPE, 2, client);
+    RequestReplyFunction functionUnderTest = new RequestReplyFunction(FN_TYPE, 2, 5, client);
 
     // send one message
     functionUnderTest.invoke(context, TypedValue.getDefaultInstance());
@@ -137,7 +142,7 @@ public class RequestReplyFunctionTest {
 
   @Test
   public void returnedMessageReleaseBackpressure() {
-    RequestReplyFunction functionUnderTest = new RequestReplyFunction(FN_TYPE, 2, client);
+    RequestReplyFunction functionUnderTest = new RequestReplyFunction(FN_TYPE, 2, 5, client);
 
     // the following invocations should cause backpressure
     functionUnderTest.invoke(context, TypedValue.getDefaultInstance());
@@ -342,7 +347,7 @@ public class RequestReplyFunctionTest {
     ToFunction originalRequest = client.wasSentToFunction;
 
     RequestReplyFunction restoredFunction =
-        new RequestReplyFunction(FN_TYPE, new PersistedRemoteFunctionValues(), 2, client, true);
+        new RequestReplyFunction(FN_TYPE, new PersistedRemoteFunctionValues(), 2, 5, client, true);
     restoredFunction.invoke(context, unknownAsyncOperation(originalRequest));
 
     // retry batch after a restore on an unknown async operation should start with empty state specs
@@ -393,7 +398,8 @@ public class RequestReplyFunctionTest {
     public CompletableFuture<FromFunction> call(
         ToFunctionRequestSummary requestSummary,
         RemoteInvocationMetrics metrics,
-        ToFunction toFunction) {
+        ToFunction toFunction,
+        int maxRetries) {
       this.wasSentToFunction = toFunction;
       try {
         return CompletableFuture.completedFuture(this.fromFunction.get());

--- a/statefun-flink/statefun-flink-core/src/test/resources/http-endpoint-binders/v1.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/http-endpoint-binders/v1.yaml
@@ -18,6 +18,7 @@ spec:
   functions: com.foo.bar/*
   urlPathTemplate: http://bar.foo.com:8080/functions/{function.name}
   maxNumBatchRequests: 10000
+  maxRetries: 5
   timeouts:
     call: 1minute
     connect: 30seconds

--- a/statefun-flink/statefun-flink-core/src/test/resources/http-endpoint-binders/v2.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/http-endpoint-binders/v2.yaml
@@ -18,6 +18,7 @@ spec:
   functions: com.foo.bar/*
   urlPathTemplate: http://bar.foo.com:8080/functions/{function.name}
   maxNumBatchRequests: 10000
+  maxRetries: 5
   transport:
     type: io.statefun.transports.v1/okhttp
     timeouts:

--- a/statefun-flink/statefun-flink-core/src/test/resources/module-v3_0/module.yaml
+++ b/statefun-flink/statefun-flink-core/src/test/resources/module-v3_0/module.yaml
@@ -32,6 +32,7 @@ module:
               read: 10second
               write: 10seconds
             maxNumBatchRequests: 10000
+            maxRetries: 5
     ingresses:
       - ingress:
           meta:

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilder.java
@@ -116,6 +116,17 @@ public class AsyncRequestReplyFunctionBuilder extends StatefulFunctionBuilder {
   }
 
   /**
+   * Sets the max retries number of attempts in order to deliver a message
+   *
+   * @param maxRetries the maximum number of attempts for delivering a message
+   * @return this builder.
+   */
+  public AsyncRequestReplyFunctionBuilder withMaxRetries(int maxRetries) {
+    builder.withMaxRetries(maxRetries);
+    return this;
+  }
+
+  /**
    * Create the endpoint spec for the function.
    *
    * @return The endpoint spec.

--- a/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
+++ b/statefun-flink/statefun-flink-datastream/src/main/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilder.java
@@ -111,6 +111,17 @@ public class RequestReplyFunctionBuilder extends StatefulFunctionBuilder {
   }
 
   /**
+   * Sets the max retries attempts in order to deliver a message
+   *
+   * @param maxRetries the maximum number of attempts for delivering a message
+   * @return this builder.
+   */
+  public RequestReplyFunctionBuilder withMaxRetries(int maxRetries) {
+    builder.withMaxRetries(maxRetries);
+    return this;
+  }
+
+  /**
    * Create the endpoint spec for the function.
    *
    * @return The endpoint spec.

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilderTest.java
@@ -44,6 +44,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     final URI uri = new URI("foobar");
 
     final int maxNumBatchRequests = 100;
+    final int maxRetries = 5;
     final Duration connectTimeout = Duration.ofSeconds(1);
     final Duration callTimeout = Duration.ofSeconds(2);
     final Duration pooledConnectionTTL = Duration.ofSeconds(3);
@@ -53,6 +54,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     final AsyncRequestReplyFunctionBuilder builder =
         StatefulFunctionBuilder.asyncRequestReplyFunctionBuilder(functionType, uri)
             .withMaxNumBatchRequests(maxNumBatchRequests)
+            .withMaxRetries(maxRetries)
             .withMaxRequestDuration(callTimeout)
             .withConnectTimeout(connectTimeout)
             .withPooledConnectionTTL(pooledConnectionTTL)
@@ -62,6 +64,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     HttpFunctionEndpointSpec spec = builder.spec();
     assertThat(spec, notNullValue());
     assertEquals(maxNumBatchRequests, spec.maxNumBatchRequests());
+    assertEquals(maxRetries, spec.maxRetries());
     assertEquals(functionType, spec.targetFunctions().asSpecificFunctionType());
     assertEquals(
         spec.transportClientFactoryType(), TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
@@ -91,6 +94,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     final URI uri = new URI("foobar");
 
     final int maxNumBatchRequests = 100;
+    final int maxRetries = 5;
     final Duration callTimeout = Duration.ofSeconds(2);
     final Duration pooledConnectionTTL = Duration.ofSeconds(3);
     final int maxRequestOrResponseSizeInBytes = 10000;
@@ -98,6 +102,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     final AsyncRequestReplyFunctionBuilder builder =
         StatefulFunctionBuilder.asyncRequestReplyFunctionBuilder(functionType, uri)
             .withMaxNumBatchRequests(maxNumBatchRequests)
+            .withMaxRetries(maxRetries)
             .withMaxRequestDuration(callTimeout)
             .withPooledConnectionTTL(pooledConnectionTTL)
             .withMaxRequestOrResponseSizeInBytes(maxRequestOrResponseSizeInBytes);
@@ -105,6 +110,7 @@ public class AsyncRequestReplyFunctionBuilderTest {
     HttpFunctionEndpointSpec spec = builder.spec();
     assertThat(spec, notNullValue());
     assertEquals(maxNumBatchRequests, spec.maxNumBatchRequests());
+    assertEquals(maxRetries, spec.maxRetries());
     assertEquals(functionType, spec.targetFunctions().asSpecificFunctionType());
     assertEquals(
         spec.transportClientFactoryType(), TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
@@ -43,6 +43,7 @@ public class RequestReplyFunctionBuilderTest {
     final URI uri = new URI("foobar");
 
     final int maxNumBatchRequests = 100;
+    final int maxRetries = 5;
     final Duration connectTimeout = Duration.ofSeconds(16);
     final Duration callTimeout = Duration.ofSeconds(21);
     final Duration readTimeout = Duration.ofSeconds(11);
@@ -51,6 +52,7 @@ public class RequestReplyFunctionBuilderTest {
     final RequestReplyFunctionBuilder builder =
         StatefulFunctionBuilder.requestReplyFunctionBuilder(functionType, uri)
             .withMaxNumBatchRequests(maxNumBatchRequests)
+            .withMaxRetries(maxRetries)
             .withMaxRequestDuration(callTimeout)
             .withConnectTimeout(connectTimeout)
             .withReadTimeout(readTimeout)
@@ -59,6 +61,7 @@ public class RequestReplyFunctionBuilderTest {
     HttpFunctionEndpointSpec spec = builder.spec();
     assertThat(spec, notNullValue());
     assertEquals(maxNumBatchRequests, spec.maxNumBatchRequests());
+    assertEquals(maxRetries, spec.maxRetries());
     assertEquals(functionType, spec.targetFunctions().asSpecificFunctionType());
     assertEquals(
         spec.transportClientFactoryType(), TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE);
@@ -87,18 +90,21 @@ public class RequestReplyFunctionBuilderTest {
     final URI uri = new URI("foobar");
 
     final int maxNumBatchRequests = 100;
+    final int maxRetries = 5;
     final Duration connectTimeout = Duration.ofSeconds(16);
     final Duration callTimeout = Duration.ofSeconds(21);
 
     final RequestReplyFunctionBuilder builder =
         StatefulFunctionBuilder.requestReplyFunctionBuilder(functionType, uri)
             .withMaxNumBatchRequests(maxNumBatchRequests)
+            .withMaxRetries(maxRetries)
             .withMaxRequestDuration(callTimeout)
             .withConnectTimeout(connectTimeout);
 
     HttpFunctionEndpointSpec spec = builder.spec();
     assertThat(spec, notNullValue());
     assertEquals(maxNumBatchRequests, spec.maxNumBatchRequests());
+    assertEquals(maxRetries, spec.maxRetries());
     assertEquals(functionType, spec.targetFunctions().asSpecificFunctionType());
     assertEquals(
         spec.transportClientFactoryType(), TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE);


### PR DESCRIPTION
This PR adds a `maxRetries` option that limits the amount of times a request will be attempted before the request is dropped. When set to the default value of -1, batches will be retried indefinitely which matches the current behaviour.

This provides a simple means to drop failed messages after a configurable number of attempts when such behaviour is desired, which is currently not very easy to implement.

This also addresses an issue with Flink Statefun where a pipeline will get stuck if a remote function fails deterministically and the issue cannot be caught inside the handler. Normally, such issues can and should be caught inside the handler code, but this is not possible if the server deterministically crashes, e.g. with `log.Fatalw` in golang. Setting a maxRetries limit prevents such behaviour from blocking pipelines indefinitely.