### PR TITLE
[FLINK-33075 ] Update outdated NOTICE files for Statefun

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,6 +18,8 @@ See bundled license files under "licenses/" for details.
 This project bundles the following dependencies under the MIT license (https://opensource.org/licenses/MIT).
 See bundled license files under "licenses/" for details.
 
+- AnchorJS v3.1.0 (https://github.com/bryanbraun/anchorjs) Copyright (c) 2020 Bryan Braun
+    -> in "docs/static/js/anchor.min.js"
 - font-awesome:4.6.3 (Code) (http://fortawesome.github.io/Font-Awesome/) - Created by Dave Gandy
-    -> css in "docs/page/font-awesome/css"
+    -> css in "docs/static/font-awesome/css/font-awesome.min.css"
 - jquery:1.11.2 (http://jquery.com/) Copyright 2014 jQuery Foundation and other contributors

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink Stateful Functions (flink-statefun)
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-flink/statefun-flink-core/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-core/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 statefun-flink-core
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
 - com.squareup.okhttp3:okhttp:3.14.6
 - com.squareup.okio:okio:1.17.2
-- io.dropwizard.metrics:metrics-core:jar:3.2.6
+- io.dropwizard.metrics:metrics-core:3.2.6
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 statefun-flink-datastream
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.kohlschutter.junixsocket:junixsocket-core:2.3.2
-- com.kohlschutter.junixsocket:junixsocket-common:2.3.2
-- com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
 - com.google.auto.service:auto-service-annotations:1.0-rc6
+- com.kohlschutter.junixsocket:junixsocket-common:2.3.2
+- com.kohlschutter.junixsocket:junixsocket-core:2.3.2
+- com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
 - com.squareup.okhttp3:okhttp:3.14.6
 - com.squareup.okio:okio:1.17.2
 - io.dropwizard.metrics:metrics-core:jar:3.2.6

--- a/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-datastream/src/main/resources/META-INF/NOTICE
@@ -18,8 +18,3 @@ This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.
 
 - com.google.protobuf:protobuf-java:3.7.1
-
-This project bundles the following dependencies under the MIT license.
-See bundled license files under "META-INF/licenses" for details.
-
-- org.slf4j:slf4j-api:1.7.7

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.google.auto.service:auto-service-annotations:1.0-rc6
 - com.google.errorprone:error_prone_annotations:2.3.4
@@ -26,7 +26,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.11.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- io.dropwizard.metrics:metrics-core:jar:3.2.6
+- io.dropwizard.metrics:metrics-core:3.2.6
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.3.2

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -6,33 +6,33 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.kohlschutter.junixsocket:junixsocket-core:2.3.2
-- com.kohlschutter.junixsocket:junixsocket-common:2.3.2
-- com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
-- commons-codec:commons-codec:1.13
-- commons-lang:commons-lang:2.6
-- commons-logging:commons-logging:1.1.3
-- commons-io:commons-io:2.8.0
-- com.google.auto.service:auto-service-annotations:1.0-rc6
-- com.google.guava:guava:29.0-jre
-- com.google.guava:failureaccess:1.0.1
-- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.errorprone:error_prone_annotations:2.3.4
-- com.google.j2objc:j2objc-annotations:1.3
-- org.checkerframework:checker-qual:2.11.1
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.kafka:kafka-clients:2.4.1
-- org.lz4:lz4-java:1.8.0
-- com.squareup.okhttp3:okhttp:3.14.6
-- com.squareup.okio:okio:1.17.2
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1
+- com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- joda-time:joda-time:2.5
-- software.amazon.ion:ion-java:1.0.2
+- com.google.auto.service:auto-service-annotations:1.0-rc6
+- com.google.errorprone:error_prone_annotations:2.3.4
+- com.google.guava:failureaccess:1.0.1
+- com.google.guava:guava:29.0-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.3
+- com.kohlschutter.junixsocket:junixsocket-common:2.3.2
+- com.kohlschutter.junixsocket:junixsocket-core:2.3.2
+- com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
+- com.squareup.okhttp3:okhttp:3.14.6
+- com.squareup.okio:okio:1.17.2
+- commons-codec:commons-codec:1.13
+- commons-io:commons-io:2.8.0
+- commons-lang:commons-lang:2.6
+- commons-logging:commons-logging:1.1.3
 - io.dropwizard.metrics:metrics-core:jar:3.2.6
+- joda-time:joda-time:2.5
 - log4j:log4j:1.2.17
+- org.apache.commons:commons-lang3:3.3.2
+- org.apache.kafka:kafka-clients:2.4.1
+- org.checkerframework:checker-qual:2.11.1
+- org.lz4:lz4-java:1.8.0
+- software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.
@@ -43,5 +43,5 @@ See bundled license files under "META-INF/licenses" for details.
 This project bundles the following dependencies under the MIT license.
 See bundled license files under "META-INF/licenses" for details.
 
-- org.slf4j:slf4j-log4j12:1.7.15
 - org.slf4j:slf4j-api:1.7.7
+- org.slf4j:slf4j-log4j12:1.7.15

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 statefun-flink-distribution
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
+++ b/statefun-flink/statefun-flink-distribution/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.google.auto.service:auto-service-annotations:1.0-rc6
 - com.google.errorprone:error_prone_annotations:2.3.4
 - com.google.guava:failureaccess:1.0.1
@@ -21,27 +21,29 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.kohlschutter.junixsocket:junixsocket-native-common:2.3.2
 - com.squareup.okhttp3:okhttp:3.14.6
 - com.squareup.okio:okio:1.17.2
-- commons-codec:commons-codec:1.13
-- commons-io:commons-io:2.8.0
+- commons-codec:commons-codec:1.15
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.11.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - io.dropwizard.metrics:metrics-core:jar:3.2.6
 - joda-time:joda-time:2.5
-- log4j:log4j:1.2.17
+- org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.3.2
-- org.apache.kafka:kafka-clients:2.4.1
+- org.apache.kafka:kafka-clients:3.2.3
 - org.checkerframework:checker-qual:2.11.1
 - org.lz4:lz4-java:1.8.0
-- software.amazon.ion:ion-java:1.0.2
+- org.objenesis:objenesis:2.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files under "META-INF/licenses" for details.
 
-- com.github.luben:zstd-jni:1.4.3-1
+- com.esotericsoftware.kryo:kryo:2.24.0
+- com.esotericsoftware.minlog:minlog:1.2
+- com.github.luben:zstd-jni:1.5.2-1
 - com.google.protobuf:protobuf-java:3.7.1
 
-This project bundles the following dependencies under the MIT license.
+This project bundles the following dependencies under the ICU license.
 See bundled license files under "META-INF/licenses" for details.
 
-- org.slf4j:slf4j-api:1.7.7
-- org.slf4j:slf4j-log4j12:1.7.15
+- com.ibm.icu:icu4j:67.1

--- a/statefun-sdk-java/src/main/resources/META-INF/NOTICE
+++ b/statefun-sdk-java/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 statefun-sdk-java
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-sdk-python/NOTICE
+++ b/statefun-sdk-python/NOTICE
@@ -1,5 +1,5 @@
 Python SDK for Apache Flink Stateful Functions
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/statefun-shaded/statefun-protobuf-shaded/src/main/resources/META-INF/NOTICE
+++ b/statefun-shaded/statefun-protobuf-shaded/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 statefun-protobuf-shaded
-Copyright 2014-2020 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This PR does 3 things:

1. Updated the copyright year
2. Sorts the existing entries in the NOTICE files
3. Updates the NOTICE files to match the actually bundled dependencies. This means that some entries are removed, because they are actually excluded, some version numbers were updated and some entries were added because they were missing in the NOTICE file, yet they were bundled. 