### PR TITLE
[FLINK-33627] Bump snappy to 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@ under the License.
         <unixsocket.version>2.3.2</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
         <flink.version>1.16.2</flink.version>
-        <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.7</scala.version>
         <lz4-java.version>1.8.0</lz4-java.version>
         <flink-shaded-jackson.version>2.12.4-15.0</flink-shaded-jackson.version>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -74,7 +74,7 @@ under the License.
                 <exclusions>
                     <!--
                     This conflicts with org.xerial.snappy:snappy-java
-                    brought from flink-streaming-java_${scala.binary.version} (transitively)
+                    brought from flink-streaming-java (transitively)
                     -->
                     <exclusion>
                         <groupId>org.xerial.snappy</groupId>
@@ -173,7 +173,7 @@ under the License.
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.4</version>
             </dependency>
             <!--
             Pin the scala library version in order to resolve the dependency conversion problem between two

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -173,7 +173,7 @@ under the License.
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.4</version>
+                <version>1.1.10.5</version>
             </dependency>
             <!--
             Pin the scala library version in order to resolve the dependency conversion problem between two

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -43,9 +43,7 @@ under the License.
             <version>${kafka.version}</version>
             <exclusions>
                 <!-- This collides with snappy-java brought from  
-                        org.apache.flink:flink-streaming-java_${scala.binary.version}
-                            org.xerial.snappy:snappy-java:1.1.4
-                -->
+                        org.apache.flink:flink-streaming-java -->
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

Bump the version of snappy to address a vulnerability (FLINK-33149)

